### PR TITLE
[0.6.0] Turn off email verification if no email client

### DIFF
--- a/dashboard/src/main/Main.tsx
+++ b/dashboard/src/main/Main.tsx
@@ -142,7 +142,7 @@ export default class Main extends Component<PropsType, StateType> {
           path="/register"
           render={() => {
             if (!this.state.isLoggedIn) {
-              return <Register authenticate={this.initialize} />;
+              return <Register authenticate={this.authenticate} />;
             } else {
               return <Redirect to="/" />;
             }

--- a/internal/forms/user.go
+++ b/internal/forms/user.go
@@ -19,6 +19,9 @@ type CreateUserForm struct {
 	WriteUserForm
 	Email    string `json:"email" form:"required,max=255,email"`
 	Password string `json:"password" form:"required,max=255"`
+
+	// ignore this field from the json
+	EmailVerified bool `json:"-"`
 }
 
 // ToUser converts a CreateUserForm to models.User
@@ -30,8 +33,9 @@ func (cuf *CreateUserForm) ToUser(_ repository.UserRepository) (*models.User, er
 	}
 
 	return &models.User{
-		Email:    cuf.Email,
-		Password: string(hashed),
+		Email:         cuf.Email,
+		Password:      string(hashed),
+		EmailVerified: cuf.EmailVerified,
 	}, nil
 }
 

--- a/server/api/oauth_github_handler.go
+++ b/server/api/oauth_github_handler.go
@@ -222,7 +222,7 @@ func (app *App) upsertUserFromToken(tok *oauth2.Token) (*models.User, error) {
 		if err == gorm.ErrRecordNotFound {
 			user = &models.User{
 				Email:         primary,
-				EmailVerified: verified,
+				EmailVerified: !app.Capabilities.Email || verified,
 				GithubUserID:  githubUser.GetID(),
 			}
 

--- a/server/api/oauth_google_handler.go
+++ b/server/api/oauth_google_handler.go
@@ -146,7 +146,7 @@ func (app *App) upsertGoogleUserFromToken(tok *oauth2.Token) (*models.User, erro
 		if err == gorm.ErrRecordNotFound {
 			user = &models.User{
 				Email:         gInfo.Email,
-				EmailVerified: gInfo.EmailVerified,
+				EmailVerified: !app.Capabilities.Email || gInfo.EmailVerified,
 				GoogleUserID:  gInfo.Sub,
 			}
 

--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -3,12 +3,13 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"gorm.io/gorm"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+
+	"gorm.io/gorm"
 
 	"github.com/porter-dev/porter/internal/analytics"
 	"github.com/porter-dev/porter/internal/kubernetes/prometheus"

--- a/server/api/user_handler.go
+++ b/server/api/user_handler.go
@@ -39,7 +39,10 @@ func (app *App) HandleCreateUser(w http.ResponseWriter, r *http.Request) {
 		app.handleErrorDataRead(err, w)
 	}
 
-	form := &forms.CreateUserForm{}
+	form := &forms.CreateUserForm{
+		// if app can send email verification, set the email verified to false
+		EmailVerified: !app.Capabilities.Email,
+	}
 
 	user, err := app.writeUser(
 		form,

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/google/go-github/github"
-	"github.com/porter-dev/porter/internal/oauth"
-	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/porter-dev/porter/internal/oauth"
+	"golang.org/x/oauth2"
 
 	"github.com/go-chi/chi"
 	"github.com/gorilla/sessions"
@@ -215,6 +216,14 @@ func (auth *Auth) DoesUserHaveProjectAccess(
 				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 				return
 			}
+		}
+
+		// read the user and make sure the email is verified
+		user, err := auth.repo.User.ReadUser(userID)
+
+		if err != nil || !user.EmailVerified {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
 		}
 
 		// get the project


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): be able to turn off email verification for locally runnable + dev versions

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Email verification is always on. 

## What is the new behavior?

If there's no email client, turn email verification off. 

## Technical Spec/Implementation Notes

To test: remove email env variables and make sure new users don't require verification. 