### PR TITLE
increase github list limit

### DIFF
--- a/server/api/git_repo_handler.go
+++ b/server/api/git_repo_handler.go
@@ -72,6 +72,9 @@ func (app *App) HandleListRepos(w http.ResponseWriter, r *http.Request) {
 
 	// list all repositories for specified user
 	repos, _, err := client.Repositories.List(context.Background(), "", &github.RepositoryListOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
 		Sort: "updated",
 	})
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Listing Github repositories capped at 30. 

## What is the new behavior?

Increase limit to 100 before pagination. 