### PR TITLE
[0.4.2] Use the `config.Token` to set project after `porter auth login --token ...`

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -85,7 +85,7 @@ func login() error {
 			config.SetToken(config.Token)
 			color.New(color.FgGreen).Println("Successfully logged in!")
 
-			projID, err := api.GetProjectIDFromToken(token)
+			projID, err := api.GetProjectIDFromToken(config.Token)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Trying to set the project automatically still throws an error. 

## What is the new behavior?

Pass the correct JWT token in for parsing. 

## Technical Spec/Implementation Notes
