### PR TITLE
[0.5.0] Change `SameSite` cookie attribute to `Lax` mode, to fix Github/OAuth login

### DIFF
--- a/internal/auth/sessionstore/sessionstore.go
+++ b/internal/auth/sessionstore/sessionstore.go
@@ -124,7 +124,7 @@ func NewStore(repo *repository.Repository, conf config.ServerConf) (*PGStore, er
 			MaxAge:   86400 * 30,
 			Secure:   true,
 			HttpOnly: true,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 		},
 		Repo: repo,
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Login w/ Github stops working once new cookie has been issued. 

## What is the new behavior?

Fix login by changing the `SameSite` attribute of the `porter` cookie to `Lax` mode. 

## Technical Spec/Implementation Notes
