### PR TITLE
[0.8.0] Allow filtering jobs by Last Run Status

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/ClusterDashboard.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/ClusterDashboard.tsx
@@ -134,6 +134,15 @@ class ClusterDashboard extends Component<PropsType, StateType> {
     return (
       <>
         <ControlRow>
+          {isAuthorizedToAdd && (
+            <Button
+              onClick={() =>
+                pushFiltered(this.props, "/launch", ["project_id"])
+              }
+            >
+              <i className="material-icons">add</i> Launch Template
+            </Button>
+          )}
           <SortFilterWrapper>
             {currentView === "jobs" && (
               <LastRunStatusSelector
@@ -158,15 +167,6 @@ class ClusterDashboard extends Component<PropsType, StateType> {
               sortType={this.state.sortType}
             />
           </SortFilterWrapper>
-          {isAuthorizedToAdd && (
-            <Button
-              onClick={() =>
-                pushFiltered(this.props, "/launch", ["project_id"])
-              }
-            >
-              <i className="material-icons">add</i> Launch Template
-            </Button>
-          )}
         </ControlRow>
 
         <ChartList
@@ -251,7 +251,7 @@ const Br = styled.div`
 
 const ControlRow = styled.div`
   display: flex;
-  flex-direction: row-reverse;
+  margin-left: auto;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 35px;

--- a/dashboard/src/main/home/cluster-dashboard/LastRunStatusSelector.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/LastRunStatusSelector.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import styled from "styled-components";
+
+import Selector from "components/Selector";
+import { JobStatus } from "shared/types";
+
+type PropsType = {
+  lastRunStatus: JobStatus;
+  setLastRunStatus: (lastRunStatus: JobStatus) => void;
+};
+
+const LastRunStatusSelector = (props: PropsType) => {
+  const options = [
+    {
+      label: "All",
+      value: null,
+    },
+  ].concat(
+    Object.entries(JobStatus).map((status) => ({
+      label: status[0],
+      value: status[1],
+    }))
+  );
+
+  return (
+    <StyledLastRunStatusSelector>
+      <Label>
+        <i className="material-icons">filter_alt</i>
+        Last Run Status
+      </Label>
+      <Selector
+        activeValue={props.lastRunStatus}
+        setActiveValue={props.setLastRunStatus}
+        options={options}
+        dropdownLabel="Last Run Status"
+        width="150px"
+        dropdownWidth="230px"
+        closeOverlay={true}
+      />
+    </StyledLastRunStatusSelector>
+  );
+};
+
+export default LastRunStatusSelector;
+
+const Label = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 12px;
+
+  > i {
+    margin-right: 8px;
+    font-size: 18px;
+  }
+`;
+
+const StyledLastRunStatusSelector = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+`;

--- a/dashboard/src/main/home/cluster-dashboard/NamespaceSelector.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/NamespaceSelector.tsx
@@ -100,7 +100,7 @@ export default class NamespaceSelector extends Component<PropsType, StateType> {
     return (
       <StyledNamespaceSelector>
         <Label>
-          <i className="material-icons">filter_alt</i> Filter
+          <i className="material-icons">filter_alt</i> Namespace
         </Label>
         <Selector
           activeValue={this.props.namespace}

--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -2,7 +2,12 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useHistory, useLocation, useRouteMatch } from "react-router";
 
-import { ChartType, StorageType } from "shared/types";
+import {
+  ChartType,
+  JobStatus,
+  JobStatusWithTime,
+  StorageType,
+} from "shared/types";
 import { Context } from "shared/Context";
 import StatusIndicator from "components/StatusIndicator";
 import { pushFiltered } from "shared/routing";
@@ -13,23 +18,20 @@ type Props = {
   chart: ChartType;
   controllers: Record<string, any>;
   isJob: boolean;
+  setJobLastRunStatus: any;
   release: any;
-};
-
-type JobStatusType = {
-  status: "succeeded" | "running" | "failed";
-  start_time: string;
 };
 
 const Chart: React.FunctionComponent<Props> = ({
   chart,
   controllers,
   isJob,
+  setJobLastRunStatus,
   release,
 }) => {
   const [expand, setExpand] = useState<boolean>(false);
   const [chartControllers, setChartControllers] = useState<any>([]);
-  const [jobStatus, setJobStatus] = useState<JobStatusType>(null);
+  const [jobStatus, setJobStatus] = useState<JobStatusWithTime>(null);
   const context = useContext(Context);
   const location = useLocation();
   const history = useHistory();
@@ -121,6 +123,7 @@ const Chart: React.FunctionComponent<Props> = ({
       )
       .then((res) => {
         setJobStatus(res.data);
+        setJobLastRunStatus(res.data.status);
       })
       .catch((err) => setCurrentError(err));
   };
@@ -195,10 +198,10 @@ const Chart: React.FunctionComponent<Props> = ({
       <TopRightContainer>
         {isJob && jobStatus?.status && (
           <>
-            <JobStatus status={jobStatus.status}>
+            <JobStatusContainer status={jobStatus.status}>
               Last run {jobStatus.status.toUpperCase()} at{" "}
               {readableDate(jobStatus.start_time)}
-            </JobStatus>
+            </JobStatusContainer>
             <StatusDot>•</StatusDot>
           </>
         )}
@@ -331,13 +334,13 @@ const Title = styled.div`
   }
 `;
 
-const JobStatus = styled.span`
+const JobStatusContainer = styled.span`
   font-weight: bold;
-  ${(props: { status: string }) => `
+  ${(props: { status: JobStatus }) => `
   color: ${
-    props.status === "succeeded"
+    props.status === JobStatus.Succeeded
       ? "rgb(56, 168, 138)"
-      : props.status === "failed"
+      : props.status === JobStatus.Failed
       ? "rgb(204, 61, 66)"
       : "#aaaabb"
   }

--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -210,7 +210,7 @@ const ChartList: React.FunctionComponent<Props> = ({
       });
     }
     return () => (isSubscribed = false);
-  }, [namespace, currentView]);
+  }, [sortType, namespace, currentView]);
 
   const renderChartList = () => {
     if (isLoading || (!namespace && namespace !== "")) {

--- a/dashboard/src/shared/types.tsx
+++ b/dashboard/src/shared/types.tsx
@@ -266,6 +266,17 @@ export interface FullActionConfigType extends ActionConfigType {
   should_create_workflow: boolean;
 }
 
+export enum JobStatus {
+  Succeeded = "succeeded",
+  Running = "running",
+  Failed = "failed",
+}
+
+export type JobStatusWithTime = {
+  status: JobStatus;
+  start_time: string;
+};
+
 export interface CapabilityType {
   github: boolean;
   provisioner: boolean;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

n/a

## What is the new behavior?

Users can filter jobs by the status of their last run


https://user-images.githubusercontent.com/44864521/130279761-eacb0c39-d276-4efe-8027-4fcaa53eb276.mov

## Technical Spec/Implementation Notes

very hacky