### PR TITLE
[0.9.0] Do not remove porter token secret on app deletion

### DIFF
--- a/internal/integrations/ci/actions/actions.go
+++ b/internal/integrations/ci/actions/actions.go
@@ -136,11 +136,6 @@ func (g *GithubActions) Cleanup() error {
 		}
 	}
 
-	// delete the porter token secret
-	if err := g.deleteGithubSecret(client, g.getPorterTokenSecretName()); err != nil {
-		return err
-	}
-
 	return g.deleteGithubFile(client, g.getPorterYMLFileName())
 }
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When an app deployed from github is deleted, the PORTER_SECRET secret from github is removed.

## What is the new behavior?

This secret is no longer removed since multiple apps can potentially use it.
