### PR TITLE
[0.7.0] - Fix eternal loading on metrics

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricsSection.tsx
@@ -184,13 +184,14 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       }
       i += 1;
     }
-    selectors.push(selector);
 
-    setIsLoading((prev) => prev + 1);
+    selectors.push(selector);
 
     if (selectors[0] === "") {
       return;
     }
+
+    setIsLoading((prev) => prev + 1);
 
     api
       .getMatchingPods(


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If there's an intent of making a query with no selectors, the is loading variable inside the metrics section will remain in true state


## What is the new behavior?

Fixed the eternal loading by preventing innecesary sums into the isLoading counter

## Technical Spec/Implementation Notes
