### PR TITLE
[0.8.0] Show status of last run in Jobs list

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -159,7 +159,7 @@ const Chart: React.FunctionComponent<Props> = ({
       </BottomWrapper>
 
       <TopRightContainer>
-        {isJob && jobStatus && (
+        {isJob && jobStatus?.status && (
           <>
             <JobStatus status={jobStatus.status}>
               Last run {jobStatus.status.toUpperCase()} at{" "}

--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -241,6 +241,7 @@ const ChartList: React.FunctionComponent<Props> = ({
           key={`${chart.namespace}-${chart.name}`}
           chart={chart}
           controllers={controllers || {}}
+          isJob={currentView === "jobs"}
           release={releases[chart.name] || {}}
         />
       );

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -542,6 +542,15 @@ const getJobs = baseApi<
   return `/api/projects/${pathParams.id}/k8s/${pathParams.namespace}/${pathParams.chart}/${pathParams.release_name}/jobs`;
 });
 
+const getJobStatus = baseApi<
+  {
+    cluster_id: number;
+  },
+  { name: string; namespace: string; id: number }
+>("GET", (pathParams) => {
+  return `/api/projects/${pathParams.id}/k8s/${pathParams.namespace}/${pathParams.name}/jobs/status`;
+});
+
 const getJobPods = baseApi<
   {
     cluster_id: number;
@@ -1062,6 +1071,7 @@ export default {
   getIngress,
   getInvites,
   getJobs,
+  getJobStatus,
   getJobPods,
   getMatchingPods,
   getMetrics,

--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -602,7 +602,8 @@ func (app *App) HandleGetReleaseAllPods(w http.ResponseWriter, r *http.Request) 
 }
 
 type GetJobStatusResult struct {
-	Status string `json:"status"`
+	Status    string       `json:"status"`
+	StartTime *metav1.Time `json:"start_time"`
 }
 
 // HandleGetJobStatus gets the status for a specific job
@@ -707,6 +708,8 @@ func (app *App) HandleGetJobStatus(w http.ResponseWriter, r *http.Request) {
 				mostRecentJob = job
 			}
 		}
+
+		res.StartTime = mostRecentJob.Status.StartTime
 
 		// get the status of the most recent job
 		if mostRecentJob.Status.Succeeded >= 1 {

--- a/server/api/release_handler.go
+++ b/server/api/release_handler.go
@@ -602,8 +602,8 @@ func (app *App) HandleGetReleaseAllPods(w http.ResponseWriter, r *http.Request) 
 }
 
 type GetJobStatusResult struct {
-	Status    string       `json:"status"`
-	StartTime *metav1.Time `json:"start_time"`
+	Status    string       `json:"status,omitempty"`
+	StartTime *metav1.Time `json:"start_time,omitempty"`
 }
 
 // HandleGetJobStatus gets the status for a specific job
@@ -693,9 +693,7 @@ func (app *App) HandleGetJobStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := &GetJobStatusResult{
-		Status: "succeeded",
-	}
+	res := &GetJobStatusResult{}
 
 	// get the most recent job
 	if len(jobs) > 0 {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

User must click on a Job to see the status of its last run

## What is the new behavior?

For each job, the status of its last run will be shown on the Job List page.

![image](https://user-images.githubusercontent.com/44864521/129747228-8aeb67f7-7a8e-4881-9300-77e2ae2dbf0a.png)


Styling
- For failed runs: red, bold
- For successful runs: green, bold
- For running runs: same as version text
- For deleting runs: same as version text

## Technical Spec/Implementation Notes
