### PR TITLE
Environment group merging and previews

### DIFF
--- a/dashboard/src/components/values-form/KeyValueArray.tsx
+++ b/dashboard/src/components/values-form/KeyValueArray.tsx
@@ -154,7 +154,7 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
             namespace={this.props.externalValues?.namespace}
             clusterId={this.props.externalValues?.clusterId}
             closeModal={() => this.setState({ showEnvModal: false })}
-            setValues={(values: any) => {
+            setValues={(values) => {
               this.props.setValues(values);
               this.setState({ values: this.objectToValues(values) });
             }}

--- a/dashboard/src/components/values-form/KeyValueArray.tsx
+++ b/dashboard/src/components/values-form/KeyValueArray.tsx
@@ -146,8 +146,8 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
       return (
         <Modal
           onRequestClose={() => this.setState({ showEnvModal: false })}
-          width="665px"
-          height="342px"
+          width="765px"
+          height="542px"
         >
           <LoadEnvGroupModal
             existingValues={this.props.values}

--- a/dashboard/src/components/values-form/KeyValueArray.tsx
+++ b/dashboard/src/components/values-form/KeyValueArray.tsx
@@ -155,8 +155,9 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
             clusterId={this.props.externalValues?.clusterId}
             closeModal={() => this.setState({ showEnvModal: false })}
             setValues={(values) => {
-              this.props.setValues(values);
-              this.setState({ values: this.objectToValues(values) });
+              const newValues = { ...this.props.values, ...values };
+              this.props.setValues(newValues);
+              this.setState({ values: this.objectToValues(newValues) });
             }}
           />
         </Modal>

--- a/dashboard/src/components/values-form/KeyValueArray.tsx
+++ b/dashboard/src/components/values-form/KeyValueArray.tsx
@@ -8,6 +8,11 @@ import sliders from "assets/sliders.svg";
 import upload from "assets/upload.svg";
 import { keysIn } from "lodash";
 
+export type KeyValue = {
+  key: string;
+  value: string;
+};
+
 type PropsType = {
   label?: string;
   values: any;
@@ -51,15 +56,8 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
     return obj;
   };
 
-  objectToValues = (obj: any) => {
-    let values = [] as any[];
-    Object.keys(obj).forEach((key: string, i: number) => {
-      let entry = {} as any;
-      entry.key = key;
-      entry.value = obj[key];
-      values.push(entry);
-    });
-    return values;
+  objectToValues = (obj: Record<string, string>): KeyValue[] => {
+    return Object.entries(obj).map(([key, value]) => ({ key, value }));
   };
 
   renderDeleteButton = (i: number) => {
@@ -152,6 +150,7 @@ export default class KeyValueArray extends Component<PropsType, StateType> {
           height="342px"
         >
           <LoadEnvGroupModal
+            existingValues={this.props.values}
             namespace={this.props.externalValues?.namespace}
             clusterId={this.props.externalValues?.clusterId}
             closeModal={() => this.setState({ showEnvModal: false })}

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
@@ -5,8 +5,13 @@ import key from "assets/key.svg";
 
 import { Context } from "shared/Context";
 
+export type EnvGroupData = {
+  data: Record<string, string>;
+  metadata: any;
+};
+
 type PropsType = {
-  envGroup: any;
+  envGroup: EnvGroupData;
   setExpanded: () => void;
 };
 

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
@@ -76,6 +76,13 @@ export default class EnvGroup extends Component<PropsType, StateType> {
   }
 }
 
+export function formattedEnvironmentValue(value: string) {
+  if (value.startsWith("PORTERSECRET_")) {
+    return "••••";
+  }
+  return value;
+}
+
 EnvGroup.contextType = Context;
 
 const BottomWrapper = styled.div`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -213,6 +213,7 @@ const GroupEnvPreview = styled.pre`
   margin: 0 0 10px 0;
   white-space: pre-line;
   word-break: break-word;
+  user-select: text;
 `;
 
 const ClashIcon = styled.i`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -9,7 +9,10 @@ import { Context } from "shared/Context";
 import Loading from "components/Loading";
 import SaveButton from "components/SaveButton";
 import { KeyValue } from "components/values-form/KeyValueArray";
-import { EnvGroupData } from "../cluster-dashboard/env-groups/EnvGroup";
+import {
+  EnvGroupData,
+  formattedEnvironmentValue,
+} from "../cluster-dashboard/env-groups/EnvGroup";
 
 type PropsType = {
   namespace: string;
@@ -130,7 +133,9 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
                 {this.props.existingValues[key] || emptyValue}
               </ClashingKeyValue>
               <ClashingKeyLabel>Replaced by</ClashingKeyLabel>
-              <ClashingKeyValue>{value || emptyValue}</ClashingKeyValue>
+              <ClashingKeyValue>
+                {formattedEnvironmentValue(value) || emptyValue}
+              </ClashingKeyValue>
             </ClashingKeyDefinitions>
             {i !== clashingKeys.length - 1 && <ClashingKeyRowDivider />}
           </li>
@@ -164,7 +169,10 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
             <SidebarSection>
               <GroupEnvPreview>
                 {Object.entries(this.state.selectedEnvGroup.data)
-                  .map(([key, value]) => `${key}=${value}`)
+                  .map(
+                    ([key, value]) =>
+                      `${key}=${formattedEnvironmentValue(value)}`
+                  )
                   .join("\n")}
               </GroupEnvPreview>
               {clashingKeys.length > 0 && (

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import close from "assets/close.png";
 import sliders from "assets/sliders.svg";
 
@@ -156,11 +156,11 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
         </Subtitle>
 
         <GroupModalSections>
-          <SidebarSection>
+          <SidebarSection $expanded={!this.state.selectedEnvGroup}>
             <EnvGroupList>{this.renderEnvGroupList()}</EnvGroupList>
           </SidebarSection>
 
-          {this.state.selectedEnvGroup ? (
+          {this.state.selectedEnvGroup && (
             <SidebarSection>
               <GroupEnvPreview>
                 {Object.entries(this.state.selectedEnvGroup.data)
@@ -174,8 +174,6 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
                 </>
               )}
             </SidebarSection>
-          ) : (
-            <i>Select an environment group.</i>
           )}
         </GroupModalSections>
 
@@ -192,9 +190,14 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
 
 LoadEnvGroupModal.contextType = Context;
 
-const SidebarSection = styled.section`
+const SidebarSection = styled.section<{ $expanded?: boolean }>`
   height: 100%;
   overflow-y: auto;
+  ${(props) =>
+    props.$expanded &&
+    css`
+      grid-column: span 2;
+    `}
 `;
 
 const GroupEnvPreview = styled.pre`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -128,11 +128,11 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
               <b>{key}</b> is defined in both environments
             </ClashingKeyTitle>
             <ClashingKeyDefinitions>
-              <ClashingKeyLabel>Defined as</ClashingKeyLabel>
+              <ClashingKeyLabel>Old</ClashingKeyLabel>
               <ClashingKeyValue>
                 {this.props.existingValues[key] || emptyValue}
               </ClashingKeyValue>
-              <ClashingKeyLabel>Replaced by</ClashingKeyLabel>
+              <ClashingKeyLabel>New</ClashingKeyLabel>
               <ClashingKeyValue>
                 {formattedEnvironmentValue(value) || emptyValue}
               </ClashingKeyValue>

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -13,6 +13,7 @@ type PropsType = {
   namespace: string;
   clusterId: number;
   closeModal: () => void;
+  existingValues: KeyValue[];
   setValues: (values: any) => void;
 };
 

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -114,8 +114,34 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
     }
   }
 
-  render() {
+  renderEnvGroupPreview(clashingKeys: KeyValue[]) {
     const emptyValue = <i>Empty value</i>;
+    return (
+      <PossibleClashingKeys>
+        {clashingKeys.map(({ key, value }, i) => (
+          <ClashingKeyRow key={key}>
+            <ClashingKeyTitle>
+              <i className="material-icons" style={{ fontSize: "18px" }}>
+                sync_problem
+              </i>
+              <b>{key}</b> is defined in both environments
+            </ClashingKeyTitle>
+            <ClashingKeyDefinitions>
+              <ClashingKeyLabel>Defined as</ClashingKeyLabel>
+              <ClashingKeyLabel>
+                {this.state.selectedEnvGroup.data[key] || emptyValue}
+              </ClashingKeyLabel>
+              <ClashingKeyLabel>Replaced by</ClashingKeyLabel>
+              <ClashingKeyLabel>{value || emptyValue}</ClashingKeyLabel>
+            </ClashingKeyDefinitions>
+            {i !== clashingKeys.length - 1 && <ClashingKeyRowDivider />}
+          </ClashingKeyRow>
+        ))}
+      </PossibleClashingKeys>
+    );
+  }
+
+  render() {
     const clashingKeys = this.state.selectedEnvGroup
       ? this.potentiallyOverriddenKeys(this.state.selectedEnvGroup.data)
       : [];
@@ -150,35 +176,7 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
               {clashingKeys.length > 0 && (
                 <>
                   <ClashingKeyRowDivider />
-                  <PossibleClashingKeys>
-                    {clashingKeys.map(({ key, value }, i) => (
-                      <ClashingKeyRow key={key}>
-                        <ClashingKeyTitle>
-                          <i
-                            className="material-icons"
-                            style={{ fontSize: "18px" }}
-                          >
-                            sync_problem
-                          </i>
-                          <b>{key}</b> is defined in both environments
-                        </ClashingKeyTitle>
-                        <ClashingKeyDefinitions>
-                          <ClashingKeyLabel>Defined as</ClashingKeyLabel>
-                          <ClashingKeyLabel>
-                            {this.state.selectedEnvGroup.data[key] ||
-                              emptyValue}
-                          </ClashingKeyLabel>
-                          <ClashingKeyLabel>Replaced by</ClashingKeyLabel>
-                          <ClashingKeyLabel>
-                            {value || emptyValue}
-                          </ClashingKeyLabel>
-                        </ClashingKeyDefinitions>
-                        {i !== clashingKeys.length - 1 && (
-                          <ClashingKeyRowDivider />
-                        )}
-                      </ClashingKeyRow>
-                    ))}
-                  </PossibleClashingKeys>
+                  {this.renderEnvGroupPreview(clashingKeys)}
                 </>
               )}
             </SidebarSection>

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -122,11 +122,15 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
     return (
       <PossibleClashingKeys>
         {clashingKeys.map(({ key, value }, i) => (
-          <li key={key}>
-            <ClashingKeyTitle>
-              <ClashIcon className="material-icons">sync_problem</ClashIcon>
-              <b>{key}</b> is defined in both environments
-            </ClashingKeyTitle>
+          <ClashingKeyItem key={key}>
+            <ClashingKeyTop>
+              <ClashIconWrapper>
+                <ClashIcon className="material-icons">sync_problem</ClashIcon>
+              </ClashIconWrapper>
+              <ClashingKeyExplanation>
+                <b>{key}</b> is defined in both environments
+              </ClashingKeyExplanation>
+            </ClashingKeyTop>
             <ClashingKeyDefinitions>
               <ClashingKeyLabel>Old</ClashingKeyLabel>
               <ClashingKeyValue>
@@ -137,8 +141,7 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
                 {formattedEnvironmentValue(value) || emptyValue}
               </ClashingKeyValue>
             </ClashingKeyDefinitions>
-            {i !== clashingKeys.length - 1 && <ClashingKeyRowDivider />}
-          </li>
+          </ClashingKeyItem>
         ))}
       </PossibleClashingKeys>
     );
@@ -216,9 +219,18 @@ const GroupEnvPreview = styled.pre`
   user-select: text;
 `;
 
+const ClashingKeyExplanation = styled.div`
+  padding: 10px 15px;
+`;
+
+const ClashIconWrapper = styled.div`
+  padding: 10px;
+  background: #3d4048;
+  display: flex;
+  align-items: center;
+`;
+
 const ClashIcon = styled.i`
-  float: left;
-  margin-inline-end: 4px;
   font-size: 18px;
 `;
 
@@ -269,7 +281,7 @@ const GroupModalSections = styled.div`
   display: grid;
   gap: 10px;
   grid-template-columns: 1fr 1fr;
-  max-height: 160px;
+  max-height: 365px;
 `;
 
 const PossibleClashingKeys = styled.ul`
@@ -283,6 +295,11 @@ const PossibleClashingKeys = styled.ul`
   }
 `;
 
+const ClashingKeyItem = styled.li`
+  border: 1px solid #292c31;
+  border-radius: 5px;
+`;
+
 const ClashingKeyRowDivider = styled.hr`
   margin: 16px 0;
   border: 1px solid #27292f;
@@ -290,18 +307,23 @@ const ClashingKeyRowDivider = styled.hr`
 
 const ClashingKeyDefinitions = styled.div`
   grid-template-columns: min-content auto;
+  padding: 5px 0;
   column-gap: 6px;
-  row-gap: 4px;
   display: grid;
 `;
 
 const ClashingKeyLabel = styled.p`
   margin: 0px;
+  font-weight: bold;
+  padding: 5px 10px;
   white-space: nowrap;
 `;
 
 const ClashingKeyValue = styled.p`
   margin: 0px;
+  display: flex;
+  padding: 0;
+  align-items: center;
   word-break: break-word;
 `;
 
@@ -310,7 +332,6 @@ const EnvGroupList = styled.div`
   border-radius: 3px;
   background: #ffffff11;
   border: 1px solid #ffffff44;
-  max-height: 160px;
   overflow-y: auto;
 `;
 
@@ -321,9 +342,15 @@ const Subtitle = styled.div`
   color: #aaaabb;
 `;
 
+const ClashingKeyTop = styled.div`
+  padding: 10px 15px;
+  background: #2e3035;
+  display: flex;
+  align-items: stretch;
+`;
+
 const ClashingKeyTitle = styled(Subtitle)`
-  margin-top: 0;
-  margin-bottom: 12px;
+  padding: 10px 15px;
 `;
 
 const ModalTitle = styled.div`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -100,8 +100,8 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
   };
 
   potentiallyOverriddenKeys(incoming: Record<string, string>): KeyValue[] {
-    return Object.entries(this.props.existingValues)
-      .filter(([key]) => incoming[key])
+    return Object.entries(incoming)
+      .filter(([key]) => this.props.existingValues[key])
       .map(([key, value]) => ({ key, value }));
   }
 
@@ -128,11 +128,11 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
             </ClashingKeyTitle>
             <ClashingKeyDefinitions>
               <ClashingKeyLabel>Defined as</ClashingKeyLabel>
-              <ClashingKeyLabel>
-                {this.state.selectedEnvGroup.data[key] || emptyValue}
-              </ClashingKeyLabel>
+              <ClashingKeyValue>
+                {this.props.existingValues[key] || emptyValue}
+              </ClashingKeyValue>
               <ClashingKeyLabel>Replaced by</ClashingKeyLabel>
-              <ClashingKeyLabel>{value || emptyValue}</ClashingKeyLabel>
+              <ClashingKeyValue>{value || emptyValue}</ClashingKeyValue>
             </ClashingKeyDefinitions>
             {i !== clashingKeys.length - 1 && <ClashingKeyRowDivider />}
           </ClashingKeyRow>
@@ -285,6 +285,11 @@ const ClashingKeyDefinitions = styled.div`
 const ClashingKeyLabel = styled.p`
   margin: 0px;
   white-space: nowrap;
+`;
+
+const ClashingKeyValue = styled.p`
+  margin: 0px;
+  word-break: break-word;
 `;
 
 const EnvGroupList = styled.div`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -119,11 +119,9 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
     return (
       <PossibleClashingKeys>
         {clashingKeys.map(({ key, value }, i) => (
-          <ClashingKeyRow key={key}>
+          <li key={key}>
             <ClashingKeyTitle>
-              <i className="material-icons" style={{ fontSize: "18px" }}>
-                sync_problem
-              </i>
+              <ClashIcon className="material-icons">sync_problem</ClashIcon>
               <b>{key}</b> is defined in both environments
             </ClashingKeyTitle>
             <ClashingKeyDefinitions>
@@ -135,7 +133,7 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
               <ClashingKeyValue>{value || emptyValue}</ClashingKeyValue>
             </ClashingKeyDefinitions>
             {i !== clashingKeys.length - 1 && <ClashingKeyRowDivider />}
-          </ClashingKeyRow>
+          </li>
         ))}
       </PossibleClashingKeys>
     );
@@ -207,6 +205,12 @@ const GroupEnvPreview = styled.pre`
   margin: 0 0 10px 0;
 `;
 
+const ClashIcon = styled.i`
+  float: left;
+  margin-inline-end: 4px;
+  font-size: 18px;
+`;
+
 const Placeholder = styled.div`
   width: 100%;
   height: 150px;
@@ -268,8 +272,6 @@ const PossibleClashingKeys = styled.ul`
   }
 `;
 
-const ClashingKeyRow = styled.li``;
-
 const ClashingKeyRowDivider = styled.hr`
   margin: 16px 0;
   border: 1px solid #27292f;
@@ -309,13 +311,8 @@ const Subtitle = styled.div`
 `;
 
 const ClashingKeyTitle = styled(Subtitle)`
-  display: flex;
-  align-items: center;
   margin-top: 0;
   margin-bottom: 12px;
-  > * {
-    margin-inline-end: 4px;
-  }
 `;
 
 const ModalTitle = styled.div`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -296,6 +296,7 @@ const PossibleClashingKeys = styled.ul`
 `;
 
 const ClashingKeyItem = styled.li`
+  overflow: hidden;
   border: 1px solid #292c31;
   border-radius: 5px;
 `;
@@ -343,14 +344,9 @@ const Subtitle = styled.div`
 `;
 
 const ClashingKeyTop = styled.div`
-  padding: 10px 15px;
   background: #2e3035;
   display: flex;
   align-items: stretch;
-`;
-
-const ClashingKeyTitle = styled(Subtitle)`
-  padding: 10px 15px;
 `;
 
 const ModalTitle = styled.div`

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -134,7 +134,8 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
             <ClashingKeyDefinitions>
               <ClashingKeyLabel>Old</ClashingKeyLabel>
               <ClashingKeyValue>
-                {this.props.existingValues[key] || emptyValue}
+                {formattedEnvironmentValue(this.props.existingValues[key]) ||
+                  emptyValue}
               </ClashingKeyValue>
               <ClashingKeyLabel>New</ClashingKeyLabel>
               <ClashingKeyValue>

--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -163,13 +163,9 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
           {this.state.selectedEnvGroup ? (
             <SidebarSection>
               <GroupEnvPreview>
-                {Object.entries(this.state.selectedEnvGroup.data).map(
-                  ([key, value]) => (
-                    <div key={key}>
-                      {key}={value}
-                    </div>
-                  )
-                )}
+                {Object.entries(this.state.selectedEnvGroup.data)
+                  .map(([key, value]) => `${key}=${value}`)
+                  .join("\n")}
               </GroupEnvPreview>
               {clashingKeys.length > 0 && (
                 <>
@@ -202,7 +198,10 @@ const SidebarSection = styled.section`
 `;
 
 const GroupEnvPreview = styled.pre`
+  font-family: monospace;
   margin: 0 0 10px 0;
+  white-space: pre-line;
+  word-break: break-word;
 `;
 
 const ClashIcon = styled.i`


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When trying to load environment variables, all existing variables are overwritten by the variables in the selected environment group.

![current implementation](https://user-images.githubusercontent.com/24978328/124369286-d867dd00-dc72-11eb-91c1-9f2dbd1b2ca6.png)

Closes #821

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?

- When selecting environment variables, you can view the contents of the variables
- You can see any conflicting variables that are both defined in the current context and incoming group 

![image](https://user-images.githubusercontent.com/24978328/124369346-a99e3680-dc73-11eb-92ef-fed8ec1a1c78.png)

![image](https://user-images.githubusercontent.com/24978328/124369566-955b3900-dc75-11eb-8dff-e99e5c2c14ed.png)


<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes

A few missing types were added.

`SaveButton` implementation was tweaked to prevent the longer status texts from overflowing outside the modal padding by adding a `left` position and `justify-content: space-between`.

The modal main content was split in half to allow adding dynamic content without having to vertically resize the modal.