### PR TITLE
[0.2.0] Set Cache-Control header so that pages reload

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
@@ -64,7 +64,6 @@ export default class Logs extends Component<PropsType, StateType> {
       return <Log key={i}>
         {this.state.logs[i].map((ansi, j) => {
           if (ansi.clearLine) {
-            console.log("CLEAR LINE IS", ansi.clearLine)
             return null
           }
 
@@ -85,9 +84,7 @@ export default class Logs extends Component<PropsType, StateType> {
       `${protocol}://${process.env.API_SERVER}/api/projects/${currentProject.id}/k8s/${selectedPod?.metadata?.namespace}/pod/${selectedPod?.metadata?.name}/logs?cluster_id=${currentCluster.id}&service_account_id=${currentCluster.service_account_id}`
     );
 
-    this.ws.onopen = () => {
-      console.log("connected to websocket");
-    };
+    this.ws.onopen = () => {};
 
     this.ws.onmessage = (evt: MessageEvent) => {
       let ansiLog = Anser.ansiToJson(evt.data)
@@ -102,13 +99,9 @@ export default class Logs extends Component<PropsType, StateType> {
       });
     };
 
-    this.ws.onerror = (err: ErrorEvent) => {
-      console.log("websocket error:", err);
-    };
+    this.ws.onerror = (err: ErrorEvent) => {};
 
-    this.ws.onclose = () => {
-      console.log("closing pod logs");
-    };
+    this.ws.onclose = () => {};
   };
 
   refreshLogs = () => {

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -1359,15 +1359,17 @@ func New(a *api.App) *chi.Mux {
 	fs := http.FileServer(http.Dir(staticFilePath))
 
 	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
-		// Set static files involving html, js, or empty cache to "no-cache", which means they must be validated
-		// for changes before the browser uses the cache
-		if base := path.Base(r.URL.Path); strings.Contains(base, "html") || strings.Contains(base, "js") || base == "." || base == "/" {
-			w.Header().Set("Cache-Control", "no-cache")
-		}
-
 		if _, err := os.Stat(staticFilePath + r.RequestURI); os.IsNotExist(err) {
+			w.Header().Set("Cache-Control", "no-cache")
+
 			http.StripPrefix(r.URL.Path, fs).ServeHTTP(w, r)
 		} else {
+			// Set static files involving html, js, or empty cache to "no-cache", which means they must be validated
+			// for changes before the browser uses the cache
+			if base := path.Base(r.URL.Path); strings.Contains(base, "html") || strings.Contains(base, "js") || base == "." || base == "/" {
+				w.Header().Set("Cache-Control", "no-cache")
+			}
+
 			fs.ServeHTTP(w, r)
 		}
 	})


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users are asked to empty cache and hard reload the webpage to see new changes reflected. 

## What is the new behavior?

Add the `Cache-Control` header set to `no-cache` for html/js resources, which means that the browser will check for changes to the resource before using the cache. 