### PR TITLE
[0.4.1] Remove max results from ECR loading and add next token

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -482,21 +482,36 @@ func (r *Registry) listECRImages(repoName string, repo repository.Repository) ([
 		return nil, err
 	}
 
-	var maxResults int64 = 999
-
 	describeResp, err := svc.DescribeImages(&ecr.DescribeImagesInput{
 		RepositoryName: &repoName,
 		ImageIds:       resp.ImageIds,
-		MaxResults:     &maxResults,
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
+	imageDetails := describeResp.ImageDetails
+
+	nextToken := describeResp.NextToken
+
+	for nextToken != nil {
+		describeResp, err := svc.DescribeImages(&ecr.DescribeImagesInput{
+			RepositoryName: &repoName,
+			ImageIds:       resp.ImageIds,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		nextToken = describeResp.NextToken
+		imageDetails = append(imageDetails, describeResp.ImageDetails...)
+	}
+
 	res := make([]*Image, 0)
 
-	for _, img := range describeResp.ImageDetails {
+	for _, img := range imageDetails {
 		for _, tag := range img.ImageTags {
 			res = append(res, &Image{
 				Digest:         *img.ImageDigest,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

ECR tags do not load on `0.4.0` due to AWS API errors. 

## What is the new behavior?

Instead of a max results field, loop through pagination tokens. 

## Technical Spec/Implementation Notes
