### PR TITLE
[0.5.0] Update `postrenderer` to case on `index.docker.io`

### DIFF
--- a/internal/helm/postrenderer.go
+++ b/internal/helm/postrenderer.go
@@ -490,25 +490,25 @@ func getNestedResource(res resource, keys ...string) resource {
 func getRegNameFromImageRef(image string) (string, error) {
 	named, err := reference.ParseNormalizedNamed(image)
 
-			if err != nil {
-				return "", err
-			}
+	if err != nil {
+		return "", err
+	}
 
-			domain := reference.Domain(named)
-			path := reference.Path(named)
+	domain := reference.Domain(named)
+	path := reference.Path(named)
 
-			var regName string
+	var regName string
 
-			// if registry is dockerhub, leave the image name as-is
-			if strings.Contains(domain, "docker.io") {
-				regName = "index.docker.io/" + path
-			} else {
-				regName = domain
+	// if registry is dockerhub, leave the image name as-is
+	if strings.Contains(domain, "docker.io") {
+		regName = "index.docker.io/" + path
+	} else {
+		regName = domain
 
-				if pathArr := strings.Split(path, "/"); len(pathArr) > 1 {
-					regName += "/" + strings.Join(pathArr[:len(pathArr)-1], "/")
-				}
-			}
+		if pathArr := strings.Split(path, "/"); len(pathArr) > 1 {
+			regName += "/" + strings.Join(pathArr[:len(pathArr)-1], "/")
+		}
+	}
 
-			return regName, nil
+	return regName, nil
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Private Docker Hub images don't pull properly onto the cluster because the image ref domain is parsed as `docker.io` rather than `index.docker.io`. 

## What is the new behavior?

Case on `docker.io` image refs and construct full registry path properly. 

## Technical Spec/Implementation Notes
