### PR TITLE
Handle non-string env values set outside of Porter

### DIFF
--- a/dashboard/src/components/values-form/KeyValueArray.tsx
+++ b/dashboard/src/components/values-form/KeyValueArray.tsx
@@ -95,6 +95,15 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
     return (
       <>
         {this.state.values.map((entry: any, i: number) => {
+
+          // Preprocess non-string env values set via raw Helm values
+          let { value } = entry;
+          if (typeof value === "object") {
+            value = JSON.stringify(value);
+          } else if (typeof value === "number") {
+            value = value.toString();
+          }
+
           return (
             <InputWrapper key={i}>
               <Input
@@ -108,13 +117,13 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
                   let obj = this.valuesToObject();
                   this.props.setValues(obj);
                 }}
-                disabled={this.props.disabled || entry?.value?.includes("PORTERSECRET") }
+                disabled={this.props.disabled || value.includes("PORTERSECRET") }
               />
               <Spacer />
               <Input
                 placeholder="ex: value"
                 width="270px"
-                value={entry.value}
+                value={value}
                 onChange={(e: any) => {
                   this.state.values[i].value = e.target.value;
                   this.setState({ values: this.state.values });
@@ -122,11 +131,11 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
                   let obj = this.valuesToObject();
                   this.props.setValues(obj);
                 }}
-                disabled={this.props.disabled || entry?.value?.includes("PORTERSECRET") }
-                type={entry?.value?.includes("PORTERSECRET") ? "password" : "text"}
+                disabled={this.props.disabled || value.includes("PORTERSECRET") }
+                type={value.includes("PORTERSECRET") ? "password" : "text"}
               />
               {this.renderDeleteButton(i)}
-              {this.renderHiddenOption(entry?.value?.includes("PORTERSECRET"), i)}
+              {this.renderHiddenOption(value.includes("PORTERSECRET"), i)}
             </InputWrapper>
           );
         })}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Environment tab in expanded chart crashes if a json object or numerical value is set as the value of an env var.

## What is the new behavior?

Environment tab does not crash

## Technical Spec/Implementation Notes
