### PR TITLE
CI/CD Feature

### DIFF
--- a/internal/forms/git_action.go
+++ b/internal/forms/git_action.go
@@ -24,3 +24,10 @@ func (ca *CreateGitAction) ToGitActionConfig() (*models.GitActionConfig, error) 
 		GitRepoID:      ca.GitRepoID,
 	}, nil
 }
+
+type CreateGitActionOptional struct {
+	GitRepo        string `json:"git_repo"`
+	ImageRepoURI   string `json:"image_repo_uri"`
+	DockerfilePath string `json:"dockerfile_path"`
+	GitRepoID      uint   `json:"git_repo_id"`
+}

--- a/internal/forms/release.go
+++ b/internal/forms/release.go
@@ -129,4 +129,7 @@ type ChartTemplateForm struct {
 type InstallChartTemplateForm struct {
 	*ReleaseForm
 	*ChartTemplateForm
+
+	// optional git action config
+	GithubActionConfig *CreateGitActionOptional `json:"github_action,omitempty"`
 }

--- a/server/api/deploy_handler.go
+++ b/server/api/deploy_handler.go
@@ -138,6 +138,25 @@ func (app *App) HandleDeployTemplate(w http.ResponseWriter, r *http.Request) {
 		}, w)
 	}
 
+	// if github action config is linked, call the github action config handler
+	if form.GithubActionConfig != nil {
+		gaForm := &forms.CreateGitAction{
+			ReleaseID:      release.ID,
+			GitRepo:        form.GithubActionConfig.GitRepo,
+			ImageRepoURI:   form.GithubActionConfig.ImageRepoURI,
+			DockerfilePath: form.GithubActionConfig.DockerfilePath,
+			GitRepoID:      form.GithubActionConfig.GitRepoID,
+		}
+
+		// validate the form
+		if err := app.validator.Struct(form); err != nil {
+			app.handleErrorFormValidation(err, ErrProjectValidateFields, w)
+			return
+		}
+
+		app.createGitActionFromForm(projID, release, name, gaForm, w, r)
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe): 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder. 
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users have no method to automatically build and push a new version of an application running on Porter without an involved manual process. 

## What is the new behavior?

Allow users to link CI (automatically build + push a new Docker image to a linked image registry) and CD (after pushing the new Docker image, automatically deploy the new image to Porter). Users should be able to link CI/CD from two locations:

1. Link while deploying a new template. The user should be given the option of "Deploy from Git Repo" or "Deploy from Container Registry." If they choose to "Deploy from Github Repo," they will be asked to link the Github repo, select the path to the Dockerfile within the Github repo, and specify the image uri (which should automatically be set to `${base_registry_uri}/${release_name}`). 
2. Link after creating a new release from the "Settings" tab. They will be asked for the same three items as above. 

Additionally, after a user has linked CI, they should be able to modify the three fields (Github repo, path to Dockerfile, image uri). Since the path to the Dockerfile depends on the Github repo, all fields should be updated together by guiding the user through the same flow that they used to create CI/CD. 

## Technical Spec/Implementation Notes

Requires changes in both the API and the frontend. On the API side, CI/CD can be added while deploying a new release by adding the following fields to `POST /projects/{project_id}/deploy/{name}/{version}`:

```js
{
  ..., // current fields in the deployment request body
  "github_action": {
    "git_repo": String, // The git repo in ${owner}/${repo} form
    "image_repo_uri": String, // the full image repo URI
    "dockerfile_path": String, // the RELATIVE path to the dockerfile in the git repo
    "git_repo_id": Number,
  },
}
```

Additionally, CI/CD can be created or updated by calling `POST /api/projects/{project_id}/ci/actions?cluster_id=<CLUSTER_ID>&name=<RELEASE_NAME>&namespace=<RELEASE_NAMESPACE>` with the request body:

```js
{
  "git_repo": String, // The git repo in ${owner}/${repo} form
  "image_repo_uri": String, // the full image repo URI
  "dockerfile_path": String, // the RELATIVE path to the dockerfile in the git repo
  "git_repo_id": Number,
}
```
