### PR TITLE
[0.8.0] Add `--registry-url` option to `porter create` command

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -74,6 +74,7 @@ var name string
 var values string
 var source string
 var image string
+var registryURL string
 
 func init() {
 	rootCmd.AddCommand(createCmd)
@@ -137,6 +138,13 @@ func init() {
 		"",
 		"if the source is \"registry\", the image to use, in repository:tag format",
 	)
+
+	createCmd.PersistentFlags().StringVar(
+		&registryURL,
+		"registry-url",
+		"",
+		"the registry URL to use (must exist in \"porter registries list\")",
+	)
 }
 
 var supportedKinds = map[string]string{"web": "", "job": "", "worker": ""}
@@ -183,6 +191,7 @@ func createFull(resp *api.AuthCheckResponse, client *api.Client, args []string) 
 			},
 			Kind:        args[0],
 			ReleaseName: name,
+			RegistryURL: registryURL,
 		},
 	}
 

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -25,6 +25,7 @@ type CreateOpts struct {
 
 	Kind        string
 	ReleaseName string
+	RegistryURL string
 }
 
 // GithubOpts are the options for linking a Github source to the app
@@ -367,7 +368,13 @@ func (c *CreateAgent) GetImageRepoURL(name, namespace string) (uint, string, err
 	var regID uint
 
 	for _, reg := range registries {
-		if reg.URL != "" {
+		if c.CreateOpts.RegistryURL != "" {
+			if c.CreateOpts.RegistryURL == reg.URL {
+				regID = reg.ID
+				imageURI = fmt.Sprintf("%s/%s-%s", reg.URL, name, namespace)
+				break
+			}
+		} else if reg.URL != "" {
 			regID = reg.ID
 			imageURI = fmt.Sprintf("%s/%s-%s", reg.URL, name, namespace)
 			break

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Version will be linked by an ldflag during build
-var Version string = "v0.5.0"
+var Version string = "v0.8.0"
 
 var versionCmd = &cobra.Command{
 	Use:     "version",


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No option to select which registry URL to use. 

## What is the new behavior?

Give the option to select with registry URL to use. Required when attempting to debug GCR issue. 

## Technical Spec/Implementation Notes
