### PR TITLE
No currentCluster in localStorage hotfix

### DIFF
--- a/dashboard/src/main/home/sidebar/ClusterSection.tsx
+++ b/dashboard/src/main/home/sidebar/ClusterSection.tsx
@@ -38,15 +38,12 @@ class ClusterSection extends Component<PropsType, StateType> {
   };
 
   updateClusters = () => {
-    console.log("updating clusters...")
     let { user, currentProject, setCurrentCluster } = this.context;
 
     // TODO: query with selected filter once implemented
     api
       .getClusters("<token>", {}, { id: currentProject.id })
       .then((res) => {
-        console.log("clusters are..");
-        console.log(res.data);
         window.analytics.identify(user.userId, {
           currentProject,
           clusters: res.data,
@@ -62,7 +59,7 @@ class ClusterSection extends Component<PropsType, StateType> {
             let saved = JSON.parse(
               localStorage.getItem(currentProject.id + "-cluster")
             );
-            if (saved !== "null") {
+            if (saved && saved !== "null") {
               // Ensures currentCluster isn't prematurely set (causes issues downstream)
               let loaded = false;
               for (let i = 0; i < clusters.length; i++) {
@@ -73,17 +70,14 @@ class ClusterSection extends Component<PropsType, StateType> {
                 ) {
                   loaded = true;
                   setCurrentCluster(clusters[i]);
-                  console.log("a: set current to", clusters[i]);
                   break;
                 }
               }
               if (!loaded) {
                 setCurrentCluster(clusters[0]);
-                console.log("b: set current to", clusters[0]);
               }
             } else {
               setCurrentCluster(clusters[0]);
-              console.log("c: set current to", clusters[0]);
             }
           } else if (
             this.props.currentView !== "provisioner" &&
@@ -91,7 +85,6 @@ class ClusterSection extends Component<PropsType, StateType> {
           ) {
             this.setState({ clusters: [] });
             setCurrentCluster(null);
-            console.log("d set cluster");
             // this.props.history.push("dashboard?tab=overview");
           }
         }

--- a/dashboard/src/main/home/sidebar/ClusterSection.tsx
+++ b/dashboard/src/main/home/sidebar/ClusterSection.tsx
@@ -38,12 +38,15 @@ class ClusterSection extends Component<PropsType, StateType> {
   };
 
   updateClusters = () => {
+    console.log("updating clusters...")
     let { user, currentProject, setCurrentCluster } = this.context;
 
     // TODO: query with selected filter once implemented
     api
       .getClusters("<token>", {}, { id: currentProject.id })
       .then((res) => {
+        console.log("clusters are..");
+        console.log(res.data);
         window.analytics.identify(user.userId, {
           currentProject,
           clusters: res.data,
@@ -60,19 +63,27 @@ class ClusterSection extends Component<PropsType, StateType> {
               localStorage.getItem(currentProject.id + "-cluster")
             );
             if (saved !== "null") {
-              setCurrentCluster(clusters[0]);
+              // Ensures currentCluster isn't prematurely set (causes issues downstream)
+              let loaded = false;
               for (let i = 0; i < clusters.length; i++) {
                 if (
                   clusters[i].id === saved.id &&
                   clusters[i].project_id === saved.project_id &&
                   clusters[i].name === saved.name
                 ) {
+                  loaded = true;
                   setCurrentCluster(clusters[i]);
+                  console.log("a: set current to", clusters[i]);
                   break;
                 }
               }
+              if (!loaded) {
+                setCurrentCluster(clusters[0]);
+                console.log("b: set current to", clusters[0]);
+              }
             } else {
               setCurrentCluster(clusters[0]);
+              console.log("c: set current to", clusters[0]);
             }
           } else if (
             this.props.currentView !== "provisioner" &&
@@ -80,6 +91,7 @@ class ClusterSection extends Component<PropsType, StateType> {
           ) {
             this.setState({ clusters: [] });
             setCurrentCluster(null);
+            console.log("d set cluster");
             // this.props.history.push("dashboard?tab=overview");
           }
         }
@@ -173,10 +185,10 @@ class ClusterSection extends Component<PropsType, StateType> {
 
   render() {
     return (
-      <div>
+      <>
         {this.renderDrawer()}
         {this.renderContents()}
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No cluster set by default if localStorage for currentCluster is null (all initialized clusters/users)

## What is the new behavior?

Set first cluster to default if localStorage returns null.

## Technical Spec/Implementation Notes
