### PR TITLE
Update deploying-from-the-cli.md

### DIFF
--- a/docs/deploy/applications/deploying-from-the-cli.md
+++ b/docs/deploy/applications/deploying-from-the-cli.md
@@ -163,7 +163,7 @@ This configuration only applies to `web` applications.
 ```yaml
 ingress:
   custom_domain: true
-  custom_paths:
+  hosts:
   - my-app.example.com
 ```
 


### PR DESCRIPTION
# Description

It seems that the [example](https://docs.porter.run/docs/deploying-from-the-cli#web-exposing-a-web-application-on-a-custom-domain) on the docs has the wrong key on the YAML, it should be `hosts` instead of `custom_paths`

# Location
- [x] Documentation
- [ ] Browser
- [ ] CLI
- [ ] API

# Steps to reproduce

1. Deploy a new app with the example `values.yaml` file exposed in the aforementioned link
2. Watch it fail
3. Deploy a new app changing the key from `custom_paths` to `hosts`

# Additional Details
