### PR TITLE
[0.4.2] Fix CLI login with token issue causing failed deployments on `v0.4.0`

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -80,7 +80,14 @@ func login() error {
 	user, _ := client.AuthCheck(context.Background())
 
 	if user != nil {
-		color.Yellow("You are already logged in. If you'd like to log out, run \"porter auth logout\".")
+		if config.Token != "" {
+			// set the token if the user calls login with the --token flag
+			config.SetToken(config.Token)
+			color.New(color.FgGreen).Println("Successfully logged in!")
+		} else {
+			color.Yellow("You are already logged in. If you'd like to log out, run \"porter auth logout\".")
+		}
+
 		return nil
 	}
 

--- a/internal/kubernetes/nodes/nodes.go
+++ b/internal/kubernetes/nodes/nodes.go
@@ -2,7 +2,6 @@ package nodes
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -67,8 +66,6 @@ func GetNodesUsage(clientset kubernetes.Interface) []*NodeWithUsageData {
 }
 
 func getPodsForNode(clientset kubernetes.Interface, nodeName string) *v1.PodList {
-	fmt.Printf("%s", nodeName)
-
 	podList, _ := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + nodeName + ",status.phase=Running",
 	})

--- a/server/api/k8s_handler.go
+++ b/server/api/k8s_handler.go
@@ -80,7 +80,7 @@ func (app *App) HandleListNamespaces(w http.ResponseWriter, r *http.Request) {
 // HandleCreateNamespace creates a new namespace given the name.
 func (app *App) HandleCreateNamespace(w http.ResponseWriter, r *http.Request) {
 	vals, err := url.ParseQuery(r.URL.RawQuery)
-	fmt.Println(vals)
+
 	if err != nil {
 		app.handleErrorFormDecoding(err, ErrReleaseDecode, w)
 		return
@@ -1064,7 +1064,7 @@ func (app *App) HandleStreamControllerStatus(w http.ResponseWriter, r *http.Requ
 	selectors := ""
 	if vals["selectors"] != nil {
 		selectors = vals["selectors"][0]
-	} 
+	}
 	err = agent.StreamControllerStatus(conn, kind, selectors)
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If a user logs in with the `--token` flag, the login command thinks that the user is already logged in because the `--token` flag is global. 

## What is the new behavior?

This command will set the token in the config so that subsequent commands are authenticated. 

## Technical Spec/Implementation Notes
