### PR TITLE
[0.5.0] [API] Procfile endpoint fixes

### DIFF
--- a/dashboard/src/components/repo-selector/ContentsList.tsx
+++ b/dashboard/src/components/repo-selector/ContentsList.tsx
@@ -273,6 +273,10 @@ export default class ContentsList extends Component<PropsType, StateType> {
         );
       }
 
+      if (processes.length == 0) {
+        this.props.setProcfilePath("");
+      }
+
       return (
         <Overlay>
           <BgOverlay

--- a/dashboard/src/components/values-form/FormWrapper.tsx
+++ b/dashboard/src/components/values-form/FormWrapper.tsx
@@ -203,13 +203,15 @@ export default class FormWrapper extends Component<PropsType, StateType> {
       if (this.props.tabOptions?.length > 0) {
         let prependTabs = [] as { value: string; label: string }[];
         let appendTabs = [] as { value: string; label: string }[];
-        this.props.tabOptions.forEach((tab: { value: string; label: string }) => {
-          if (tab.value === "status" || tab.value === "metrics") {
-            prependTabs.push(tab);
-          } else {
-            appendTabs.push(tab);
+        this.props.tabOptions.forEach(
+          (tab: { value: string; label: string }) => {
+            if (tab.value === "status" || tab.value === "metrics") {
+              prependTabs.push(tab);
+            } else {
+              appendTabs.push(tab);
+            }
           }
-        });
+        );
         tabOptions = prependTabs.concat(tabOptions.concat(appendTabs));
       }
       this.setState({ tabOptions }, callback);
@@ -267,7 +269,10 @@ export default class FormWrapper extends Component<PropsType, StateType> {
       !_.isEqual(prevProps.tabOptions, this.props.tabOptions) ||
       !_.isEqual(prevProps.formData, this.props.formData)
     ) {
-      if (prevProps.tabOptions?.length === 0 && !_.isEqual(prevProps.tabOptions, this.props.tabOptions)) {
+      if (
+        prevProps.tabOptions?.length === 0 &&
+        !_.isEqual(prevProps.tabOptions, this.props.tabOptions)
+      ) {
         this.setState({ currentTab: "status" });
       }
       let formHasChanged = !_.isEqual(prevProps.formData, this.props.formData);

--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -37,7 +37,7 @@ type StateType = {
   imageTag: string;
 
   actionConfig: ActionConfigType;
-  procfileProcess?: string;
+  procfileProcess: string;
   branch: string;
   repoType: string;
   dockerfilePath: string | null;
@@ -69,7 +69,7 @@ class LaunchFlow extends Component<PropsType, StateType> {
     imageTag: "",
 
     actionConfig: { ...defaultActionConfig },
-    procfileProcess: null as string | null,
+    procfileProcess: "",
     branch: "",
     repoType: "",
     dockerfilePath: null as string | null,

--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -37,7 +37,7 @@ type StateType = {
   imageTag: string;
 
   actionConfig: ActionConfigType;
-  procfileProcess: string;
+  procfileProcess?: string;
   branch: string;
   repoType: string;
   dockerfilePath: string | null;
@@ -69,7 +69,7 @@ class LaunchFlow extends Component<PropsType, StateType> {
     imageTag: "",
 
     actionConfig: { ...defaultActionConfig },
-    procfileProcess: "",
+    procfileProcess: null as string | null,
     branch: "",
     repoType: "",
     dockerfilePath: null as string | null,

--- a/server/api/git_repo_handler.go
+++ b/server/api/git_repo_handler.go
@@ -354,7 +354,7 @@ func (app *App) HandleGetProcfileContents(w http.ResponseWriter, r *http.Request
 	)
 
 	if err != nil {
-		app.handleErrorInternal(err, w)
+		http.NotFound(w, r)
 		return
 	}
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

`/procfile` endpoint has an internal server error when no procfile is present in a directory. If the Procfile is empty then the user is blocked from continuing their application setup.

## What is the new behavior?

`/procfile` endpoint returns a 404 instead when there's no Procfile, and user can now continue with empty Procfile

## Technical Spec/Implementation Notes
