### PR TITLE
[0.5.0] Support external k8s clusters as a provisioner/ingress option

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -24,7 +24,7 @@ services:
       - ./cmd:/porter/cmd
       - ./internal:/porter/internal
       - ./server:/porter/server
-      - /Users/abelanger/porter/porter-server/docker/kubeconfig.yaml:/porter/kubeconfig.yaml
+      - ./docker/kubeconfig.yaml:/porter/kubeconfig.yaml
   postgres:
     image: postgres:latest
     container_name: postgres

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -24,6 +24,7 @@ services:
       - ./cmd:/porter/cmd
       - ./internal:/porter/internal
       - ./server:/porter/server
+      - /Users/abelanger/porter/porter-server/docker/kubeconfig.yaml:/porter/kubeconfig.yaml
   postgres:
     image: postgres:latest
     container_name: postgres

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,10 +52,15 @@ type ServerConf struct {
 	SendgridProjectInviteTemplateID string `env:"SENDGRID_INVITE_TEMPLATE_ID"`
 	SendgridSenderEmail             string `env:"SENDGRID_SENDER_EMAIL"`
 
-	DOClientID          string `env:"DO_CLIENT_ID"`
-	DOClientSecret      string `env:"DO_CLIENT_SECRET"`
-	ProvisionerImageTag string `env:"PROV_IMAGE_TAG,default=latest"`
-	SegmentClientKey    string `env:"SEGMENT_CLIENT_KEY"`
+	DOClientID                 string `env:"DO_CLIENT_ID"`
+	DOClientSecret             string `env:"DO_CLIENT_SECRET"`
+	ProvisionerImageTag        string `env:"PROV_IMAGE_TAG,default=latest"`
+	ProvisionerImagePullSecret string `env:"PROV_IMAGE_PULL_SECRET"`
+	SegmentClientKey           string `env:"SEGMENT_CLIENT_KEY"`
+
+	ProvisionerCluster string `env:"PROVISIONER_CLUSTER"`
+	IngressCluster     string `env:"INGRESS_CLUSTER"`
+	SelfKubeconfig     string `env:"SELF_KUBECONFIG"`
 }
 
 // DBConf is the database configuration: if generated from environment variables,

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -834,6 +834,7 @@ func (a *Agent) ProvisionECR(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	id := infra.GetUniqueName()
 	prov := &provisioner.Conf{
@@ -844,6 +845,7 @@ func (a *Agent) ProvisionECR(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		LastApplied:         infra.LastApplied,
 		AWS: &aws.Conf{
 			AWSRegion:          awsConf.AWSRegion,
@@ -869,6 +871,7 @@ func (a *Agent) ProvisionEKS(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	id := infra.GetUniqueName()
 	prov := &provisioner.Conf{
@@ -879,6 +882,7 @@ func (a *Agent) ProvisionEKS(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		LastApplied:         infra.LastApplied,
 		AWS: &aws.Conf{
 			AWSRegion:          awsConf.AWSRegion,
@@ -904,6 +908,7 @@ func (a *Agent) ProvisionGCR(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	id := infra.GetUniqueName()
 	prov := &provisioner.Conf{
@@ -914,6 +919,7 @@ func (a *Agent) ProvisionGCR(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		LastApplied:         infra.LastApplied,
 		GCP: &gcp.Conf{
 			GCPRegion:    gcpConf.GCPRegion,
@@ -936,6 +942,7 @@ func (a *Agent) ProvisionGKE(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	id := infra.GetUniqueName()
 	prov := &provisioner.Conf{
@@ -946,6 +953,7 @@ func (a *Agent) ProvisionGKE(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		LastApplied:         infra.LastApplied,
 		GCP: &gcp.Conf{
 			GCPRegion:    gcpConf.GCPRegion,
@@ -972,6 +980,7 @@ func (a *Agent) ProvisionDOCR(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	// get the token
 	oauthInt, err := repo.OAuthIntegration.ReadOAuthIntegration(
@@ -997,6 +1006,7 @@ func (a *Agent) ProvisionDOCR(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		LastApplied:         infra.LastApplied,
 		DO: &do.Conf{
 			DOToken: tok,
@@ -1022,6 +1032,7 @@ func (a *Agent) ProvisionDOKS(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	// get the token
 	oauthInt, err := repo.OAuthIntegration.ReadOAuthIntegration(
@@ -1048,6 +1059,7 @@ func (a *Agent) ProvisionDOKS(
 		Postgres:            pgConf,
 		LastApplied:         infra.LastApplied,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 		DO: &do.Conf{
 			DOToken: tok,
 		},
@@ -1069,6 +1081,7 @@ func (a *Agent) ProvisionTest(
 	pgConf *config.DBConf,
 	redisConf *config.RedisConf,
 	provImageTag string,
+	provImagePullSecret string,
 ) (*batchv1.Job, error) {
 	id := infra.GetUniqueName()
 
@@ -1080,6 +1093,7 @@ func (a *Agent) ProvisionTest(
 		Redis:               redisConf,
 		Postgres:            pgConf,
 		ProvisionerImageTag: provImageTag,
+		ImagePullSecret:     provImagePullSecret,
 	}
 
 	return a.provision(prov, infra, repo)

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -85,7 +85,7 @@ func GetAgentInClusterConfig() (*Agent, error) {
 		return nil, err
 	}
 
-	restClientGetter := newRESTClientGetterFromInClusterConfig(conf)
+	restClientGetter := NewRESTClientGetterFromInClusterConfig(conf)
 	clientset, err := kubernetes.NewForConfig(conf)
 
 	return &Agent{restClientGetter, clientset}, nil
@@ -386,9 +386,9 @@ func (conf *OutOfClusterConfig) setTokenCache(token string, expiry time.Time) er
 	return err
 }
 
-// newRESTClientGetterFromInClusterConfig returns a RESTClientGetter using
+// NewRESTClientGetterFromInClusterConfig returns a RESTClientGetter using
 // default values set from the *rest.Config
-func newRESTClientGetterFromInClusterConfig(conf *rest.Config) genericclioptions.RESTClientGetter {
+func NewRESTClientGetterFromInClusterConfig(conf *rest.Config) genericclioptions.RESTClientGetter {
 	cfs := genericclioptions.NewConfigFlags(false)
 
 	cfs.ClusterName = &conf.ServerName

--- a/internal/kubernetes/provisioner/provisioner.go
+++ b/internal/kubernetes/provisioner/provisioner.go
@@ -423,11 +423,6 @@ func (conf *Conf) addTFEnv(env []v1.EnvVar) []v1.EnvVar {
 		Value: "./terraform",
 	})
 
-	// env = append(env, v1.EnvVar{
-	// 	Name:  "TF_PLUGIN_CACHE_DIR",
-	// 	Value: "/.terraform/plugin-cache",
-	// })
-
 	env = append(env, v1.EnvVar{
 		Name:  "TF_PORTER_BACKEND",
 		Value: "postgres",

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -10,6 +10,7 @@ import (
 	vr "github.com/go-playground/validator/v10"
 	"github.com/porter-dev/porter/internal/auth/sessionstore"
 	"github.com/porter-dev/porter/internal/auth/token"
+	"github.com/porter-dev/porter/internal/kubernetes/local"
 	"github.com/porter-dev/porter/internal/oauth"
 	"golang.org/x/oauth2"
 	"gorm.io/gorm"
@@ -67,7 +68,8 @@ type App struct {
 	TestAgents *TestAgents
 
 	// An in-cluster agent if service is running in cluster
-	InClusterAgent *kubernetes.Agent
+	ProvisionerAgent *kubernetes.Agent
+	IngressAgent     *kubernetes.Agent
 
 	// redis client for redis connection
 	RedisConf *config.RedisConf
@@ -140,21 +142,11 @@ func New(conf *AppConfig) (*App, error) {
 	}
 
 	app.Store = store
-
-	// if application is running in-cluster, set provisioning capabilities
-	if kubernetes.IsInCluster() {
-		app.Capabilities.Provisioning = true
-
-		agent, err := kubernetes.GetAgentInClusterConfig()
-
-		if err != nil {
-			return nil, fmt.Errorf("could not get in-cluster agent: %v", err)
-		}
-
-		app.InClusterAgent = agent
-	}
-
 	sc := conf.ServerConf
+
+	// get the InClusterAgent from either a file-based kubeconfig or the in-cluster agent
+	app.assignProvisionerAgent(&sc)
+	app.assignIngressAgent(&sc)
 
 	// if server config contains OAuth client info, create clients
 	if sc.GithubClientID != "" && sc.GithubClientSecret != "" {
@@ -215,6 +207,58 @@ func New(conf *AppConfig) (*App, error) {
 	}
 
 	return app, nil
+}
+
+func (app *App) assignProvisionerAgent(sc *config.ServerConf) error {
+	if sc.ProvisionerCluster == "kubeconfig" && sc.SelfKubeconfig != "" {
+		app.Capabilities.Provisioning = true
+
+		agent, err := local.GetSelfAgentFromFileConfig(sc.SelfKubeconfig)
+
+		if err != nil {
+			return fmt.Errorf("could not get in-cluster agent: %v", err)
+		}
+
+		app.ProvisionerAgent = agent
+	} else if sc.ProvisionerCluster == "kubeconfig" {
+		return fmt.Errorf(`"kubeconfig" cluster option requires path to kubeconfig`)
+	}
+
+	app.Capabilities.Provisioning = true
+
+	agent, err := kubernetes.GetAgentInClusterConfig()
+
+	if err != nil {
+		return fmt.Errorf("could not get in-cluster agent: %v", err)
+	}
+
+	app.ProvisionerAgent = agent
+
+	return nil
+}
+
+func (app *App) assignIngressAgent(sc *config.ServerConf) error {
+	if sc.IngressCluster == "kubeconfig" && sc.SelfKubeconfig != "" {
+		agent, err := local.GetSelfAgentFromFileConfig(sc.SelfKubeconfig)
+
+		if err != nil {
+			return fmt.Errorf("could not get in-cluster agent: %v", err)
+		}
+
+		app.IngressAgent = agent
+	} else if sc.IngressCluster == "kubeconfig" {
+		return fmt.Errorf(`"kubeconfig" cluster option requires path to kubeconfig`)
+	}
+
+	agent, err := kubernetes.GetAgentInClusterConfig()
+
+	if err != nil {
+		return fmt.Errorf("could not get in-cluster agent: %v", err)
+	}
+
+	app.IngressAgent = agent
+
+	return nil
 }
 
 func (app *App) getTokenFromRequest(r *http.Request) *token.Token {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -220,6 +220,8 @@ func (app *App) assignProvisionerAgent(sc *config.ServerConf) error {
 		}
 
 		app.ProvisionerAgent = agent
+
+		return nil
 	} else if sc.ProvisionerCluster == "kubeconfig" {
 		return fmt.Errorf(`"kubeconfig" cluster option requires path to kubeconfig`)
 	}
@@ -246,6 +248,8 @@ func (app *App) assignIngressAgent(sc *config.ServerConf) error {
 		}
 
 		app.IngressAgent = agent
+
+		return nil
 	} else if sc.IngressCluster == "kubeconfig" {
 		return fmt.Errorf(`"kubeconfig" cluster option requires path to kubeconfig`)
 	}

--- a/server/api/dns_record_handler.go
+++ b/server/api/dns_record_handler.go
@@ -76,7 +76,7 @@ func (app *App) HandleCreateDNSRecord(w http.ResponseWriter, r *http.Request) {
 
 	_record := domain.DNSRecord(*record)
 
-	err = _record.CreateDomain(app.InClusterAgent.Clientset)
+	err = _record.CreateDomain(app.IngressAgent.Clientset)
 
 	if err != nil {
 		app.handleErrorInternal(err, w)

--- a/server/api/provision_handler.go
+++ b/server/api/provision_handler.go
@@ -51,7 +51,7 @@ func (app *App) HandleProvisionTestInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionTest(
+	_, err = app.ProvisionerAgent.ProvisionTest(
 		uint(projID),
 		infra,
 		*app.Repo,
@@ -59,6 +59,7 @@ func (app *App) HandleProvisionTestInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -127,6 +128,7 @@ func (app *App) HandleDestroyTestInfra(w http.ResponseWriter, r *http.Request) {
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -191,7 +193,7 @@ func (app *App) HandleProvisionAWSECRInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionECR(
+	_, err = app.ProvisionerAgent.ProvisionECR(
 		uint(projID),
 		awsInt,
 		form.ECRName,
@@ -201,6 +203,7 @@ func (app *App) HandleProvisionAWSECRInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -273,7 +276,7 @@ func (app *App) HandleDestroyAWSECRInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionECR(
+	_, err = app.ProvisionerAgent.ProvisionECR(
 		infra.ProjectID,
 		awsInt,
 		form.ECRName,
@@ -283,6 +286,7 @@ func (app *App) HandleDestroyAWSECRInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -347,7 +351,7 @@ func (app *App) HandleProvisionAWSEKSInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionEKS(
+	_, err = app.ProvisionerAgent.ProvisionEKS(
 		uint(projID),
 		awsInt,
 		form.EKSName,
@@ -358,6 +362,7 @@ func (app *App) HandleProvisionAWSEKSInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -430,7 +435,7 @@ func (app *App) HandleDestroyAWSEKSInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionEKS(
+	_, err = app.ProvisionerAgent.ProvisionEKS(
 		infra.ProjectID,
 		awsInt,
 		form.EKSName,
@@ -441,6 +446,7 @@ func (app *App) HandleDestroyAWSEKSInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -505,7 +511,7 @@ func (app *App) HandleProvisionGCPGCRInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionGCR(
+	_, err = app.ProvisionerAgent.ProvisionGCR(
 		uint(projID),
 		gcpInt,
 		*app.Repo,
@@ -514,6 +520,7 @@ func (app *App) HandleProvisionGCPGCRInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -588,7 +595,7 @@ func (app *App) HandleProvisionGCPGKEInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionGKE(
+	_, err = app.ProvisionerAgent.ProvisionGKE(
 		uint(projID),
 		gcpInt,
 		form.GKEName,
@@ -598,6 +605,7 @@ func (app *App) HandleProvisionGCPGKEInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -670,7 +678,7 @@ func (app *App) HandleDestroyGCPGKEInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionGKE(
+	_, err = app.ProvisionerAgent.ProvisionGKE(
 		infra.ProjectID,
 		gcpInt,
 		form.GKEName,
@@ -680,6 +688,7 @@ func (app *App) HandleDestroyGCPGKEInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -788,7 +797,7 @@ func (app *App) HandleProvisionDODOCRInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionDOCR(
+	_, err = app.ProvisionerAgent.ProvisionDOCR(
 		uint(projID),
 		oauthInt,
 		app.DOConf,
@@ -800,6 +809,7 @@ func (app *App) HandleProvisionDODOCRInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -872,7 +882,7 @@ func (app *App) HandleDestroyDODOCRInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionDOCR(
+	_, err = app.ProvisionerAgent.ProvisionDOCR(
 		infra.ProjectID,
 		oauthInt,
 		app.DOConf,
@@ -884,6 +894,7 @@ func (app *App) HandleDestroyDODOCRInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -948,7 +959,7 @@ func (app *App) HandleProvisionDODOKSInfra(w http.ResponseWriter, r *http.Reques
 	}
 
 	// launch provisioning pod
-	_, err = app.InClusterAgent.ProvisionDOKS(
+	_, err = app.ProvisionerAgent.ProvisionDOKS(
 		uint(projID),
 		oauthInt,
 		app.DOConf,
@@ -960,6 +971,7 @@ func (app *App) HandleProvisionDODOKSInfra(w http.ResponseWriter, r *http.Reques
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {
@@ -1032,7 +1044,7 @@ func (app *App) HandleDestroyDODOKSInfra(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = app.InClusterAgent.ProvisionDOKS(
+	_, err = app.ProvisionerAgent.ProvisionDOKS(
 		infra.ProjectID,
 		oauthInt,
 		app.DOConf,
@@ -1044,6 +1056,7 @@ func (app *App) HandleDestroyDODOKSInfra(w http.ResponseWriter, r *http.Request)
 		&app.DBConf,
 		app.RedisConf,
 		app.ServerConf.ProvisionerImageTag,
+		app.ServerConf.ProvisionerImagePullSecret,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Ingresses and provisioning pods are currently using an in-cluster config to create k8s objects. 

## What is the new behavior?

Add the option to specify `INGRESS_CLUSTER`and/or `PROVISIONER_CLUSTER` as `kubeconfig`, with a path to the kubeconfig set as `SELF_KUBECONFIG`. 

## Technical Spec/Implementation Notes
