### PR TITLE
delete cluster token caches on update

### DIFF
--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -252,6 +252,12 @@ func (repo *ClusterRepository) UpdateClusterTokenCache(
 		return nil, err
 	}
 
+	// delete the existing token cache first
+	if err := ctxDB.Where("id = ?", tokenCache.ID).Unscoped().Delete(&cluster.TokenCache).Error; err != nil {
+		return nil, err
+	}
+
+	// set the new token cache
 	cluster.TokenCache.Token = tokenCache.Token
 	cluster.TokenCache.Expiry = tokenCache.Expiry
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Many tokens get written when token decryption fails, without old tokens being deleted. 

## What is the new behavior?

This deletes old cluster tokens on update. 
