### PR TITLE
[0.5.0] [bugfix] Update chart uses old chart config instead of new one

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -112,10 +112,10 @@ export default class ExpandedChart extends Component<PropsType, StateType> {
           !this.state.newestImage
         ) {
           imageIsPlaceholder = true;
-        } 
+        }
         this.updateComponents(
-          { 
-            currentChart: res.data, 
+          {
+            currentChart: res.data,
             loading: false,
             imageIsPlaceholder,
             newestImage,
@@ -260,6 +260,11 @@ export default class ExpandedChart extends Component<PropsType, StateType> {
       values = this.props.currentChart.config;
     }
 
+    // Override config from currentChart prop if we have it on the current state
+    if (this.state.currentChart.config) {
+      values = this.state.currentChart.config;
+    }
+
     for (let key in rawValues) {
       _.set(values, key, rawValues[key]);
     }
@@ -397,7 +402,8 @@ export default class ExpandedChart extends Component<PropsType, StateType> {
             <Placeholder>
               <TextWrap>
                 <Header>
-                  <Spinner src={loading} /> This application is currently being deployed
+                  <Spinner src={loading} /> This application is currently being
+                  deployed
                 </Header>
                 Navigate to the "Actions" tab of your GitHub repo to view live
                 build logs.


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the chart updates it still uses the previous config to update the values.

Issue Number: Closes #829 

## What is the new behavior?

Chart update should use the last config that comes from the live update of the chart.

## Technical Spec/Implementation Notes

ExpandedChart was using the currentChart that comes from the ExpandedChartWrapper instead of using the local state that has the latest data
