### PR TITLE
Fixed namespace list reference not updating useMemo sorted namespaces

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/dashboard/NamespaceList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/NamespaceList.tsx
@@ -109,7 +109,7 @@ export const NamespaceList: React.FunctionComponent = () => {
             (namespace) => namespace.metadata.name === data.Object.metadata.name
           );
           oldNamespaces.splice(oldNamespaceIndex, 1, data.Object);
-          return oldNamespaces;
+          return [...oldNamespaces];
         });
       }
     };

--- a/dashboard/src/main/home/cluster-dashboard/dashboard/NamespaceList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/NamespaceList.tsx
@@ -165,14 +165,15 @@ export const NamespaceList: React.FunctionComponent = () => {
                   {namespace?.status?.phase}
                 </Status>
               </ContentContainer>
-              {isAvailableForDeletion(namespace?.metadata?.name) && (
-                <OptionsDropdown>
-                  <DropdownOption onClick={() => onDelete(namespace)}>
-                    <i className="material-icons-outlined">delete</i>
-                    <span>Delete</span>
-                  </DropdownOption>
-                </OptionsDropdown>
-              )}
+              {isAvailableForDeletion(namespace?.metadata?.name) &&
+                namespace?.status?.phase === "Active" && (
+                  <OptionsDropdown>
+                    <DropdownOption onClick={() => onDelete(namespace)}>
+                      <i className="material-icons-outlined">delete</i>
+                      <span>Delete</span>
+                    </DropdownOption>
+                  </OptionsDropdown>
+                )}
             </StyledCard>
           );
         })}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When triggering a delete, the namespace wasn't updating the status, so it seemed like it wasn't updating.

Closes #855 

## What is the new behavior?

Fixed behavior, now when you trigger a delete for a namespace, the status will update to "Terminating" so the user can see that the deletion is in process

## Technical Spec/Implementation Notes

The problem was on the WebSocket update event, when we tried to update the list of namespaces, we need to pass the setNamespaces function a new object so it can trigger updates on functions like useMemo.

In this case, I just replace the `return oldNamespaces` with a return `[...oldNamespaces]` as it will return a new reference to the "new" array.

UPDATE:
Also, just to prevent double requests to deletion, I added a condition to not be able to remove a namespace unless it is on Active phase.
