### PR TITLE
[0.2.0] Hide default domain in form.yaml

### DIFF
--- a/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/LaunchTemplate.tsx
@@ -244,7 +244,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
 
     // check if template is docker and create external domain if necessary
     if (this.props.currentTemplate.name == "web") {
-      if (values?.ingress?.enabled && values?.ingress?.hosts?.length == 0) {
+      if (!values?.ingress?.custom_domain) {
         url = await new Promise((resolve, reject) => {
           api
             .createSubdomain(
@@ -265,8 +265,7 @@ class LaunchTemplate extends Component<PropsType, StateType> {
             });
         });
 
-        values.ingress.hosts = [url];
-        values.ingress.custom_domain = true;
+        values.ingress.porter_hosts = [url];
       }
     }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): change behavior of default domain to prevent it from being editable in `form.yaml`. 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users may attempt to modify the default domain when this is not possible. 

## What is the new behavior?

Hide the domain from `form.yaml` when it's set to a default domain field. This field should still be editable so that users can set up their own domain. 