### PR TITLE
[0.6.0] Pod Selection Bugfix

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
@@ -25,6 +25,7 @@ type StateType = {
   selectors: string[];
   available: number;
   total: number;
+  canUpdatePod: boolean;
 };
 
 // Controller tab in log section that displays list of pods on click.
@@ -38,6 +39,7 @@ export default class ControllerTab extends Component<PropsType, StateType> {
     selectors: [] as string[],
     available: null as number,
     total: null as number,
+    canUpdatePod: true,
   };
 
   updatePods = () => {
@@ -77,7 +79,13 @@ export default class ControllerTab extends Component<PropsType, StateType> {
           status === "failed" &&
             pod.status?.message &&
             this.props.setPodError(pod.status?.message);
-          selectPod(res.data[0]);
+          if (this.state.canUpdatePod) {
+            // this prevents multiple requests from changing the first pod
+            selectPod(res.data[0]);
+            this.setState({
+              canUpdatePod: false,
+            });
+          }
         }
       })
       .catch((err) => {
@@ -317,6 +325,9 @@ export default class ControllerTab extends Component<PropsType, StateType> {
                   pod.status?.message &&
                   this.props.setPodError(pod.status?.message);
                 selectPod(pod);
+                this.setState({
+                  canUpdatePod: false,
+                });
               }}
             >
               <Gutter>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

This PR closes #884, issue is described there.

## Technical Spec/Implementation Notes

`ControllerTab` sends out multiple requests to get pods, and those can finish at different times since they are async. Since each request sets the first selected pod, the behavior described before is seen. The solution is to just allow the first pod to only be set once.
