### PR TITLE
[0.3.0] Show selected namespace pods in status and metric tabs

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
@@ -369,6 +369,7 @@ export default class MetricsSection extends Component<PropsType, StateType> {
         "<token>",
         {
           cluster_id: currentCluster.id,
+          namespace: selectedController?.metadata?.namespace,
           selectors,
         },
         {

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
@@ -59,6 +59,7 @@ export default class ControllerTab extends Component<PropsType, StateType> {
         "<token>",
         {
           cluster_id: currentCluster.id,
+          namespace: controller?.metadata?.namespace,
           selectors,
         },
         {

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -463,6 +463,7 @@ const getJobPods = baseApi<
 const getMatchingPods = baseApi<
   {
     cluster_id: number;
+    namespace: string;
     selectors: string[];
   },
   { id: number }

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -330,9 +330,9 @@ func (a *Agent) GetCronJob(c grapher.Object) (*batchv1beta1.CronJob, error) {
 }
 
 // GetPodsByLabel retrieves pods with matching labels
-func (a *Agent) GetPodsByLabel(selector string) (*v1.PodList, error) {
+func (a *Agent) GetPodsByLabel(selector string, namespace string) (*v1.PodList, error) {
 	// Search in all namespaces for matching pods
-	return a.Clientset.CoreV1().Pods("").List(
+	return a.Clientset.CoreV1().Pods(namespace).List(
 		context.TODO(),
 		metav1.ListOptions{
 			LabelSelector: selector,

--- a/server/api/k8s_handler.go
+++ b/server/api/k8s_handler.go
@@ -613,9 +613,10 @@ func (app *App) HandleListPods(w http.ResponseWriter, r *http.Request) {
 		agent, err = kubernetes.GetAgentOutOfClusterConfig(form.OutOfClusterConfig)
 	}
 
+	namespace := vals.Get("namespace")
 	pods := []v1.Pod{}
 	for _, selector := range vals["selectors"] {
-		podsList, err := agent.GetPodsByLabel(selector)
+		podsList, err := agent.GetPodsByLabel(selector, namespace)
 
 		if err != nil {
 			app.handleErrorFormValidation(err, ErrK8sValidate, w)

--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -549,7 +549,8 @@ func (app *App) HandleGetReleaseAllPods(w http.ResponseWriter, r *http.Request) 
 			selectors = append(selectors, key+"="+val)
 		}
 
-		podList, err := k8sAgent.GetPodsByLabel(strings.Join(selectors, ","))
+		namespace := vals.Get("namespace")
+		podList, err := k8sAgent.GetPodsByLabel(strings.Join(selectors, ","), namespace)
 
 		if err != nil {
 			app.handleErrorDataRead(err, w)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [x] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.-->
When viewing active pods for a deployment and helm charts with the same name had been deployed in different namespaces, they would all show up in the "Status / Metric" tabs even if they did not reside in the namespace of the chart currently being viewed. 

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds a namespace query parameter send along from the front end to only show charts deployed in the actively viewed namespace.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

CC @abelanger5 