### PR TITLE
[0.6.0] [Frontend, API] Trying to improve Expanded Chart performance

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -75,10 +75,9 @@ const ExpandedChart: React.FC<Props> = (props) => {
   const [url, setUrl] = useState<string>(null);
   const [showDeleteOverlay, setShowDeleteOverlay] = useState<boolean>(false);
   const [deleting, setDeleting] = useState<boolean>(false);
-  const [imageIsPlaceholder, setImageIsPlaceholer] = useState<boolean | null>(
-    null
-  );
+  const [imageIsPlaceholder, setImageIsPlaceholer] = useState<boolean>(false);
   const [newestImage, setNewestImage] = useState<string>(null);
+  const [isLoadingChartData, setIsLoadingChartData] = useState<boolean>(true);
 
   const [isAuthorized] = useAuth();
 
@@ -95,6 +94,7 @@ const ExpandedChart: React.FC<Props> = (props) => {
 
   // Retrieve full chart data (includes form and values)
   const getChartData = async (chart: ChartType) => {
+    setIsLoadingChartData(true);
     const res = await api.getChart(
       "<token>",
       {
@@ -124,7 +124,7 @@ const ExpandedChart: React.FC<Props> = (props) => {
 
     setCurrentChart(res.data);
 
-    updateComponents(res.data);
+    updateComponents(res.data).finally(() => setIsLoadingChartData(false));
   };
 
   const getControllers = async (chart: ChartType) => {
@@ -346,6 +346,17 @@ const ExpandedChart: React.FC<Props> = (props) => {
       case "metrics":
         return <MetricsSection currentChart={chart} />;
       case "status":
+        if (isLoadingChartData) {
+          return (
+            <Placeholder>
+              <TextWrap>
+                <Header>
+                  <Spinner src={loadingSrc} />
+                </Header>
+              </TextWrap>
+            </Placeholder>
+          );
+        }
         if (imageIsPlaceholder) {
           return (
             <Placeholder>

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -75,7 +75,9 @@ const ExpandedChart: React.FC<Props> = (props) => {
   const [url, setUrl] = useState<string>(null);
   const [showDeleteOverlay, setShowDeleteOverlay] = useState<boolean>(false);
   const [deleting, setDeleting] = useState<boolean>(false);
-  const [imageIsPlaceholder, setImageIsPlaceholer] = useState<boolean>(false);
+  const [imageIsPlaceholder, setImageIsPlaceholer] = useState<boolean | null>(
+    null
+  );
   const [newestImage, setNewestImage] = useState<string>(null);
 
   const [isAuthorized] = useAuth();
@@ -117,9 +119,10 @@ const ExpandedChart: React.FC<Props> = (props) => {
     ) {
       imageIsPlaceholder = true;
     }
-    setCurrentChart(res.data);
     setImageIsPlaceholer(imageIsPlaceholder);
     setNewestImage(newNewestImage);
+
+    setCurrentChart(res.data);
 
     updateComponents(res.data);
   };
@@ -510,7 +513,11 @@ const ExpandedChart: React.FC<Props> = (props) => {
     });
 
     if (!service?.Name || !service?.Namespace) {
-      return;
+      return (
+        <Url>
+          <Bolded>Loading...</Bolded>
+        </Url>
+      );
     }
 
     return (
@@ -573,12 +580,10 @@ const ExpandedChart: React.FC<Props> = (props) => {
 
   useEffect(() => {
     let isSubscribed = true;
-    let ingressName = null;
-    for (var i = 0; i < components.length; i++) {
-      if (components[i].Kind === "Ingress") {
-        ingressName = components[i].Name;
-      }
-    }
+
+    const ingressComponent = components?.find((c) => c.Kind === "Ingress");
+
+    const ingressName = ingressComponent?.Name;
 
     if (!ingressName) return;
 
@@ -612,7 +617,7 @@ const ExpandedChart: React.FC<Props> = (props) => {
       })
       .catch(console.log);
     return () => (isSubscribed = false);
-  }, [components]);
+  }, [components, currentCluster, currentProject, currentChart]);
 
   return (
     <>

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -771,7 +771,7 @@ const ExpandedChart: React.FC<PropsType> = (props) => {
           <FormWrapper
             isReadOnly={
               imageIsPlaceholder ||
-              props.isAuthorized("application", "", ["get", "update"])
+              !props.isAuthorized("application", "", ["get", "update"])
             }
             formData={formData}
             tabOptions={tabOptions}

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -129,7 +129,7 @@ const ExpandedChart: React.FC<PropsType> = (props) => {
             currentChart: res.data,
             loading: false,
             imageIsPlaceholder,
-            newNewestImage,
+            newestImage: newNewestImage,
           },
           res.data
         );
@@ -222,6 +222,7 @@ const ExpandedChart: React.FC<PropsType> = (props) => {
   };
 
   const updateComponents = (state: any, currentChart: ChartType) => {
+    console.log("updating components...");
     api
       .getChartComponents(
         "<token>",
@@ -237,6 +238,10 @@ const ExpandedChart: React.FC<PropsType> = (props) => {
         }
       )
       .then((res) => {
+        console.log(state);
+        setLoading(state.loading);
+        setImageIsPlaceholer(state.imageIsPlaceholder);
+        setNewestImage(state.newestImage);
         setComponents(res.data.Objects);
         setPodSelectors(res.data.PodSelectors);
         updateTabs();
@@ -661,6 +666,13 @@ const ExpandedChart: React.FC<PropsType> = (props) => {
         ingressName = components[i].Name;
       }
     }
+
+    if (!ingressName) return;
+
+    console.group("data");
+    console.log(components);
+    console.log(ingressName);
+    console.groupEnd();
 
     api
       .getIngress(

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -117,15 +117,11 @@ const ExpandedChart: React.FC<Props> = (props) => {
     ) {
       imageIsPlaceholder = true;
     }
-    updateComponents(
-      {
-        currentChart: res.data,
-        loading: false,
-        imageIsPlaceholder,
-        newestImage: newNewestImage,
-      },
-      res.data
-    );
+    setCurrentChart(res.data);
+    setImageIsPlaceholer(imageIsPlaceholder);
+    setNewestImage(newNewestImage);
+
+    updateComponents(res.data);
   };
 
   const getControllers = async (chart: ChartType) => {
@@ -195,7 +191,7 @@ const ExpandedChart: React.FC<Props> = (props) => {
     newWebsocket(kind, apiEndpoint, wsConfig);
   };
 
-  const updateComponents = async (state: any, currentChart: ChartType) => {
+  const updateComponents = async (currentChart: ChartType) => {
     try {
       const res = await api.getChartComponents(
         "<token>",
@@ -210,9 +206,6 @@ const ExpandedChart: React.FC<Props> = (props) => {
           revision: currentChart.version,
         }
       );
-      setCurrentChart(state.currentChart);
-      setImageIsPlaceholer(state.imageIsPlaceholder);
-      setNewestImage(state.newestImage);
       setComponents(res.data.Objects);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Expanded Chart makes a lot of requests to the backend, a lot of which are duplicated:

![image](https://user-images.githubusercontent.com/25856165/125840523-5ef82de8-35f9-4145-b260-df435009b4d1.png)

Many of these take a long time to happen (for example, the history endpoint in the image above takes quite a while to load and is requested 3 times) and lots of requests propagate state updates upwards which also causes problems.

## What is the new behavior?

The idea is to try to reduce the number of requests these components make by creating a context that handles some part of these requests.

## Technical Spec/Implementation Notes
