### PR TITLE
fix duplicate env var issue caused by identical pointers

### DIFF
--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -107,7 +107,8 @@ func (a *Agent) UpdateConfigMap(name string, namespace string, configMap map[str
 	cmData := make(map[string]*string)
 
 	for key, val := range configMap {
-		cmData[key] = &val
+		valCopy := val
+		cmData[key] = &valCopy
 
 		if len(val) == 0 {
 			cmData[key] = nil
@@ -144,7 +145,8 @@ func (a *Agent) UpdateLinkedSecret(name, namespace, cmName string, data map[stri
 	secretData := make(map[string]*[]byte)
 
 	for key, val := range data {
-		secretData[key] = &val
+		valCopy := val
+		secretData[key] = &valCopy
 
 		if len(val) == 0 {
 			secretData[key] = nil


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Duplicate pointers result in env vars not being updated correctly. 

## What is the new behavior?

Dedup pointers.