### PR TITLE
fixed display out of memory error on initial tab

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
@@ -73,6 +73,9 @@ export default class ControllerTab extends Component<PropsType, StateType> {
         this.setState({ pods, raw: res.data, showTooltip });
 
         if (isFirst) {
+          let pod = res.data[0];
+          let status = this.getPodStatus(pod.status);
+          (status === "failed" && pod.status?.message) && this.props.setPodError(pod.status?.message);
           selectPod(res.data[0]);
         }
       })


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe): 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder. 
- [X] If it's a frontend change, Prettier has been run
- [X] Docs have been reviewed and added / updated if needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. 

Issue Number: N/A

-->
Out of memory pod error doesn't display if the failed pod is the initially selected pod in the "Status" tab.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Out of memory pod error now displays if the failed pod is the initially selected pod in the "Status" tab.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
