### PR TITLE
[0.5.0] Support `core` queries for `form.yaml`

### DIFF
--- a/internal/templater/dynamic/reader.go
+++ b/internal/templater/dynamic/reader.go
@@ -58,6 +58,11 @@ func NewDynamicTemplateReader(client dynamic.Interface, obj *Object) templater.T
 		Resource: r.Object.Resource,
 	}
 
+	// just case on the "core" group and unset it
+	if r.Object.Group == "core" {
+		objRes.Group = ""
+	}
+
 	r.gvr = objRes
 
 	r.resource = r.Client.Resource(objRes).Namespace(r.Object.Namespace)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Specify a Group Version Resource with `Group` set to `core` fails, since `core` should not be part of the k8s API string. 

## What is the new behavior?

Case on `core` and remove it from the GVR. 

## Technical Spec/Implementation Notes
