### PR TITLE
[0.8.0] Detailed Slack error notifications

### DIFF
--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -1029,8 +1029,10 @@ func (app *App) HandleUpgradeRelease(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		notifyOpts.Status = slack.StatusFailed
+		notifyOpts.Info = err.Error()
 
-		notifier.Notify(notifyOpts)
+		slackErr := notifier.Notify(notifyOpts)
+		fmt.Println("SLACK ERROR IS", slackErr)
 
 		app.sendExternalError(err, http.StatusInternalServerError, HTTPError{
 			Code:   ErrReleaseDeploy,
@@ -1252,6 +1254,7 @@ func (app *App) HandleReleaseDeployWebhook(w http.ResponseWriter, r *http.Reques
 
 	if err != nil {
 		notifyOpts.Status = slack.StatusFailed
+		notifyOpts.Info = err.Error()
 
 		notifier.Notify(notifyOpts)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Slack notifications are not very detailed:

![image](https://user-images.githubusercontent.com/25448214/129037718-307d3ad7-7f7c-41e7-b210-22936129c734.png)

## What is the new behavior?

Add some detailed error messages to accompany the notification:

![image](https://user-images.githubusercontent.com/25448214/129037799-7d1fc594-e096-4fb7-bfa7-3bd1729dfbf1.png)

## Technical Spec/Implementation Notes

Unfortunately some errors thrown by the API server/Helm are extremely ugly and could potentially write environment variables to Slack (not "secret" env variables, but env variables that exist in the deployment manifests). I truncated the error messages to 200 characters and did some minor casing for those types of "unmarshalerDecoder" errors, but it is far from perfect. 