### PR TITLE
[0.9.0] Add cluster check middleware to notification routes

### DIFF
--- a/server/router/router.go
+++ b/server/router/router.go
@@ -915,7 +915,11 @@ func New(a *api.App) *chi.Mux {
 				"POST",
 				"/projects/{project_id}/releases/{name}/notifications",
 				auth.DoesUserHaveProjectAccess(
-					requestlog.NewHandler(a.HandleUpdateNotificationConfig, l),
+					auth.DoesUserHaveClusterAccess(
+						requestlog.NewHandler(a.HandleUpdateNotificationConfig, l),
+						mw.URLParam,
+						mw.BodyParam,
+					),
 					mw.URLParam,
 					mw.WriteAccess,
 				),
@@ -925,7 +929,11 @@ func New(a *api.App) *chi.Mux {
 				"GET",
 				"/projects/{project_id}/releases/{name}/notifications",
 				auth.DoesUserHaveProjectAccess(
-					requestlog.NewHandler(a.HandleGetNotificationConfig, l),
+					auth.DoesUserHaveClusterAccess(
+						requestlog.NewHandler(a.HandleGetNotificationConfig, l),
+						mw.URLParam,
+						mw.BodyParam,
+					),
 					mw.URLParam,
 					mw.WriteAccess,
 				),

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -932,7 +932,7 @@ func New(a *api.App) *chi.Mux {
 					auth.DoesUserHaveClusterAccess(
 						requestlog.NewHandler(a.HandleGetNotificationConfig, l),
 						mw.URLParam,
-						mw.URLParam,
+						mw.QueryParam,
 					),
 					mw.URLParam,
 					mw.WriteAccess,

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -932,7 +932,7 @@ func New(a *api.App) *chi.Mux {
 					auth.DoesUserHaveClusterAccess(
 						requestlog.NewHandler(a.HandleGetNotificationConfig, l),
 						mw.URLParam,
-						mw.BodyParam,
+						mw.URLParam,
 					),
 					mw.URLParam,
 					mw.WriteAccess,


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.

## What is the current behavior?

Notification routes don't have a cluster middleware check

## What is the new behavior?

Notification routes now have a cluster middleware check
