### PR TITLE
[0.9.0] Only send new user event when creating user (github login)

### DIFF
--- a/server/api/oauth_github_handler.go
+++ b/server/api/oauth_github_handler.go
@@ -133,11 +133,6 @@ func (app *App) HandleGithubOAuthCallback(w http.ResponseWriter, r *http.Request
 		// send to segment
 		app.AnalyticsClient.Identify(analytics.CreateSegmentIdentifyUser(user))
 
-		app.AnalyticsClient.Track(analytics.UserCreateTrack(&analytics.UserCreateTrackOpts{
-			UserScopedTrackOpts: analytics.GetUserScopedTrackOpts(user.ID),
-			Email:               user.Email,
-		}))
-
 		// log the user in
 		app.Logger.Info().Msgf("New user created: %d", user.ID)
 
@@ -235,6 +230,11 @@ func (app *App) upsertUserFromToken(tok *oauth2.Token) (*models.User, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			app.AnalyticsClient.Track(analytics.UserCreateTrack(&analytics.UserCreateTrackOpts{
+				UserScopedTrackOpts: analytics.GetUserScopedTrackOpts(user.ID),
+				Email:               user.Email,
+			}))
 
 			if !verified {
 				// non-fatal email verification flow


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

New user events sent on every github login. 

## What is the new behavior?

Only send on actual user creation. 

## Technical Spec/Implementation Notes
