### PR TITLE
Show jobs with no runs only in "All"

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -316,9 +316,9 @@ const ChartList: React.FunctionComponent<Props> = ({
         const status: JobStatusWithTimeAndVersion = _.get(
           jobStatus,
           getChartKey(chart.name, chart.namespace),
-          null
+          { status: null } as any
         );
-        return !status || status.status === lastRunStatus;
+        return status.status === lastRunStatus;
       });
 
     if (sortType == "Newest") {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When a job has been deployed (i.e. in hello-porter image state) or has no actual "runs" associated with it, it shows up everywhere across Running/Succeeded/Failed filters

## What is the new behavior?

When a job has been deployed (i.e. in hello-porter image state) or has no actual "runs" associated with it, it shows up only in the "All" filter

## Technical Spec/Implementation Notes
