### PR TITLE
call updateTabs after chart data is retrieved

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -98,7 +98,9 @@ export default class ExpandedChart extends Component<PropsType, StateType> {
         }
       )
       .then((res) => {
-        this.setState({ currentChart: res.data, loading: false });
+        this.setState({ currentChart: res.data, loading: false }, () => {
+          this.updateTabs();
+        });
       })
       .catch(console.log);
   };
@@ -560,15 +562,6 @@ export default class ExpandedChart extends Component<PropsType, StateType> {
         })
       )
       .catch(console.log);
-
-    this.updateTabs();
-  }
-
-  componentDidUpdate(prevProps: PropsType) {
-    if (this.props.currentChart !== prevProps.currentChart) {
-      this.updateTabs();
-      this.updateResources();
-    }
   }
 
   componentWillUnmount() {

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -73,7 +73,9 @@ export default class ExpandedJobChart extends Component<PropsType, StateType> {
         }
       )
       .then((res) => {
-        this.setState({ currentChart: res.data, loading: false });
+        this.setState({ currentChart: res.data, loading: false }, () => {
+          this.updateTabs();
+        });
       })
       .catch(console.log);
   };
@@ -357,23 +359,8 @@ export default class ExpandedJobChart extends Component<PropsType, StateType> {
 
     this.getChartData(currentChart);
     this.getJobs(currentChart);
-    this.updateTabs();
     this.setupJobWebsocket(currentChart);
   }
-
-  componentDidUpdate(prevProps: PropsType) {
-    if (this.props.currentChart !== prevProps.currentChart) {
-      this.updateTabs();
-    }
-  }
-
-  //   componentWillUnmount() {
-  //     if (this.state.websockets) {
-  //       this.state.websockets.forEach((ws: WebSocket) => {
-  //         ws.close();
-  //       });
-  //     }
-  //   }
 
   handleUninstallChart = () => {
     let { currentProject, currentCluster } = this.context;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->
Form tabs don't load in when initially expanding chart/job bc of updated Expanded(Job)Chart didUpdate.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Form tabs load in properly, removed unnecessary componentDidUpdate lifecycle method

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
