### PR TITLE
[0.4.0] Increase max results in ECR to 999

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -482,9 +482,12 @@ func (r *Registry) listECRImages(repoName string, repo repository.Repository) ([
 		return nil, err
 	}
 
+	var maxResults int64 = 999
+
 	describeResp, err := svc.DescribeImages(&ecr.DescribeImagesInput{
 		RepositoryName: &repoName,
 		ImageIds:       resp.ImageIds,
+		MaxResults:     &maxResults,
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): change behavior of ECR list images to support up to 999 tags. 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Only 100 unique images (image + tag) are shown on the dashboard. 

## What is the new behavior?

Increase limit to 999 before implementing pagination. 

## Technical Spec/Implementation Notes
