### PR TITLE
[0.5.0] [Frontend, Forms] Improvements for show_if and other form variables

### DIFF
--- a/dashboard/src/components/values-form/FormDebugger.tsx
+++ b/dashboard/src/components/values-form/FormDebugger.tsx
@@ -280,7 +280,10 @@ tabs:
     - type: subtitle
       label: "Note: Hidden required fields aren't supported yet (global only)"
   - name: controlled-by-external
-    show_if: checkbox_a
+    show_if:
+      or:
+        - checkbox_a
+        - not_a_variable
     contents:
     - type: heading
       label: Conditional Display (A)

--- a/dashboard/src/components/values-form/FormWrapper.tsx
+++ b/dashboard/src/components/values-form/FormWrapper.tsx
@@ -65,7 +65,17 @@ export default class FormWrapper extends Component<PropsType, StateType> {
       let tabOptions = [] as { value: string; label: string }[];
       let tabs = this.props.formData?.tabs;
       let requiredFields = [] as string[];
-      let metaState: any = {};
+      let metaState: any = {
+        "currentCluster.service.is_gcp": {
+          value: this.context.currentCluster.service == "gke",
+        },
+        "currentCluster.service.is_aws": {
+          value: this.context.currentCluster.service == "eks",
+        },
+        "currentCluster.service.is_do": {
+          value: this.context.currentCluster.service == "doks",
+        },
+      };
       if (tabs) {
         tabs.forEach((tab: any, i: number) => {
           if (tab?.name && tab.label) {

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -311,7 +311,7 @@ export default class ValuesForm extends Component<PropsType, StateType> {
     });
   };
 
-  evalShowIf: (vals: ShowIf) => boolean = (vals: ShowIf) => {
+  evalShowIf = (vals: ShowIf): boolean => {
     if (!vals) {
       return false;
     }

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -1,7 +1,13 @@
 import React, { Component } from "react";
 import styled from "styled-components";
 
-import { Section, FormElement } from "shared/types";
+import {
+  Section,
+  FormElement,
+  ShowIf,
+  ShowIfOr,
+  ShowIfAnd,
+} from "shared/types";
 import { Context } from "shared/Context";
 
 import CheckboxRow from "./CheckboxRow";
@@ -304,17 +310,41 @@ export default class ValuesForm extends Component<PropsType, StateType> {
     });
   };
 
+  evalShowIf = (vals: ShowIf) => {
+    if (!vals) {
+      return false;
+    }
+    if (typeof vals == "string") {
+      return !!this.props.metaState[vals]?.value;
+    }
+    if ((vals as ShowIfOr).or) {
+      vals = vals as ShowIfOr;
+      for (let i = 0; i < vals.or.length; i++) {
+        if (this.evalShowIf(vals.or[i])) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if ((vals as ShowIfAnd).and) {
+      vals = vals as ShowIfAnd;
+      for (let i = 0; i < vals.and.length; i++) {
+        if (!this.evalShowIf(vals.and[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    return false;
+  };
+
   renderFormContents = () => {
     if (this.props.metaState) {
       return this.props.sections?.map((section: Section, i: number) => {
         // Hide collapsible section if deciding field is false
-        if (section.show_if) {
-          if (
-            !this.props.metaState[section.show_if] ||
-            this.props.metaState[section.show_if].value === false
-          ) {
-            return null;
-          }
+        if (section.show_if && !this.evalShowIf(section.show_if)) {
+          return null;
         }
 
         return <div key={i}>{this.renderSection(section)}</div>;

--- a/dashboard/src/components/values-form/ValuesForm.tsx
+++ b/dashboard/src/components/values-form/ValuesForm.tsx
@@ -7,6 +7,7 @@ import {
   ShowIf,
   ShowIfOr,
   ShowIfAnd,
+  ShowIfNot,
 } from "shared/types";
 import { Context } from "shared/Context";
 
@@ -310,7 +311,7 @@ export default class ValuesForm extends Component<PropsType, StateType> {
     });
   };
 
-  evalShowIf = (vals: ShowIf) => {
+  evalShowIf: (vals: ShowIf) => boolean = (vals: ShowIf) => {
     if (!vals) {
       return false;
     }
@@ -334,6 +335,10 @@ export default class ValuesForm extends Component<PropsType, StateType> {
         }
       }
       return true;
+    }
+    if ((vals as ShowIfNot).not) {
+      vals = vals as ShowIfNot;
+      return !this.evalShowIf(vals.not);
     }
 
     return false;

--- a/dashboard/src/shared/types.tsx
+++ b/dashboard/src/shared/types.tsx
@@ -112,7 +112,11 @@ export interface ShowIfOr {
   or: ShowIf[];
 }
 
-export type ShowIf = string | ShowIfAnd | ShowIfOr;
+export interface ShowIfNot {
+  not: ShowIf;
+}
+
+export type ShowIf = string | ShowIfAnd | ShowIfOr | ShowIfNot;
 
 export interface Section {
   name?: string;

--- a/dashboard/src/shared/types.tsx
+++ b/dashboard/src/shared/types.tsx
@@ -104,9 +104,19 @@ export interface FormYAML {
   }[];
 }
 
+export interface ShowIfAnd {
+  and: ShowIf[];
+}
+
+export interface ShowIfOr {
+  or: ShowIf[];
+}
+
+export type ShowIf = string | ShowIfAnd | ShowIfOr;
+
 export interface Section {
   name?: string;
-  show_if?: string;
+  show_if?: ShowIf;
   contents: FormElement[];
 }
 

--- a/internal/models/templates.go
+++ b/internal/models/templates.go
@@ -36,7 +36,7 @@ type FormTab struct {
 type FormSection struct {
 	Context  *FormContext   `yaml:"context" json:"context"`
 	Name     string         `yaml:"name" json:"name"`
-	ShowIf   string         `yaml:"show_if" json:"show_if"`
+	ShowIf   interface{}    `yaml:"show_if" json:"show_if"`
 	Contents []*FormContent `yaml:"contents" json:"contents,omitempty"`
 }
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The `show_if` logic provided by forms only supports one variable, which makes it impossible to do more complicated statements (for instance, needing two variables to be true in order to show something).
Some forms have cloud-specific options with no way to remove them.

## What is the new behavior?

Users can now specify logic with more complex conditionals through yaml:
```yaml
show_if:
  and:
    - a
    - not: b
    - or:
      - c
      - d
```
Every form now has variables like `currentCluster.service.is_aws`, etc. that allow for checking for specific clusters.

## Technical Spec/Implementation Notes
Nothing special, the error handling for form boolean expressions isn't very strong right now, but it shouldn't break anything present right now. Also, if a variable isn't necessarily a boolean, it is converted to a boolean using normal javascript conventions.