### PR TITLE
Multi-process procfile support

### DIFF
--- a/dashboard/src/components/repo-selector/ActionConfEditor.tsx
+++ b/dashboard/src/components/repo-selector/ActionConfEditor.tsx
@@ -106,7 +106,12 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
       );
     }
 
-    if (this.props.procfilePath && this.props.folderPath && !this.props.dockerfilePath &&!this.props.procfileProcess) {
+    if (
+      this.props.procfilePath &&
+      this.props.folderPath &&
+      !this.props.dockerfilePath &&
+      !this.props.procfileProcess
+    ) {
       return (
         <>
           <ExpandedWrapperAlt>
@@ -117,7 +122,9 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
               procfilePath={this.props.procfilePath}
               setDockerfilePath={(x: string) => this.props.setDockerfilePath(x)}
               setProcfilePath={(x: string) => this.props.setProcfilePath(x)}
-              setProcfileProcess={(x: string) => this.props.setProcfileProcess(x)}
+              setProcfileProcess={(x: string) =>
+                this.props.setProcfileProcess(x)
+              }
               setFolderPath={(x: string) => this.props.setFolderPath(x)}
             />
           </ExpandedWrapperAlt>
@@ -132,7 +139,7 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
             Select Branch
           </BackButton>
         </>
-      )
+      );
     }
 
     return (

--- a/dashboard/src/components/repo-selector/ActionConfEditor.tsx
+++ b/dashboard/src/components/repo-selector/ActionConfEditor.tsx
@@ -17,7 +17,9 @@ type PropsType = {
   reset: any;
   dockerfilePath: string;
   procfilePath: string;
+  procfileProcess: string;
   setDockerfilePath: (x: string) => void;
+  setProcfileProcess: (x: string) => void;
   setProcfilePath: (x: string) => void;
   folderPath: string;
   setFolderPath: (x: string) => void;
@@ -104,11 +106,10 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
       );
     }
 
-    if (this.props.procfilePath && this.props.folderPath && !this.props.dockerfilePath) {
+    if (this.props.procfilePath && this.props.folderPath && !this.props.dockerfilePath &&!this.props.procfileProcess) {
       return (
         <>
-        <div>hello</div>
-          {/* <ExpandedWrapperAlt>
+          <ExpandedWrapperAlt>
             <ContentsList
               actionConfig={actionConfig}
               branch={branch}
@@ -116,6 +117,7 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
               procfilePath={this.props.procfilePath}
               setDockerfilePath={(x: string) => this.props.setDockerfilePath(x)}
               setProcfilePath={(x: string) => this.props.setProcfilePath(x)}
+              setProcfileProcess={(x: string) => this.props.setProcfileProcess(x)}
               setFolderPath={(x: string) => this.props.setFolderPath(x)}
             />
           </ExpandedWrapperAlt>
@@ -128,7 +130,7 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
           >
             <i className="material-icons">keyboard_backspace</i>
             Select Branch
-          </BackButton> */}
+          </BackButton>
         </>
       )
     }
@@ -138,6 +140,8 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
         branch={branch}
         setDockerfilePath={this.props.setDockerfilePath}
         setFolderPath={this.props.setFolderPath}
+        setProcfilePath={this.props.setProcfilePath}
+        setProcfileProcess={this.props.setProcfileProcess}
         actionConfig={actionConfig}
         setActionConfig={setActionConfig}
         dockerfilePath={this.props.dockerfilePath}

--- a/dashboard/src/components/repo-selector/ActionConfEditor.tsx
+++ b/dashboard/src/components/repo-selector/ActionConfEditor.tsx
@@ -16,7 +16,9 @@ type PropsType = {
   setBranch: (x: string) => void;
   reset: any;
   dockerfilePath: string;
+  procfilePath: string;
   setDockerfilePath: (x: string) => void;
+  setProcfilePath: (x: string) => void;
   folderPath: string;
   setFolderPath: (x: string) => void;
   setSelectedRegistry: (x: any) => void;
@@ -84,6 +86,7 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
               branch={branch}
               setActionConfig={setActionConfig}
               setDockerfilePath={(x: string) => this.props.setDockerfilePath(x)}
+              setProcfilePath={(x: string) => this.props.setProcfilePath(x)}
               setFolderPath={(x: string) => this.props.setFolderPath(x)}
             />
           </ExpandedWrapperAlt>
@@ -100,6 +103,36 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
         </>
       );
     }
+
+    if (this.props.procfilePath && this.props.folderPath && !this.props.dockerfilePath) {
+      return (
+        <>
+        <div>hello</div>
+          {/* <ExpandedWrapperAlt>
+            <ContentsList
+              actionConfig={actionConfig}
+              branch={branch}
+              setActionConfig={setActionConfig}
+              procfilePath={this.props.procfilePath}
+              setDockerfilePath={(x: string) => this.props.setDockerfilePath(x)}
+              setProcfilePath={(x: string) => this.props.setProcfilePath(x)}
+              setFolderPath={(x: string) => this.props.setFolderPath(x)}
+            />
+          </ExpandedWrapperAlt>
+          <Br />
+          <BackButton
+            width="145px"
+            onClick={() => {
+              setBranch("");
+            }}
+          >
+            <i className="material-icons">keyboard_backspace</i>
+            Select Branch
+          </BackButton> */}
+        </>
+      )
+    }
+
     return (
       <ActionDetails
         branch={branch}
@@ -108,6 +141,7 @@ export default class ActionConfEditor extends Component<PropsType, StateType> {
         actionConfig={actionConfig}
         setActionConfig={setActionConfig}
         dockerfilePath={this.props.dockerfilePath}
+        procfilePath={this.props.procfilePath}
         folderPath={this.props.folderPath}
         setSelectedRegistry={this.props.setSelectedRegistry}
         selectedRegistry={this.props.selectedRegistry}

--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -169,21 +169,24 @@ export default class ActionDetails extends Component<PropsType, StateType> {
             <i className="material-icons">keyboard_backspace</i>
             Select Folder
           </BackButton>
-          {this.props.selectedRegistry ? (
-            <StatusWrapper successful={true}>
-              <i className="material-icons">done</i> Source selected
-            </StatusWrapper>
-          ) : (!this.props.procfilePath && !this.props.dockerfilePath) ? (
+          {
+          
+          (!this.props.procfilePath && !this.props.dockerfilePath) ? (
             <StatusWrapper>
               <i className="material-icons">error_outline</i>
               Procfile not detected.
+            </StatusWrapper>
+          ) : this.props.selectedRegistry ? (
+            <StatusWrapper successful={true}>
+              <i className="material-icons">done</i> Source selected
             </StatusWrapper>
           ) : (
             <StatusWrapper>
               <i className="material-icons">error_outline</i>A connected
               container registry is required
             </StatusWrapper>
-          )}
+          )          
+          }
         </Flex>
       </>
     );

--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -15,6 +15,7 @@ type PropsType = {
   setActionConfig: (x: ActionConfigType) => void;
   branch: string;
   dockerfilePath: string;
+  procfilePath: string;
   folderPath: string;
   setSelectedRegistry: (x: any) => void;
   selectedRegistry: any;
@@ -28,12 +29,6 @@ type StateType = {
   registries: any[] | null;
   loading: boolean;
 };
-
-const dummyRegistries = [
-  { id: 1, service: "ecr", url: "https://idfkasdfasdf" },
-  { id: 12, service: "ecr", url: "https://dfasdfidfkasdfasdf" },
-  { id: 11, service: "gcr", url: "https://idfkasdfasdf" },
-] as any[];
 
 export default class ActionDetails extends Component<PropsType, StateType> {
   state = {
@@ -112,6 +107,7 @@ export default class ActionDetails extends Component<PropsType, StateType> {
   };
 
   render() {
+    console.log(this.props.dockerfilePath, this.props.folderPath, this.props.procfilePath)
     return (
       <>
         <DarkMatter />
@@ -173,6 +169,11 @@ export default class ActionDetails extends Component<PropsType, StateType> {
           {this.props.selectedRegistry ? (
             <StatusWrapper successful={true}>
               <i className="material-icons">done</i> Source selected
+            </StatusWrapper>
+          ) : (!this.props.procfilePath && !this.props.dockerfilePath) ? (
+            <StatusWrapper>
+              <i className="material-icons">error_outline</i>
+              Procfile not detected.
             </StatusWrapper>
           ) : (
             <StatusWrapper>

--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -16,6 +16,8 @@ type PropsType = {
   branch: string;
   dockerfilePath: string;
   procfilePath: string;
+  setProcfilePath: (x: string) => void;
+  setProcfileProcess: (x: string) => void;
   folderPath: string;
   setSelectedRegistry: (x: any) => void;
   selectedRegistry: any;
@@ -107,7 +109,6 @@ export default class ActionDetails extends Component<PropsType, StateType> {
   };
 
   render() {
-    console.log(this.props.dockerfilePath, this.props.folderPath, this.props.procfilePath)
     return (
       <>
         <DarkMatter />
@@ -161,6 +162,8 @@ export default class ActionDetails extends Component<PropsType, StateType> {
             onClick={() => {
               this.props.setDockerfilePath(null);
               this.props.setFolderPath(null);
+              this.props.setProcfilePath(null);
+              this.props.setProcfileProcess(null);
             }}
           >
             <i className="material-icons">keyboard_backspace</i>

--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -169,9 +169,7 @@ export default class ActionDetails extends Component<PropsType, StateType> {
             <i className="material-icons">keyboard_backspace</i>
             Select Folder
           </BackButton>
-          {
-          
-          (!this.props.procfilePath && !this.props.dockerfilePath) ? (
+          {!this.props.procfilePath && !this.props.dockerfilePath ? (
             <StatusWrapper>
               <i className="material-icons">error_outline</i>
               Procfile not detected.
@@ -185,8 +183,7 @@ export default class ActionDetails extends Component<PropsType, StateType> {
               <i className="material-icons">error_outline</i>A connected
               container registry is required
             </StatusWrapper>
-          )          
-          }
+          )}
         </Flex>
       </>
     );

--- a/dashboard/src/components/repo-selector/ContentsList.tsx
+++ b/dashboard/src/components/repo-selector/ContentsList.tsx
@@ -16,7 +16,7 @@ type PropsType = {
   branch: string;
   procfilePath?: string;
   setActionConfig: (x: ActionConfigType) => void;
-  setProcfileProcess?: (x: string) => void; 
+  setProcfileProcess?: (x: string) => void;
   setDockerfilePath: (x: string) => void;
   setProcfilePath: (x: string) => void;
   setFolderPath: (x: string) => void;
@@ -104,7 +104,7 @@ export default class ContentsList extends Component<PropsType, StateType> {
         }
       )
       .then((res) => {
-        this.setState({ processes: res.data})
+        this.setState({ processes: res.data });
       })
       .catch((err) => {
         console.log(err);
@@ -198,7 +198,7 @@ export default class ContentsList extends Component<PropsType, StateType> {
         dockerfiles.push(fileName);
       }
       if (fileName.includes("Procfile")) {
-        this.props.setProcfilePath(item.Path)
+        this.props.setProcfilePath(item.Path);
       }
     });
     if (dockerfiles.length > 0) {
@@ -217,35 +217,42 @@ export default class ContentsList extends Component<PropsType, StateType> {
       let processes = Object.keys(this.state.processes);
       return (
         <Overlay>
-          <BgOverlay onClick={() => this.setState({ dockerfiles: [] }, () => {
-            this.props.setFolderPath("");
-            this.props.setProcfilePath("");
-          })} />
-          <CloseButton onClick={() => this.setState({ dockerfiles: [] }, () => {
-            this.props.setProcfilePath("");
-          })}>
+          <BgOverlay
+            onClick={() =>
+              this.setState({ dockerfiles: [] }, () => {
+                this.props.setFolderPath("");
+                this.props.setProcfilePath("");
+              })
+            }
+          />
+          <CloseButton
+            onClick={() =>
+              this.setState({ dockerfiles: [] }, () => {
+                this.props.setProcfilePath("");
+              })
+            }
+          >
             <CloseButtonImg src={close} />
           </CloseButton>
           <Label>
-            Porter has detected a Procfile in this folder. Which process would you
-            like to run?
+            Porter has detected a Procfile in this folder. Which process would
+            you like to run?
           </Label>
           <DockerfileList>
-            {
-              processes.map((process: string, i: number) => {
-                return (
-                  <Row
-                    key={i}
-                    onClick={() => { this.props.setProcfileProcess(process) }
-                    }
-                    isLast={processes.length - 1 === i}
-                  >
-                    <Indicator selected={false}></Indicator>
-                    {process}
-                  </Row>
-                );
-              })            
-            }
+            {processes.map((process: string, i: number) => {
+              return (
+                <Row
+                  key={i}
+                  onClick={() => {
+                    this.props.setProcfileProcess(process);
+                  }}
+                  isLast={processes.length - 1 === i}
+                >
+                  <Indicator selected={false}></Indicator>
+                  {process}
+                </Row>
+              );
+            })}
           </DockerfileList>
         </Overlay>
       );
@@ -281,10 +288,9 @@ export default class ContentsList extends Component<PropsType, StateType> {
           </DockerfileList>
           <ConfirmButton
             onClick={() => {
-              this.props.setFolderPath(this.state.currentDir || "./")
-              this.props.setProcfilePath("./Procfile")
-            }
-            }
+              this.props.setFolderPath(this.state.currentDir || "./");
+              this.props.setProcfilePath("./Procfile");
+            }}
           >
             No, I don't want to use a Dockerfile
           </ConfirmButton>

--- a/dashboard/src/components/repo-selector/ContentsList.tsx
+++ b/dashboard/src/components/repo-selector/ContentsList.tsx
@@ -14,8 +14,10 @@ import Loading from "../Loading";
 type PropsType = {
   actionConfig: ActionConfigType | null;
   branch: string;
+  procfilePath?: string;
   setActionConfig: (x: ActionConfigType) => void;
   setDockerfilePath: (x: string) => void;
+  setProcfilePath: (x: string) => void;
   setFolderPath: (x: string) => void;
 };
 
@@ -26,8 +28,6 @@ type StateType = {
   currentDir: string;
   dockerfiles: string[];
 };
-
-const dummyDockerfiles = ["dev.Dockerfile", "prod.Dockerfile", "Dockerfile"];
 
 export default class ContentsList extends Component<PropsType, StateType> {
   state = {
@@ -130,6 +130,7 @@ export default class ContentsList extends Component<PropsType, StateType> {
           </FileItem>
         );
       }
+
       return (
         <FileItem key={i} lastItem={i === contents.length - 1}>
           <img src={file} />
@@ -172,6 +173,9 @@ export default class ContentsList extends Component<PropsType, StateType> {
       let fileName = splits[splits.length - 1];
       if (fileName.includes("Dockerfile")) {
         dockerfiles.push(fileName);
+      }
+      if (fileName.includes("Procfile")) {
+        this.props.setProcfilePath(item.Path)
       }
     });
     if (dockerfiles.length > 0) {
@@ -216,8 +220,10 @@ export default class ContentsList extends Component<PropsType, StateType> {
             })}
           </DockerfileList>
           <ConfirmButton
-            onClick={() =>
+            onClick={() => {
               this.props.setFolderPath(this.state.currentDir || "./")
+              this.props.setProcfilePath(`${this.state.currentDir}/Procfile` || `./Procfile`)
+            }
             }
           >
             No, I don't want to use a Dockerfile

--- a/dashboard/src/components/repo-selector/ContentsList.tsx
+++ b/dashboard/src/components/repo-selector/ContentsList.tsx
@@ -16,6 +16,7 @@ type PropsType = {
   branch: string;
   procfilePath?: string;
   setActionConfig: (x: ActionConfigType) => void;
+  setProcfileProcess?: (x: string) => void; 
   setDockerfilePath: (x: string) => void;
   setProcfilePath: (x: string) => void;
   setFolderPath: (x: string) => void;
@@ -190,6 +191,45 @@ export default class ContentsList extends Component<PropsType, StateType> {
   };
 
   renderOverlay = () => {
+    if (this.props.procfilePath) {
+      return (
+        <Overlay>
+          <BgOverlay onClick={() => this.setState({ dockerfiles: [] }, () => {
+            this.props.setFolderPath("");
+            this.props.setProcfilePath("");
+          })} />
+          <CloseButton onClick={() => this.setState({ dockerfiles: [] }, () => {
+            this.props.setProcfilePath("");
+          })}>
+            <CloseButtonImg src={close} />
+          </CloseButton>
+          <Label>
+            Porter has detected a Procfile in this folder. Which process would you
+            like to run?
+          </Label>
+          <DockerfileList>
+            {this.state.dockerfiles.map((dockerfile: string, i: number) => {
+              return (
+                <Row
+                  key={i}
+                  onClick={() => {
+                    console.log('ok')
+                    this.props.setProcfileProcess(
+                      'web'
+                    )
+                  }
+                  }
+                  isLast={this.state.dockerfiles.length - 1 === i}
+                >
+                  <Indicator selected={false}></Indicator>
+                  {dockerfile}
+                </Row>
+              );
+            })}
+          </DockerfileList>
+        </Overlay>
+      );
+    }
     if (this.state.dockerfiles.length > 0) {
       return (
         <Overlay>

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -44,10 +44,14 @@ export default class ValuesForm extends Component<PropsType, StateType> {
     return section.contents.map((item: FormElement, i: number) => {
       // If no name is assigned use values.yaml variable as identifier
       let key = item.name || item.variable;
-      
+
       // ugly exception to hide start command option when procfile process is set.
-      if ((item.variable === "container.command" || (item.type == "subtitle" && item.name == "command_description")) && this.props.procfileProcess) {
-          return;
+      if (
+        (item.variable === "container.command" ||
+          (item.type == "subtitle" && item.name == "command_description")) &&
+        this.props.procfileProcess
+      ) {
+        return;
       }
 
       switch (item.type) {

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -23,6 +23,7 @@ type PropsType = {
   disabled?: boolean;
   namespace?: string;
   clusterId?: number;
+  procfileProcess?: string;
 };
 
 type StateType = any;
@@ -43,6 +44,12 @@ export default class ValuesForm extends Component<PropsType, StateType> {
     return section.contents.map((item: FormElement, i: number) => {
       // If no name is assigned use values.yaml variable as identifier
       let key = item.name || item.variable;
+      
+      // ugly exception to hide start command option when procfile process is set.
+      if ((item.variable === "container.command" || (item.type == "subtitle" && item.name == "command_description")) && this.props.procfileProcess) {
+          return;
+      }
+
       switch (item.type) {
         case "heading":
           return <Heading key={i}>{item.label}</Heading>;

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -143,7 +143,11 @@ class Home extends Component<PropsType, StateType> {
     return callback();
   };
 
-  provisionDOKS = async (integrationId: number, region: string, clusterName: string) => {
+  provisionDOKS = async (
+    integrationId: number,
+    region: string,
+    clusterName: string
+  ) => {
     console.log("Provisioning DOKS...");
     await api.createDOKS(
       "<token>",
@@ -178,7 +182,7 @@ class Home extends Component<PropsType, StateType> {
           let urlParams = new URLSearchParams(queryString);
           let tier = urlParams.get("tier");
           let region = urlParams.get("region");
-          let clusterName = urlParams.get("cluster_name")
+          let clusterName = urlParams.get("cluster_name");
           let infras = urlParams.getAll("infras");
           if (infras.length === 2) {
             this.provisionDOCR(tgtIntegration.id, tier, () => {

--- a/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
@@ -383,6 +383,14 @@ class LaunchTemplate extends Component<PropsType, StateType> {
       procfilePath,
     } = this.state;
 
+    if (
+      sourceType === "repo" &&
+      (!dockerfilePath && folderPath) &&
+      !procfilePath
+    ) {
+      return "Procfile not detected."
+    }
+
     if (!this.submitIsDisabled()) {
       return this.state.saveValuesStatus;
     }
@@ -390,14 +398,6 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     // handle exception when deploy process is on loading
     if (this.state.saveValuesStatus === "loading") {
       return "loading"
-    }
-
-    if (
-      sourceType === "repo" &&
-      (!dockerfilePath && folderPath) &&
-      !procfilePath
-    ) {
-      return "Procfile not detected."
     }
 
     if (

--- a/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
@@ -50,6 +50,7 @@ type StateType = {
   tabContents: any;
   namespaceOptions: { label: string; value: string }[];
   actionConfig: ActionConfigType;
+  procfileProcess: string;
   branch: string;
   repoType: string;
   dockerfilePath: string | null;
@@ -87,6 +88,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     branch: "",
     repoType: "",
     dockerfilePath: null as string | null,
+    procfileProcess: null as string | null,
     procfilePath: null as string | null,
     folderPath: null as string | null,
     selectedRegistry: null as any | null,
@@ -427,6 +429,14 @@ class LaunchTemplate extends Component<PropsType, StateType> {
         renderSaveButton={true}
       >
         {(metaState: any, setMetaState: any) => {
+
+          if (!metaState) {
+            return;
+          }
+          
+          // handle when procfileProcess is already specified
+          metaState['container.command'] = this.state.procfileProcess ? this.state.procfileProcess : "";
+
           return this.props.form?.tabs.map((tab: any, i: number) => {
             // If tab is current, render
             if (tab.name === this.state.currentTab) {
@@ -440,6 +450,8 @@ class LaunchTemplate extends Component<PropsType, StateType> {
                   // For env group loader
                   namespace={this.state.selectedNamespace}
                   clusterId={this.state.selectedClusterId}
+                  // For procfile process
+                  procfileProcess={this.state.procfileProcess}
                 />
               );
             }
@@ -675,6 +687,8 @@ class LaunchTemplate extends Component<PropsType, StateType> {
                 );
               })
             }
+            procfileProcess={this.state.procfileProcess}
+            setProcfileProcess={(procfileProcess: string) => this.setState({ procfileProcess })}
             setBranch={(branch: string) => this.setState({ branch })}
             setDockerfilePath={(x: string) =>
               this.setState({ dockerfilePath: x })

--- a/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
@@ -53,6 +53,7 @@ type StateType = {
   branch: string;
   repoType: string;
   dockerfilePath: string | null;
+  procfilePath: string | null;
   folderPath: string | null;
   selectedRegistry: any | null;
   env: any;
@@ -86,6 +87,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     branch: "",
     repoType: "",
     dockerfilePath: null as string | null,
+    procfilePath: null as string | null,
     folderPath: null as string | null,
     selectedRegistry: null as any | null,
     env: {},
@@ -376,6 +378,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
       sourceType,
       dockerfilePath,
       folderPath,
+      procfilePath,
     } = this.state;
 
     if (!this.submitIsDisabled()) {
@@ -385,6 +388,14 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     // handle exception when deploy process is on loading
     if (this.state.saveValuesStatus === "loading") {
       return "loading"
+    }
+
+    if (
+      sourceType === "repo" &&
+      (!dockerfilePath && folderPath) &&
+      !procfilePath
+    ) {
+      return "Procfile not detected."
     }
 
     if (
@@ -588,7 +599,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     } else if (this.state.sourceType === "registry") {
       return (
         <StyledSourceBox>
-          <CloseButton onClick={() => this.setState({ sourceType: "" })}>
+          <CloseButton onClick={() => this.setState({ sourceType: "", selectedImageUrl: "", selectedTag: "" })}>
             <CloseButtonImg src={close} />
           </CloseButton>
           <Subtitle>
@@ -668,6 +679,10 @@ class LaunchTemplate extends Component<PropsType, StateType> {
             setDockerfilePath={(x: string) =>
               this.setState({ dockerfilePath: x })
             }
+            setProcfilePath={(x: string) => {
+              this.setState({ procfilePath: x })
+            }}
+            procfilePath={this.state.procfilePath}
             dockerfilePath={this.state.dockerfilePath}
             folderPath={this.state.folderPath}
             setFolderPath={(x: string) => this.setState({ folderPath: x })}

--- a/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
@@ -385,10 +385,11 @@ class LaunchTemplate extends Component<PropsType, StateType> {
 
     if (
       sourceType === "repo" &&
-      (!dockerfilePath && folderPath) &&
+      !dockerfilePath &&
+      folderPath &&
       !procfilePath
     ) {
-      return "Procfile not detected."
+      return "Procfile not detected.";
     }
 
     if (!this.submitIsDisabled()) {
@@ -397,7 +398,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
 
     // handle exception when deploy process is on loading
     if (this.state.saveValuesStatus === "loading") {
-      return "loading"
+      return "loading";
     }
 
     if (
@@ -412,7 +413,6 @@ class LaunchTemplate extends Component<PropsType, StateType> {
       return "Template name contains illegal characters";
     }
     return "No application source specified";
-
   };
 
   renderTabContents = () => {
@@ -429,13 +429,14 @@ class LaunchTemplate extends Component<PropsType, StateType> {
         renderSaveButton={true}
       >
         {(metaState: any, setMetaState: any) => {
-
           if (!metaState) {
             return;
           }
-          
+
           // handle when procfileProcess is already specified
-          metaState['container.command'] = this.state.procfileProcess ? this.state.procfileProcess : "";
+          metaState["container.command"] = this.state.procfileProcess
+            ? this.state.procfileProcess
+            : "";
 
           return this.props.form?.tabs.map((tab: any, i: number) => {
             // If tab is current, render
@@ -611,7 +612,15 @@ class LaunchTemplate extends Component<PropsType, StateType> {
     } else if (this.state.sourceType === "registry") {
       return (
         <StyledSourceBox>
-          <CloseButton onClick={() => this.setState({ sourceType: "", selectedImageUrl: "", selectedTag: "" })}>
+          <CloseButton
+            onClick={() =>
+              this.setState({
+                sourceType: "",
+                selectedImageUrl: "",
+                selectedTag: "",
+              })
+            }
+          >
             <CloseButtonImg src={close} />
           </CloseButton>
           <Subtitle>
@@ -688,13 +697,15 @@ class LaunchTemplate extends Component<PropsType, StateType> {
               })
             }
             procfileProcess={this.state.procfileProcess}
-            setProcfileProcess={(procfileProcess: string) => this.setState({ procfileProcess })}
+            setProcfileProcess={(procfileProcess: string) =>
+              this.setState({ procfileProcess })
+            }
             setBranch={(branch: string) => this.setState({ branch })}
             setDockerfilePath={(x: string) =>
               this.setState({ dockerfilePath: x })
             }
             setProcfilePath={(x: string) => {
-              this.setState({ procfilePath: x })
+              this.setState({ procfilePath: x });
             }}
             procfilePath={this.state.procfilePath}
             dockerfilePath={this.state.dockerfilePath}

--- a/dashboard/src/main/home/provisioner/AWSFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/AWSFormSection.tsx
@@ -89,7 +89,7 @@ class AWSFormSection extends Component<PropsType, StateType> {
   componentDidMount = () => {
     let { infras } = this.props;
     let { selectedInfras } = this.state;
-    this.setClusterNameIfNotSet()
+    this.setClusterNameIfNotSet();
 
     if (infras) {
       // From the dashboard, only uncheck and disable if "creating" or "created"
@@ -106,39 +106,60 @@ class AWSFormSection extends Component<PropsType, StateType> {
     }
   };
 
-  componentDidUpdate = (prevProps : PropsType, prevState : StateType) => {
+  componentDidUpdate = (prevProps: PropsType, prevState: StateType) => {
     if (prevProps.projectName != this.props.projectName) {
-      this.setClusterNameIfNotSet()
+      this.setClusterNameIfNotSet();
     }
-  }
+  };
 
   setClusterNameIfNotSet = () => {
-    let projectName = this.props.projectName || this.context.currentProject?.name
+    let projectName =
+      this.props.projectName || this.context.currentProject?.name;
 
-    if (!this.state.clusterNameSet && !this.state.clusterName.includes(`${projectName}-cluster`)) {
+    if (
+      !this.state.clusterNameSet &&
+      !this.state.clusterName.includes(`${projectName}-cluster`)
+    ) {
       this.setState({
-        clusterName: `${projectName}-cluster-${Math.random().toString(36).substring(2, 8)}`
-      })
+        clusterName: `${projectName}-cluster-${Math.random()
+          .toString(36)
+          .substring(2, 8)}`,
+      });
     }
-  }
+  };
 
   checkFormDisabled = () => {
     if (!this.state.provisionConfirmed) {
       return true;
     }
 
-    let { awsRegion, awsAccessId, awsSecretKey, selectedInfras, clusterName } = this.state;
+    let {
+      awsRegion,
+      awsAccessId,
+      awsSecretKey,
+      selectedInfras,
+      clusterName,
+    } = this.state;
     let { projectName } = this.props;
     if (projectName || projectName === "") {
       return (
         !isAlphanumeric(projectName) ||
-        !(awsAccessId !== "" && awsSecretKey !== "" && awsRegion !== "" && clusterName !== "") ||
+        !(
+          awsAccessId !== "" &&
+          awsSecretKey !== "" &&
+          awsRegion !== "" &&
+          clusterName !== ""
+        ) ||
         selectedInfras.length === 0
       );
     } else {
       return (
-        !(awsAccessId !== "" && awsSecretKey !== "" && awsRegion !== "" && clusterName !== "") ||
-        selectedInfras.length === 0
+        !(
+          awsAccessId !== "" &&
+          awsSecretKey !== "" &&
+          awsRegion !== "" &&
+          clusterName !== ""
+        ) || selectedInfras.length === 0
       );
     }
   };
@@ -209,7 +230,13 @@ class AWSFormSection extends Component<PropsType, StateType> {
   };
 
   provisionEKS = () => {
-    let { awsAccessId, awsSecretKey, awsRegion, awsMachineType, clusterName } = this.state;
+    let {
+      awsAccessId,
+      awsSecretKey,
+      awsRegion,
+      awsMachineType,
+      clusterName,
+    } = this.state;
     let { currentProject } = this.context;
 
     api
@@ -296,18 +323,25 @@ class AWSFormSection extends Component<PropsType, StateType> {
   renderClusterNameSection = () => {
     let { selectedInfras, clusterName } = this.state;
 
-    if (selectedInfras.length == 2 ||  (selectedInfras.length == 1 && selectedInfras[0].value === "eks")) {
-      return <InputRow
-        type="text"
-        value={clusterName}
-        setValue={(x: string) => this.setState({ clusterName: x, clusterNameSet: true })}
-        label="Cluster Name"
-        placeholder="ex: porter-cluster"
-        width="100%"
-        isRequired={true}
-      />
+    if (
+      selectedInfras.length == 2 ||
+      (selectedInfras.length == 1 && selectedInfras[0].value === "eks")
+    ) {
+      return (
+        <InputRow
+          type="text"
+          value={clusterName}
+          setValue={(x: string) =>
+            this.setState({ clusterName: x, clusterNameSet: true })
+          }
+          label="Cluster Name"
+          placeholder="ex: porter-cluster"
+          width="100%"
+          isRequired={true}
+        />
+      );
     }
-  }
+  };
 
   render() {
     let { setSelectedProvisioner } = this.props;

--- a/dashboard/src/main/home/provisioner/DOFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/DOFormSection.tsx
@@ -68,7 +68,7 @@ export default class DOFormSection extends Component<PropsType, StateType> {
   componentDidMount = () => {
     let { infras } = this.props;
     let { selectedInfras } = this.state;
-    this.setClusterNameIfNotSet()
+    this.setClusterNameIfNotSet();
 
     if (infras) {
       // From the dashboard, only uncheck and disable if "creating" or "created"
@@ -85,21 +85,27 @@ export default class DOFormSection extends Component<PropsType, StateType> {
     }
   };
 
-  componentDidUpdate = (prevProps : PropsType, prevState : StateType) => {
+  componentDidUpdate = (prevProps: PropsType, prevState: StateType) => {
     if (prevProps.projectName != this.props.projectName) {
-      this.setClusterNameIfNotSet()
+      this.setClusterNameIfNotSet();
     }
-  }
+  };
 
   setClusterNameIfNotSet = () => {
-    let projectName = this.props.projectName || this.context.currentProject?.name
+    let projectName =
+      this.props.projectName || this.context.currentProject?.name;
 
-    if (!this.state.clusterNameSet && !this.state.clusterName.includes(`${projectName}-cluster`)) {
+    if (
+      !this.state.clusterNameSet &&
+      !this.state.clusterName.includes(`${projectName}-cluster`)
+    ) {
       this.setState({
-        clusterName: `${projectName}-cluster-${Math.random().toString(36).substring(2, 8)}`
-      })
+        clusterName: `${projectName}-cluster-${Math.random()
+          .toString(36)
+          .substring(2, 8)}`,
+      });
     }
-  }
+  };
 
   checkFormDisabled = () => {
     if (!this.state.provisionConfirmed) {
@@ -109,7 +115,11 @@ export default class DOFormSection extends Component<PropsType, StateType> {
     let { selectedInfras, clusterName } = this.state;
     let { projectName } = this.props;
     if (projectName || projectName === "") {
-      return !isAlphanumeric(projectName) || selectedInfras.length === 0 || !clusterName;
+      return (
+        !isAlphanumeric(projectName) ||
+        selectedInfras.length === 0 ||
+        !clusterName
+      );
     } else {
       return selectedInfras.length === 0 || !clusterName;
     }
@@ -149,7 +159,12 @@ export default class DOFormSection extends Component<PropsType, StateType> {
   };
 
   doRedirect = (projectId: number) => {
-    let { subscriptionTier, doRegion, selectedInfras, clusterName } = this.state;
+    let {
+      subscriptionTier,
+      doRegion,
+      selectedInfras,
+      clusterName,
+    } = this.state;
     let redirectUrl = `/api/oauth/projects/${projectId}/digitalocean?project_id=${projectId}&provision=do`;
     redirectUrl += `&tier=${subscriptionTier}&region=${doRegion}&cluster_name=${clusterName}`;
     selectedInfras.forEach((option: { value: string; label: string }) => {
@@ -178,7 +193,11 @@ export default class DOFormSection extends Component<PropsType, StateType> {
         return "Project name contains illegal characters";
       }
     }
-    if (!this.state.provisionConfirmed || this.props.projectName === "" || !this.state.clusterName) {
+    if (
+      !this.state.provisionConfirmed ||
+      this.props.projectName === "" ||
+      !this.state.clusterName
+    ) {
       return "Required fields missing";
     }
   };
@@ -186,18 +205,25 @@ export default class DOFormSection extends Component<PropsType, StateType> {
   renderClusterNameSection = () => {
     let { selectedInfras, clusterName } = this.state;
 
-    if (selectedInfras.length == 2 ||  (selectedInfras.length == 1 && selectedInfras[0].value === "doks")) {
-      return <InputRow
-        type="text"
-        value={clusterName}
-        setValue={(x: string) => this.setState({ clusterName: x, clusterNameSet: true })}
-        label="Cluster Name"
-        placeholder="ex: porter-cluster"
-        width="100%"
-        isRequired={true}
-      />
+    if (
+      selectedInfras.length == 2 ||
+      (selectedInfras.length == 1 && selectedInfras[0].value === "doks")
+    ) {
+      return (
+        <InputRow
+          type="text"
+          value={clusterName}
+          setValue={(x: string) =>
+            this.setState({ clusterName: x, clusterNameSet: true })
+          }
+          label="Cluster Name"
+          placeholder="ex: porter-cluster"
+          width="100%"
+          isRequired={true}
+        />
+      );
     }
-  }
+  };
 
   render() {
     let { setSelectedProvisioner } = this.props;

--- a/dashboard/src/main/home/provisioner/GCPFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/GCPFormSection.tsx
@@ -81,7 +81,7 @@ class GCPFormSection extends Component<PropsType, StateType> {
   componentDidMount = () => {
     let { infras } = this.props;
     let { selectedInfras } = this.state;
-    this.setClusterNameIfNotSet()
+    this.setClusterNameIfNotSet();
 
     if (infras) {
       // From the dashboard, only uncheck and disable if "creating" or "created"
@@ -98,39 +98,60 @@ class GCPFormSection extends Component<PropsType, StateType> {
     }
   };
 
-  componentDidUpdate = (prevProps : PropsType, prevState : StateType) => {
+  componentDidUpdate = (prevProps: PropsType, prevState: StateType) => {
     if (prevProps.projectName != this.props.projectName) {
-      this.setClusterNameIfNotSet()
+      this.setClusterNameIfNotSet();
     }
-  }
+  };
 
   setClusterNameIfNotSet = () => {
-    let projectName = this.props.projectName || this.context.currentProject?.name
+    let projectName =
+      this.props.projectName || this.context.currentProject?.name;
 
-    if (!this.state.clusterNameSet && !this.state.clusterName.includes(`${projectName}-cluster`)) {
+    if (
+      !this.state.clusterNameSet &&
+      !this.state.clusterName.includes(`${projectName}-cluster`)
+    ) {
       this.setState({
-        clusterName: `${projectName}-cluster-${Math.random().toString(36).substring(2, 8)}`
-      })
+        clusterName: `${projectName}-cluster-${Math.random()
+          .toString(36)
+          .substring(2, 8)}`,
+      });
     }
-  }
+  };
 
   checkFormDisabled = () => {
     if (!this.state.provisionConfirmed) {
       return true;
     }
 
-    let { gcpRegion, gcpProjectId, gcpKeyData, selectedInfras, clusterName } = this.state;
+    let {
+      gcpRegion,
+      gcpProjectId,
+      gcpKeyData,
+      selectedInfras,
+      clusterName,
+    } = this.state;
     let { projectName } = this.props;
     if (projectName || projectName === "") {
       return (
         !isAlphanumeric(projectName) ||
-        !(gcpProjectId !== "" && gcpKeyData !== "" && gcpRegion !== "" && clusterName !== "") ||
+        !(
+          gcpProjectId !== "" &&
+          gcpKeyData !== "" &&
+          gcpRegion !== "" &&
+          clusterName !== ""
+        ) ||
         selectedInfras.length === 0
       );
     } else {
       return (
-        !(gcpProjectId !== "" && gcpKeyData !== "" && gcpRegion !== "" && clusterName !== "") ||
-        selectedInfras.length === 0
+        !(
+          gcpProjectId !== "" &&
+          gcpKeyData !== "" &&
+          gcpRegion !== "" &&
+          clusterName !== ""
+        ) || selectedInfras.length === 0
       );
     }
   };
@@ -274,18 +295,25 @@ class GCPFormSection extends Component<PropsType, StateType> {
   renderClusterNameSection = () => {
     let { selectedInfras, clusterName } = this.state;
 
-    if (selectedInfras.length == 2 ||  (selectedInfras.length == 1 && selectedInfras[0].value === "gke")) {
-      return <InputRow
-        type="text"
-        value={clusterName}
-        setValue={(x: string) => this.setState({ clusterName: x, clusterNameSet: true })}
-        label="Cluster Name"
-        placeholder="ex: porter-cluster"
-        width="100%"
-        isRequired={true}
-      />
+    if (
+      selectedInfras.length == 2 ||
+      (selectedInfras.length == 1 && selectedInfras[0].value === "gke")
+    ) {
+      return (
+        <InputRow
+          type="text"
+          value={clusterName}
+          setValue={(x: string) =>
+            this.setState({ clusterName: x, clusterNameSet: true })
+          }
+          label="Cluster Name"
+          placeholder="ex: porter-cluster"
+          width="100%"
+          isRequired={true}
+        />
+      );
     }
-  }
+  };
 
   render() {
     let { setSelectedProvisioner } = this.props;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?
users need to specify the process name as a start command when an image is built with a Procfile with multiple processes.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?
Porter parses the procfile and prompts the user to specify the process they want to run. Start command is hidden when a process is specified.

When both Procfile and Dockerfile are present, porter first prompts the user to choose a Dockerfile. If the user chooses not to use a Dockerfile, the Procfile process prompt is shown.

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
