### PR TITLE
[0.2.0] Support immutable secret values for deployments

### DIFF
--- a/cli/cmd/github/release.go
+++ b/cli/cmd/github/release.go
@@ -156,7 +156,6 @@ func (z *ZIPReleaseGetter) getDownloadRegexp() (*regexp.Regexp, error) {
 // // it, and adds the binary to the porter directory
 // func DownloadLatestServerRelease(porterDir string) error {
 // 	releaseURL, staticReleaseURL, err := getLatestReleaseDownloadURL()
-// 	fmt.Println(releaseURL)
 
 // 	if err != nil {
 // 		return err

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -108,6 +108,7 @@ export default class ValuesForm extends Component<PropsType, StateType> {
               }}
               label={item.label}
               disabled={this.props.disabled}
+              secretOption={true}
             />
           );
         case "key-value-array":

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/CreateEnvGroup.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/CreateEnvGroup.tsx
@@ -8,7 +8,7 @@ import { Context } from "shared/Context";
 import { ClusterType } from "shared/types";
 
 import InputRow from "components/values-form/InputRow";
-import KeyValueArray from "components/values-form/KeyValueArray";
+import EnvGroupArray, { KeyValueType } from "./EnvGroupArray";
 import Selector from "components/Selector";
 import Helper from "components/values-form/Helper";
 import SaveButton from "components/SaveButton";
@@ -25,7 +25,7 @@ type StateType = {
   envGroupName: string;
   selectedNamespace: string;
   namespaceOptions: any[];
-  envVariables: any;
+  envVariables: KeyValueType[];
   submitStatus: string;
 };
 
@@ -36,7 +36,7 @@ export default class CreateEnvGroup extends Component<PropsType, StateType> {
     envGroupName: "",
     selectedNamespace: "default",
     namespaceOptions: [] as any[],
-    envVariables: {} as any,
+    envVariables: [] as KeyValueType[],
     submitStatus: "",
   };
 
@@ -52,13 +52,26 @@ export default class CreateEnvGroup extends Component<PropsType, StateType> {
 
   onSubmit = () => {
     this.setState({ submitStatus: "loading" });
+
+    let apiEnvVariables : Record<string, string> = {}
+    let secretEnvVariables : Record<string, string> = {}
+
+    this.state.envVariables.forEach((envVar: KeyValueType) => {
+      if (envVar.hidden) {
+        secretEnvVariables[envVar.key] = envVar.value
+      } else {
+        apiEnvVariables[envVar.key] = envVar.value
+      }
+    })
+
     api
       .createConfigMap(
         "<token>",
         {
           name: this.state.envGroupName,
           namespace: this.state.selectedNamespace,
-          variables: this.state.envVariables,
+          variables: apiEnvVariables,
+          secret_variables: secretEnvVariables,
         },
         {
           id: this.context.currentProject.id,
@@ -159,11 +172,12 @@ export default class CreateEnvGroup extends Component<PropsType, StateType> {
             Set environment variables for your secrets and environment-specific
             configuration.
           </Helper>
-          <KeyValueArray
+          <EnvGroupArray
             namespace={this.state.selectedNamespace}
             values={this.state.envVariables}
             setValues={(x: any) => this.setState({ envVariables: x })}
             fileUpload={true}
+            secretOption={true}
           />
           <SaveButton
             disabled={this.isDisabled()}

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -753,6 +753,7 @@ const createConfigMap = baseApi<
     name: string;
     namespace: string;
     variables: Record<string, string>;
+    secret_variables?: Record<string, string>;
   },
   { id: number; cluster_id: number }
 >("POST", (pathParams) => {
@@ -765,6 +766,7 @@ const updateConfigMap = baseApi<
     name: string;
     namespace: string;
     variables: Record<string, string>;
+    secret_variables?: Record<string, string>;
   },
   { id: number; cluster_id: number }
 >("POST", (pathParams) => {

--- a/internal/forms/k8s.go
+++ b/internal/forms/k8s.go
@@ -39,7 +39,8 @@ func (kf *K8sForm) PopulateK8sOptionsFromQueryParams(
 }
 
 type ConfigMapForm struct {
-	Name string `json:"name" form:"required"`
-	Namespace string `json:"namespace" form:"required"`
-	EnvVariables map[string]string `json:"variables"`
+	Name               string            `json:"name" form:"required"`
+	Namespace          string            `json:"namespace" form:"required"`
+	EnvVariables       map[string]string `json:"variables"`
+	SecretEnvVariables map[string]string `json:"secret_variables"`
 }

--- a/server/api/k8s_handler.go
+++ b/server/api/k8s_handler.go
@@ -77,7 +77,6 @@ func (app *App) HandleListNamespaces(w http.ResponseWriter, r *http.Request) {
 
 // HandleCreateConfigMap deletes the pod given the name and namespace.
 func (app *App) HandleCreateConfigMap(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("CREATING CONFGIMAP")
 	vals, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		app.handleErrorFormDecoding(err, ErrReleaseDecode, w)
@@ -116,6 +115,32 @@ func (app *App) HandleCreateConfigMap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	secretData := make(map[string][]byte)
+
+	for key, rawValue := range configMap.SecretEnvVariables {
+		// encodedValue := base64.StdEncoding.EncodeToString([]byte(rawValue))
+
+		// if err != nil {
+		// 	app.handleErrorInternal(err, w)
+		// 	return
+		// }
+
+		secretData[key] = []byte(rawValue)
+	}
+
+	// create secret first
+	_, err = agent.CreateLinkedSecret(configMap.Name, configMap.Namespace, configMap.Name, secretData)
+
+	if err != nil {
+		app.handleErrorInternal(err, w)
+		return
+	}
+
+	// add all secret env variables to configmap with value PORTERSECRET_${configmap_name}
+	for key, _ := range configMap.SecretEnvVariables {
+		configMap.EnvVariables[key] = fmt.Sprintf("PORTERSECRET_%s", configMap.Name)
+	}
+
 	_, err = agent.CreateConfigMap(configMap.Name, configMap.Namespace, configMap.EnvVariables)
 
 	if err != nil {
@@ -135,7 +160,7 @@ func (app *App) HandleCreateConfigMap(w http.ResponseWriter, r *http.Request) {
 // HandleListConfigMaps lists all configmaps in a namespace.
 func (app *App) HandleListConfigMaps(w http.ResponseWriter, r *http.Request) {
 	vals, err := url.ParseQuery(r.URL.RawQuery)
-	
+
 	if err != nil {
 		app.handleErrorFormDecoding(err, ErrReleaseDecode, w)
 		return
@@ -185,7 +210,7 @@ func (app *App) HandleListConfigMaps(w http.ResponseWriter, r *http.Request) {
 // HandleGetConfigMap retreives the configmap given the name and namespace.
 func (app *App) HandleGetConfigMap(w http.ResponseWriter, r *http.Request) {
 	vals, err := url.ParseQuery(r.URL.RawQuery)
-	
+
 	if err != nil {
 		app.handleErrorFormDecoding(err, ErrReleaseDecode, w)
 		return
@@ -265,6 +290,13 @@ func (app *App) HandleDeleteConfigMap(w http.ResponseWriter, r *http.Request) {
 		agent, err = kubernetes.GetAgentOutOfClusterConfig(form.OutOfClusterConfig)
 	}
 
+	err = agent.DeleteLinkedSecret(vals["name"][0], vals["namespace"][0])
+
+	if err != nil {
+		app.handleErrorInternal(err, w)
+		return
+	}
+
 	err = agent.DeleteConfigMap(vals["name"][0], vals["namespace"][0])
 
 	if err != nil {
@@ -317,7 +349,38 @@ func (app *App) HandleUpdateConfigMap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = agent.UpdateConfigMap(configMap.Name, configMap.Namespace, configMap.EnvVariables)
+	secretData := make(map[string][]byte)
+
+	for key, rawValue := range configMap.SecretEnvVariables {
+		// encodedValue, err := base64.StdEncoding.DecodeString(rawValue)
+
+		// if err != nil {
+		// 	app.handleErrorInternal(err, w)
+		// 	return
+		// }
+
+		secretData[key] = []byte(rawValue)
+	}
+
+	// create secret first
+	err = agent.UpdateLinkedSecret(configMap.Name, configMap.Namespace, configMap.Name, secretData)
+
+	if err != nil {
+		app.handleErrorInternal(err, w)
+		return
+	}
+
+	// add all secret env variables to configmap with value PORTERSECRET_${configmap_name}
+	for key, val := range configMap.SecretEnvVariables {
+		configMap.EnvVariables[key] = fmt.Sprintf("PORTERSECRET_%s", configMap.Name)
+
+		// if val is empty, set to empty
+		if val == "" {
+			configMap.EnvVariables[key] = ""
+		}
+	}
+
+	err = agent.UpdateConfigMap(configMap.Name, configMap.Namespace, configMap.EnvVariables)
 
 	if err != nil {
 		app.handleErrorInternal(err, w)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

There is no way to inject secret environment variables that you don't want exposed on the Porter dashboard after creation. 

## What is the new behavior?

Support opaque secrets that are immutable once created. Docs should be added before release. 

## Technical Spec/Implementation Notes
