### PR TITLE
Fix application logs displaying on system logs

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
@@ -139,6 +139,8 @@ export default class Logs extends Component<PropsType, StateType> {
     if (prevState.currentTab !== this.state.currentTab) {
       let { selectedPod } = this.props;
 
+      this.ws?.close();
+
       this.setState({ logs: [] });
 
       if (this.state.currentTab == "Application") {


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When an application is running live logs, and the user tries to see the system log of that app, the application live logs will appear on the system tab

## What is the new behavior?

The system logs shows the logs properly without involving any application logs

## Technical Spec/Implementation Notes

The websocket was keeped open even if we changed between application/system logs tab. The solution is just close the websocket before any tab change (we were already opening a new was connection each time we entered the application tab).
