### PR TITLE
Update ClusterInstructionsModal.tsx

### DIFF
--- a/dashboard/src/main/home/modals/ClusterInstructionsModal.tsx
+++ b/dashboard/src/main/home/modals/ClusterInstructionsModal.tsx
@@ -34,7 +34,7 @@ export default class ClusterInstructionsModal extends Component<
               <br />
               name=$(curl -s
               https://api.github.com/repos/porter-dev/porter/releases/latest |
-              grep "browser_download_url.*porter_.*_Darwin_x86_64\.zip" | cut -d
+              grep "browser_download_url.*/porter_.*_Darwin_x86_64\.zip" | cut -d
               ":" -f 2,3 | tr -d \")
               <br />
               name=$(basename $name)


### PR DESCRIPTION
Fix Regex for downloading porter CLI to be in sync with the rest of the docs.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe):
While adding an existing cluster on the Website, when instruction is presented to download porter CLI, regex is pointing to multiple binaries and `docker-credential-porter` CLI is downloaded instead of porter CLI.

The rest of the Docs are already fixed from what I saw on the Github Repo.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

-->

Current Regex greps both binaries, instead of just Porter CLI

```
$ curl -s https://api.github.com/repos/porter-dev/porter/releases/latest | grep "browser_download_url.*porter_.*_Darwin_x86_64\.zip" | cut -d ":" -f 2,3 | tr -d \"
 https://github.com/porter-dev/porter/releases/download/v0.8.5/docker-credential-porter_v0.8.5_Darwin_x86_64.zip
 https://github.com/porter-dev/porter/releases/download/v0.8.5/porter_v0.8.5_Darwin_x86_64.zip
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Docs already have the right Regex, looks like it was not updated to reflect on the Website.
https://docs.porter.run/docs/cli-documentation
```
$ curl -s https://api.github.com/repos/porter-dev/porter/releases/latest | grep "browser_download_url.*/porter_.*_Darwin_x86_64\.zip" | cut -d ":" -f 2,3 | tr -d \"
 https://github.com/porter-dev/porter/releases/download/v0.8.5/porter_v0.8.5_Darwin_x86_64.zip
```

## Technical Spec/Implementation Notes
