### PR TITLE
[0.8.0] Fix DO expiry value not being set

### DIFF
--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -168,7 +168,7 @@ func GetAccessToken(
 		AccessToken:  string(prevToken.AccessToken),
 		RefreshToken: string(prevToken.RefreshToken),
 		TokenType:    "Bearer",
-		Expiry:       prevToken.Expiry,
+		Expiry:       expiry,
 	})
 
 	token, err := tokSource.Token()


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

`prevToken.Expiry` was still being used. 

## What is the new behavior?

Replace with proper `expiry` variable. 

## Technical Spec/Implementation Notes
