### PR TITLE
[0.8.0] `porter run` fixes

### DIFF
--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -96,13 +96,17 @@ func logs(_ *api.AuthCheckResponse, client *api.Client, args []string) error {
 		selectedContainerName = selectedContainer
 	}
 
-	restConf, err := getRESTConfig(client)
+	config := &PorterRunSharedConfig{
+		Client: client,
+	}
+
+	err = config.setSharedConfig()
 
 	if err != nil {
 		return fmt.Errorf("Could not retrieve kube credentials: %s", err.Error())
 	}
 
-	_, err = pipePodLogsToStdout(restConf, namespace, selectedPod.Name, selectedContainerName, follow)
+	_, err = pipePodLogsToStdout(config, namespace, selectedPod.Name, selectedContainerName, follow)
 
 	return err
 }

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -102,5 +102,7 @@ func logs(_ *api.AuthCheckResponse, client *api.Client, args []string) error {
 		return fmt.Errorf("Could not retrieve kube credentials: %s", err.Error())
 	}
 
-	return pipePodLogsToStdout(restConf, namespace, selectedPod.Name, selectedContainerName, follow)
+	_, err = pipePodLogsToStdout(restConf, namespace, selectedPod.Name, selectedContainerName, follow)
+
+	return err
 }

--- a/cli/cmd/utils/browser.go
+++ b/cli/cmd/utils/browser.go
@@ -11,7 +11,7 @@ func OpenBrowser(url string) error {
 	var cmd string
 	var args []string
 
-	fmt.Printf("Attempting to open your browser. If this does not work, please navigate to: %s", url)
+	fmt.Printf("Attempting to open your browser. If this does not work, please navigate to: %s\n", url)
 
 	switch runtime.GOOS {
 	case "windows":


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe): modifications to `porter run` behavior

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Several issues:
- Removed `nodeName` from ephemeral pod spec, so that pods can be scheduled on any available node
- When TTY fails and logs aren't available for a pod, it will show the pod events (for example, if no node has enough memory for the pod) 
- Refresh the kubeconfig/client for deleting the ephemeral pod, to guarantee deletion

## What is the new behavior?

Fixes the three issues above. 

## Technical Spec/Implementation Notes
