### PR TITLE
Implemented scroll to bottom button

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
@@ -225,6 +225,32 @@ export default class Logs extends Component<PropsType, StateType> {
               System
             </Tab>
           </LogTabs>
+          <Options>
+            <Scroll
+              onClick={() => {
+                this.setState({ scroll: !this.state.scroll }, () => {
+                  if (this.state.scroll) {
+                    this.scrollToBottom(true);
+                  }
+                });
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={this.state.scroll}
+                onChange={() => {}}
+              />
+              Scroll to Bottom
+            </Scroll>
+            <Refresh
+              onClick={() => {
+                this.refreshLogs();
+              }}
+            >
+              <i className="material-icons">autorenew</i>
+              Refresh
+            </Refresh>
+          </Options>
         </LogStreamAlt>
       );
     }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

There's no scroll to bottom button when checking logs from a certain job.

Issue Number: Closes #839 

## What is the new behavior?
Have a scroll to bottom button when checking logs from a certain job.

## Technical Spec/Implementation Notes
Copied the same implementation of scroll to bottom that we have from non rawText to rawText render on `dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx` component