### PR TITLE
[0.7.0] [FIX] - Use environment protocol and host to display webhook url

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/SettingsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/SettingsSection.tsx
@@ -185,7 +185,11 @@ const SettingsSection: React.FC<PropsType> = ({
       return;
     }
 
-    const curlWebhook = `curl -X POST 'https://dashboard.getporter.dev/api/webhooks/deploy/${webhookToken}?commit=YOUR_COMMIT_HASH'`;
+    const protocol = window.location.protocol == "https:" ? "https" : "http";
+
+    const url = `${protocol}://${window.location.host}`;
+
+    const curlWebhook = `curl -X POST '${url}/api/webhooks/deploy/${webhookToken}?commit=YOUR_COMMIT_HASH'`;
 
     const isAuthorizedToCreateWebhook = isAuthorized("application", "", [
       "get",


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Webhook URL to redeploy applications was dashboard.porter.run even if the dashboard was hosted under other domain

Issue Number: N/A


## What is the new behavior?

Get the URL from the same domain and same protocol as where the dashboard is hosted from
![image](https://user-images.githubusercontent.com/23369263/127061067-6b9aef72-6205-4601-8d62-4a8d1bf70bd0.png)

