### PR TITLE
[BUGFIX] - Fix aws integration id field

### DIFF
--- a/dashboard/src/main/home/provisioner/AWSFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/AWSFormSection.tsx
@@ -267,9 +267,9 @@ const AWSFormSectionFC: React.FC<PropsType> = (props) => {
       .filter(filterNonAWSInfras)
       .map((infra) => {
         if (infra.value === "ecr") {
-          return provisionECR(awsIntegrationId);
+          return provisionECR(awsIntegrationId?.id);
         }
-        return provisionEKS(awsIntegrationId);
+        return provisionEKS(awsIntegrationId?.id);
       });
     // Wait for all promises to be completed (could be just one)
     await Promise.all(infraCreationRequests);


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Aws form refactor caused issues on aws provisioning form, sending the whole object for the aws integration id instead of just the id field

## What is the new behavior?

Send just the id instead of the whole object on aws_integration_id

