### PR TITLE
[0.8.0] Remove probes from `porter run`

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -445,6 +445,9 @@ func createPodFromExisting(config *PorterRunSharedConfig, existing *v1.Pod, args
 
 	newPod.Status = v1.PodStatus{}
 
+	// only use "primary" container
+	newPod.Spec.Containers = newPod.Spec.Containers[0:1]
+
 	// set restart policy to never
 	newPod.Spec.RestartPolicy = v1.RestartPolicyNever
 
@@ -462,6 +465,11 @@ func createPodFromExisting(config *PorterRunSharedConfig, existing *v1.Pod, args
 	newPod.Spec.Containers[0].Stdin = true
 	newPod.Spec.Containers[0].StdinOnce = true
 	newPod.Spec.NodeName = ""
+
+	// remove health checks and probes
+	newPod.Spec.Containers[0].LivenessProbe = nil
+	newPod.Spec.Containers[0].ReadinessProbe = nil
+	newPod.Spec.Containers[0].StartupProbe = nil
 
 	// create the pod and return it
 	return config.Clientset.CoreV1().Pods(existing.ObjectMeta.Namespace).Create(


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When a pod is copied with healthchecks, the ephemeral pod created by `porter run` will be terminated unexpectedly due to health checks being enabled. 

## What is the new behavior?

Remove health checks. 

## Technical Spec/Implementation Notes
