### PR TITLE
[0.7.0] Fix WSL issues on auth login

### DIFF
--- a/cli/cmd/login/server.go
+++ b/cli/cmd/login/server.go
@@ -57,7 +57,6 @@ func Login(
 	// open browser for host login
 	var redirectHost string
 	if utils.CheckIfWsl() {
-		fmt.Println("Got till here")
 		redirectHost = fmt.Sprintf("http://%s:%d", utils.GetWslHostName(), port)
 	} else {
 		redirectHost = fmt.Sprintf("http://localhost:%d", port)

--- a/cli/cmd/login/server.go
+++ b/cli/cmd/login/server.go
@@ -55,7 +55,14 @@ func Login(
 	}()
 
 	// open browser for host login
-	redirectHost := fmt.Sprintf("http://localhost:%d", port)
+	var redirectHost string
+	if utils.CheckIfWsl() {
+		fmt.Println("Got till here")
+		redirectHost = fmt.Sprintf("http://%s:%d", utils.GetWslHostName(), port)
+	} else {
+		redirectHost = fmt.Sprintf("http://localhost:%d", port)
+	}
+
 	loginURL := fmt.Sprintf("%s/api/cli/login?redirect=%s", host, url.QueryEscape(redirectHost))
 
 	err = utils.OpenBrowser(loginURL)

--- a/cli/cmd/utils/browser.go
+++ b/cli/cmd/utils/browser.go
@@ -1,22 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"os/exec"
-	"regexp"
 	"runtime"
 )
-
-func checkIfWsl() bool {
-	out, err := exec.Command("uname", "-a").Output()
-	if err != nil {
-		return false
-	}
-	// On some cases, uname on wsl outputs microsoft capitalized
-	if matched, err := regexp.Match(`microsoft|Microsoft`, out); err != nil {
-		return matched
-	}
-	return false
-}
 
 // OpenBrowser opens the specified URL in the default browser of the user.
 func OpenBrowser(url string) error {
@@ -30,12 +18,14 @@ func OpenBrowser(url string) error {
 	case "darwin":
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		if checkIfWsl() {
-			cmd = "explorer.exe"
+		if CheckIfWsl() {
+			cmd = "cmd.exe"
+			args = []string{"/c", "start"}
 		} else {
 			cmd = "xdg-open"
 		}
 	}
+	fmt.Println(url)
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()
 }

--- a/cli/cmd/utils/browser.go
+++ b/cli/cmd/utils/browser.go
@@ -2,8 +2,21 @@ package utils
 
 import (
 	"os/exec"
+	"regexp"
 	"runtime"
 )
+
+func checkIfWsl() bool {
+	out, err := exec.Command("uname", "-a").Output()
+	if err != nil {
+		return false
+	}
+	// On some cases, uname on wsl outputs microsoft capitalized
+	if matched, err := regexp.Match(`microsoft|Microsoft`, out); err != nil {
+		return matched
+	}
+	return false
+}
 
 // OpenBrowser opens the specified URL in the default browser of the user.
 func OpenBrowser(url string) error {
@@ -17,7 +30,11 @@ func OpenBrowser(url string) error {
 	case "darwin":
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
+		if checkIfWsl() {
+			cmd = "explorer.exe"
+		} else {
+			cmd = "xdg-open"
+		}
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()

--- a/cli/cmd/utils/browser.go
+++ b/cli/cmd/utils/browser.go
@@ -11,6 +11,8 @@ func OpenBrowser(url string) error {
 	var cmd string
 	var args []string
 
+	fmt.Printf("Attempting to open your browser. If this does not work, please navigate to: %s", url)
+
 	switch runtime.GOOS {
 	case "windows":
 		cmd = "cmd"
@@ -25,7 +27,7 @@ func OpenBrowser(url string) error {
 			cmd = "xdg-open"
 		}
 	}
-	fmt.Println(url)
+
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()
 }

--- a/cli/cmd/utils/wsl.go
+++ b/cli/cmd/utils/wsl.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// Checks based on uname if the linux environment is under wsl or not
+func CheckIfWsl() bool {
+	out, err := exec.Command("uname", "-a").Output()
+	if err != nil {
+		return false
+	}
+	// On some cases, uname on wsl outputs microsoft capitalized
+	matched, _ := regexp.Match(`microsoft|Microsoft`, out)
+	return matched
+}
+
+// Gets the subsystem host ip
+// If the CLI is running under WSL the localhost url will not work so
+// this function should return the real ip that we should redirect to
+func GetWslHostName() string {
+	out, err := exec.Command("wsl.exe", "hostname", "-I").Output()
+	if err != nil {
+		return "localhost"
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If the CLI is running under WSL is common to find issues when trying to open the browser or even on the redirection from login if opening the browser is solved.

## What is the new behavior?

Added functions to retrieve if the CLI is running under WSL and if so, use correct commands for opening the browser or to assign correctly the redirection url

## Technical Spec/Implementation Notes

For checking if the user is running under WSL I used the uname -a command and check if it has "microsoft" in it. 

And for getting the host url the provided solution by wsl is using `wsl.exe hostname -I` from inside wsl to get the exact IP on where the subsystem is running.
