### PR TITLE
[0.7.0] Fix empty selector query on metrics tab

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
@@ -187,6 +187,10 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
 
     setIsLoading((prev) => prev + 1);
 
+    if (selectors[0] === "") {
+      return;
+    }
+
     api
       .getMatchingPods(
         "<token>",


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

On some occasions, the metrics tab would query all the pods on the cluster due to a empty selectors query param

Issue Number: Closes #962 

## What is the new behavior?

Avoid making the pod query if no selectors is present.

## Technical Spec/Implementation Notes
