### PR TITLE
[0.6.1] CLI fixes to add as patch

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -56,7 +56,6 @@ var logoutCmd = &cobra.Command{
 	},
 }
 
-var token string = ""
 var manual bool = false
 
 func init() {
@@ -80,27 +79,39 @@ func login() error {
 	user, _ := client.AuthCheck(context.Background())
 
 	if user != nil {
+		// set the token if the user calls login with the --token flag or the PORTER_TOKEN env
 		if config.Token != "" {
-			// set the token if the user calls login with the --token flag
 			config.SetToken(config.Token)
 			color.New(color.FgGreen).Println("Successfully logged in!")
 
-			projID, err := api.GetProjectIDFromToken(config.Token)
+			projID, exists, err := api.GetProjectIDFromToken(config.Token)
 
 			if err != nil {
 				return err
 			}
 
-			err = config.SetProject(projID)
+			// if project ID does not exist for the token, this is a user-issued CLI token, so the project
+			// ID should be queried
+			if !exists {
+				err = setProjectForUser(client, user.ID)
 
-			if err != nil {
-				return err
-			}
+				if err != nil {
+					return err
+				}
+			} else {
+				// if the project ID does exist for the token, this is a project-issued token, and
+				// the project should be set automatically
+				err = config.SetProject(projID)
 
-			err = setProjectCluster(client, projID)
+				if err != nil {
+					return err
+				}
 
-			if err != nil {
-				return err
+				err = setProjectCluster(client, projID)
+
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			color.Yellow("You are already logged in. If you'd like to log out, run \"porter auth logout\".")
@@ -114,78 +125,46 @@ func login() error {
 		return loginManual()
 	}
 
-	// check for a token
-	var err error
+	// log the user in
+	token, err := loginBrowser.Login(config.Host)
 
-	if token == "" {
-		token, err = loginBrowser.Login(config.Host)
+	if err != nil {
+		return err
+	}
 
-		if err != nil {
-			return err
-		}
+	// set the token in config
+	err = config.SetToken(token)
 
-		// set the token in config
-		err = config.SetToken(token)
+	if err != nil {
+		return err
+	}
 
-		if err != nil {
-			return err
-		}
+	client = api.NewClientWithToken(config.Host+"/api", token)
 
-		client := api.NewClientWithToken(config.Host+"/api", token)
+	user, err = client.AuthCheck(context.Background())
 
-		user, err := client.AuthCheck(context.Background())
+	if user == nil {
+		color.Red("Invalid token.")
+		return err
+	}
 
-		if user == nil {
-			color.Red("Invalid token.")
-			return err
-		}
+	color.New(color.FgGreen).Println("Successfully logged in!")
 
-		color.New(color.FgGreen).Println("Successfully logged in!")
+	return setProjectForUser(client, user.ID)
+}
 
-		// get a list of projects, and set the current project
-		projects, err := client.ListUserProjects(context.Background(), user.ID)
+func setProjectForUser(client *api.Client, userID uint) error {
+	// get a list of projects, and set the current project
+	projects, err := client.ListUserProjects(context.Background(), userID)
 
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 
-		if len(projects) > 0 {
-			config.SetProject(projects[0].ID)
+	if len(projects) > 0 {
+		config.SetProject(projects[0].ID)
 
-			err = setProjectCluster(client, projects[0].ID)
-
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		// set the token in config
-		err = config.SetToken(token)
-
-		if err != nil {
-			return err
-		}
-
-		client := api.NewClientWithToken(config.Host+"/api", token)
-
-		user, err := client.AuthCheck(context.Background())
-
-		if user == nil {
-			color.Red("Invalid token.")
-			return err
-		}
-
-		color.New(color.FgGreen).Println("Successfully logged in!")
-
-		projID, err := api.GetProjectIDFromToken(token)
-
-		if err != nil {
-			return err
-		}
-
-		config.SetProject(projID)
-
-		err = setProjectCluster(client, projID)
+		err = setProjectCluster(client, projects[0].ID)
 
 		if err != nil {
 			return err

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -91,7 +91,17 @@ func login() error {
 				return err
 			}
 
-			config.SetProject(projID)
+			err = config.SetProject(projID)
+
+			if err != nil {
+				return err
+			}
+
+			err = setProjectCluster(client, projID)
+
+			if err != nil {
+				return err
+			}
 		} else {
 			color.Yellow("You are already logged in. If you'd like to log out, run \"porter auth logout\".")
 		}
@@ -141,6 +151,12 @@ func login() error {
 
 		if len(projects) > 0 {
 			config.SetProject(projects[0].ID)
+
+			err = setProjectCluster(client, projects[0].ID)
+
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		// set the token in config
@@ -168,6 +184,12 @@ func login() error {
 		}
 
 		config.SetProject(projID)
+
+		err = setProjectCluster(client, projID)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -215,6 +237,12 @@ func loginManual() error {
 
 	if len(projects) > 0 {
 		config.SetProject(projects[0].ID)
+
+		err = setProjectCluster(client, projects[0].ID)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -91,10 +91,10 @@ func NewDeployAgent(client *api.Client, app string, opts *DeployOpts) (*DeployAg
 			// is docker
 			if release.GitActionConfig.DockerfilePath != "" {
 				deployAgent.opts.Method = DeployBuildTypeDocker
+			} else {
+				// otherwise build type is pack
+				deployAgent.opts.Method = DeployBuildTypePack
 			}
-
-			// otherwise build type is pack
-			deployAgent.opts.Method = DeployBuildTypePack
 		} else {
 			// if the git action config does not exist, we use docker by default
 			deployAgent.opts.Method = DeployBuildTypeDocker

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -299,18 +299,6 @@ func (d *DeployAgent) UpdateImageAndValues(overrideValues map[string]interface{}
 		currImageSection["tag"] = d.tag
 	}
 
-	// if opts.Kind == "web" || opts.Kind == "worker" {
-	// 	mergedValues["image"] = map[string]interface{}{
-	// 		"repository": "public.ecr.aws/o1j4x7p4/hello-porter",
-	// 		"tag":        "latest",
-	// 	}
-	// } else if opts.Kind == "job" {
-	// 	mergedValues["image"] = map[string]interface{}{
-	// 		"repository": "public.ecr.aws/o1j4x7p4/hello-porter-job",
-	// 		"tag":        "latest",
-	// 	}
-	// }
-
 	bytes, err := json.Marshal(mergedValues)
 
 	if err != nil {

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -279,9 +279,37 @@ func (d *DeployAgent) UpdateImageAndValues(overrideValues map[string]interface{}
 	// overwrite the tag based on a new image
 	currImageSection := mergedValues["image"].(map[string]interface{})
 
+	// if the current image section is hello-porter, the image must be overriden
+	if currImageSection["repository"] == "public.ecr.aws/o1j4x7p4/hello-porter" ||
+		currImageSection["repository"] == "public.ecr.aws/o1j4x7p4/hello-porter-job" {
+		newImage, err := d.getReleaseImage()
+
+		if err != nil {
+			return fmt.Errorf("could not overwrite hello-porter image: %s", err.Error())
+		}
+
+		currImageSection["repository"] = newImage
+
+		// set to latest just to be safe -- this will be overriden if "d.tag" is set in
+		// the agent
+		currImageSection["tag"] = "latest"
+	}
+
 	if d.tag != "" && currImageSection["tag"] != d.tag {
 		currImageSection["tag"] = d.tag
 	}
+
+	// if opts.Kind == "web" || opts.Kind == "worker" {
+	// 	mergedValues["image"] = map[string]interface{}{
+	// 		"repository": "public.ecr.aws/o1j4x7p4/hello-porter",
+	// 		"tag":        "latest",
+	// 	}
+	// } else if opts.Kind == "job" {
+	// 	mergedValues["image"] = map[string]interface{}{
+	// 		"repository": "public.ecr.aws/o1j4x7p4/hello-porter-job",
+	// 		"tag":        "latest",
+	// 	}
+	// }
 
 	bytes, err := json.Marshal(mergedValues)
 

--- a/cli/cmd/login/server.go
+++ b/cli/cmd/login/server.go
@@ -19,9 +19,15 @@ func redirect(
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprint(w, successScreen)
 
-		queryParams, _ := url.ParseQuery(r.URL.RawQuery)
+		queryParams, err := url.ParseQuery(r.URL.RawQuery)
 
-		codechan <- queryParams["code"][0]
+		if err != nil {
+			return
+		}
+
+		if codeParam, exists := queryParams["code"]; exists && len(codeParam) > 0 {
+			codechan <- queryParams["code"][0]
+		}
 	}
 }
 

--- a/cli/cmd/project.go
+++ b/cli/cmd/project.go
@@ -140,3 +140,17 @@ func deleteProject(_ *api.AuthCheckResponse, client *api.Client, args []string) 
 
 	return nil
 }
+
+func setProjectCluster(client *api.Client, projectID uint) error {
+	clusters, err := client.ListProjectClusters(context.Background(), projectID)
+
+	if err != nil {
+		return err
+	}
+
+	if len(clusters) > 0 {
+		config.SetCluster(clusters[0].ID)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.9
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/aws/aws-sdk-go v1.35.4
-	github.com/bradleyfalzon/ghinstallation v1.1.1 // indirect
+	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/buildpacks/pack v0.19.0
 	github.com/cli/cli v1.11.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -28,7 +28,7 @@ require (
 	github.com/google/go-github/v29 v29.0.3 // indirect
 	github.com/google/go-github/v33 v33.0.0
 	github.com/google/go-querystring v1.1.0 // indirect
-  github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/schema v1.2.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix: multiple
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Several issues:
1. `porter update` called on `hello-porter` deployments do not update the image
2. Build method is incorrectly set to `pack` when a path to the dockerfile is set, and `--method` is not explicitly set
3. Cluster ID should be set automatically when project ID is set after login
4. Error trace resembling the following after `porter auth login`:

```
net/http.(*conn).serve.func1(0xc000b98dc0)
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:1801 +0x147
panic(0x667f300, 0xc000d3e140)
        /usr/local/Cellar/go/1.15.5/libexec/src/runtime/panic.go:975 +0x47a
github.com/porter-dev/porter/cli/cmd/login.redirect.func1(0x6c69ac0, 0xc000990000, 0xc000555000)
        /Users/abelanger/porter/porter-server/cli/cmd/login/server.go:26 +0x311
net/http.HandlerFunc.ServeHTTP(0xc000d7c000, 0x6c69ac0, 0xc000990000, 0xc000555000)
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:2042 +0x44
net/http.(*ServeMux).ServeHTTP(0x7eefb20, 0x6c69ac0, 0xc000990000, 0xc000555000)
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:2417 +0x1ad
net/http.serverHandler.ServeHTTP(0xc000e14000, 0x6c69ac0, 0xc000990000, 0xc000555000)
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc000b98dc0, 0x6c79340, 0xc00072dc00)
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
        /usr/local/Cellar/go/1.15.5/libexec/src/net/http/server.go:2969 +0x36c
```

5. Better casing when login is called via a `--token` flag. 

## What is the new behavior?

Fixes the issues above. 

## Technical Spec/Implementation Notes

For point 4, the issue was that the browser listener (`redirect` function in `/cli/cmd/login`) was not casing on if a `code` param exists or not, and was called once with a code, and once without. 
