### PR TITLE
[Bugfix] Apps deployed without github application cannot update secrets

### DIFF
--- a/internal/models/gitrepo.go
+++ b/internal/models/gitrepo.go
@@ -62,7 +62,10 @@ type GitActionConfig struct {
 	ImageRepoURI string `json:"image_repo_uri"`
 
 	// The git installation ID
-	GithubInstallationID uint `json:"git_repo_id"`
+	GithubInstallationID uint `json:"git_installation_id"`
+
+	// The git repo ID (legacy field)
+	GitRepoID uint `json:"git_repo_id"`
 
 	// The path to the dockerfile in the git repo
 	DockerfilePath string `json:"dockerfile_path"`

--- a/server/api/deploy_handler.go
+++ b/server/api/deploy_handler.go
@@ -352,7 +352,7 @@ func (app *App) HandleUninstallTemplate(w http.ResponseWriter, r *http.Request) 
 
 				yaml.Unmarshal(rawValues, cEnv)
 
-				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GithubInstallationID)
+				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GitRepoID)
 
 				if err != nil {
 					if err != gorm.ErrRecordNotFound {

--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -1028,7 +1028,7 @@ func (app *App) HandleUpgradeRelease(w http.ResponseWriter, r *http.Request) {
 
 				yaml.Unmarshal([]byte(form.Values), cEnv)
 
-				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GithubInstallationID)
+				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GitRepoID)
 
 				if err != nil {
 					if err != gorm.ErrRecordNotFound {
@@ -1408,7 +1408,7 @@ func (app *App) HandleRollbackRelease(w http.ResponseWriter, r *http.Request) {
 
 				yaml.Unmarshal(rawValues, cEnv)
 
-				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GithubInstallationID)
+				gr, err := app.Repo.GitRepo.ReadGitRepo(gitAction.GitRepoID)
 
 				if err != nil {
 					if err != gorm.ErrRecordNotFound {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Apps deployed without github application cannot update secrets

## What is the new behavior?

Apps deployed without github application can update secrets

## Technical Spec/Implementation Notes

Issue was with renaming a column in the orm
