### PR TITLE
fix buildpack env passing

### DIFF
--- a/internal/integrations/ci/actions/steps.go
+++ b/internal/integrations/ci/actions/steps.go
@@ -59,10 +59,11 @@ func getDockerBuildPushStep(envSecretName, dockerFilePath, repoURL string) Githu
 
 const buildPackPush string = `
 export $(echo "${{secrets.%s}}" | xargs)
+echo "${{secrets.%s}}" > /.env_porter
 sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
 sudo apt-get update
 sudo apt-get install pack-cli
-sudo pack build %s:$(git rev-parse --short HEAD) --path %s --builder heroku/buildpacks:18
+sudo pack build %s:$(git rev-parse --short HEAD) --path %s --builder heroku/buildpacks:18 --env-file ./env_porter
 sudo docker push %s:$(git rev-parse --short HEAD)
 `
 
@@ -70,7 +71,7 @@ func getBuildPackPushStep(envSecretName, folderPath, repoURL string) GithubActio
 	return GithubActionYAMLStep{
 		Name: "Docker build, push",
 		ID:   "docker_build_push",
-		Run:  fmt.Sprintf(buildPackPush, envSecretName, repoURL, folderPath, repoURL),
+		Run:  fmt.Sprintf(buildPackPush, envSecretName, envSecretName, repoURL, folderPath, repoURL),
 	}
 }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Buildpack env variables aren't propagated all the way to the pack command. 