### PR TITLE
[0.9.0] Improve loading time on chart

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -99,7 +99,9 @@ const Chart: React.FunctionComponent<Props> = ({
         let urlParams = new URLSearchParams(location.search);
         let cluster = urlParams.get("cluster");
         let route = `${match.url}/${cluster}/${chart.namespace}/${chart.name}`;
-        pushFiltered({ location, history }, route, ["project_id"]);
+        pushFiltered({ location, history }, route, ["project_id"], {
+          chart_revision: chart.version,
+        });
       }}
     >
       <Title>


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently, ExpandedChartWrapper makes a request for all the revisions of a specific chart to get the last revision and then makes the actual query to get the chart object. This causes really long times to get the revisions and is not performant. 

## What is the new behavior?

Improve the performance by redirecting from the chart list with the version that we need to retrieve the full chart information.
