### PR TITLE
[0.6.0] [bugfix] - Manifest list not showing scroll

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ListSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ListSection.tsx
@@ -128,6 +128,7 @@ const TabWrapper = styled.div`
   margin-right: 10px;
   border-radius: 5px;
   overflow: hidden;
+  overflow-y: auto;
 `;
 
 const FlexWrapper = styled.div`


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the manifest list has too many items it's not scrollable

Closes #893 

## What is the new behavior?

The manifest list will display a scroll bar when there are too many items

## Technical Spec/Implementation Notes

Added `overflow-y: auto;` to the manifest list wrapper so it'll show the scroll bar when necessary