### PR TITLE
[POR-36] Token cache slows down dashboard

### DIFF
--- a/cmd/migrate/keyrotate/rotate.go
+++ b/cmd/migrate/keyrotate/rotate.go
@@ -143,7 +143,7 @@ func rotateClusterModel(db *_gorm.DB, oldKey, newKey *[32]byte) error {
 
 				// in these cases we'll wipe the data -- if it can't be decrypted, we can't
 				// recover it
-				if err := db.Unscoped().Where("id = ?", cluster.TokenCacheID).Delete().Error; err != nil {
+				if err := db.Unscoped().Where("id = ?", cluster.TokenCacheID).Delete(&ints.ClusterTokenCache{}).Error; err != nil {
 					return err
 				}
 				cluster.TokenCacheID = 0

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -38,7 +38,7 @@ func main() {
 		logger.Fatal().Err(err).Msg("")
 		return
 	}
-	if err := db.Raw("LTER TABLE cluster_token_caches DROP CONSTRAINT IF EXISTS fk_clusters_token_cache").Error; err != nil {
+	if err := db.Raw("ALTER TABLE cluster_token_caches DROP CONSTRAINT IF EXISTS fk_clusters_token_cache").Error; err != nil {
 		logger.Fatal().Err(err).Msg("")
 		return
 	}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -38,6 +38,10 @@ func main() {
 		logger.Fatal().Err(err).Msg("")
 		return
 	}
+	if err := db.Raw("LTER TABLE cluster_token_caches DROP CONSTRAINT IF EXISTS fk_clusters_token_cache").Error; err != nil {
+		logger.Fatal().Err(err).Msg("")
+		return
+	}
 
 	if shouldRotate, oldKeyStr, newKeyStr := shouldKeyRotate(); shouldRotate {
 		oldKey := [32]byte{}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -34,6 +34,11 @@ func main() {
 		return
 	}
 
+	if err := db.Raw("ALTER TABLE clusters DROP CONSTRAINT IF EXISTS fk_cluster_token_caches").Error; err != nil {
+		logger.Fatal().Err(err).Msg("")
+		return
+	}
+
 	if shouldRotate, oldKeyStr, newKeyStr := shouldKeyRotate(); shouldRotate {
 		oldKey := [32]byte{}
 		newKey := [32]byte{}

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -62,8 +62,8 @@ type Cluster struct {
 	DOIntegrationID   uint
 
 	// A token cache that can be used by an auth mechanism, if desired
-	TokenCache   *integrations.ClusterTokenCache `json:"token_cache" gorm:"-" sql:"-"`
-	TokenCacheID uint                            `gorm:"token_cache_id"`
+	TokenCache   integrations.ClusterTokenCache `json:"token_cache" gorm:"-" sql:"-"`
+	TokenCacheID uint                           `gorm:"token_cache_id"`
 
 	// CertificateAuthorityData for the cluster, encrypted at rest
 	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -62,7 +62,8 @@ type Cluster struct {
 	DOIntegrationID   uint
 
 	// A token cache that can be used by an auth mechanism, if desired
-	TokenCache integrations.ClusterTokenCache `json:"token_cache"`
+	TokenCache   *integrations.ClusterTokenCache `json:"token_cache" gorm:"-" sql:"-"`
+	TokenCacheID uint                            `gorm:"token_cache_id"`
 
 	// CertificateAuthorityData for the cluster, encrypted at rest
 	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`

--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -2,7 +2,6 @@ package gorm
 
 import (
 	"context"
-
 	"github.com/porter-dev/porter/internal/models"
 	"github.com/porter-dev/porter/internal/repository"
 	"gorm.io/gorm"
@@ -172,7 +171,9 @@ func (repo *ClusterRepository) ReadCluster(
 	cluster := &models.Cluster{}
 
 	// preload Clusters association
-	if err := ctxDB.Preload("TokenCache").Where("id = ?", id).First(&cluster).Error; err != nil {
+	if err := ctxDB.Debug().Preload("TokenCache", func(db *gorm.DB) *gorm.DB {
+		return db.Limit(100).Order("cluster_token_caches.updated_at DESC")
+	}).Where("id = ?", id).First(&cluster).Error; err != nil {
 		return nil, err
 	}
 
@@ -261,7 +262,7 @@ func (repo *ClusterRepository) UpdateClusterTokenCache(
 	cluster.TokenCache.Token = tokenCache.Token
 	cluster.TokenCache.Expiry = tokenCache.Expiry
 
-	if err := ctxDB.Save(cluster).Error; err != nil {
+	if err := ctxDB.Debug().Save(cluster).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -144,13 +144,9 @@ func (repo *ClusterRepository) CreateCluster(
 	}
 
 	// create a token cache by default
-	if cluster.TokenCache == nil {
-		cluster.TokenCache = &ints.ClusterTokenCache{}
-	}
-
 	cluster.TokenCache.ClusterID = cluster.ID
 
-	if err := ctxDB.Save(cluster.TokenCache).Error; err != nil {
+	if err := ctxDB.Create(&cluster.TokenCache).Error; err != nil {
 		return nil, err
 	}
 
@@ -182,9 +178,16 @@ func (repo *ClusterRepository) ReadCluster(
 		return nil, err
 	}
 
-	fmt.Println("AaaaAAJASJKSAJKJKSJKSAJKAJK")
+	fmt.Println(cluster.TokenCache)
 	fmt.Println(cluster.TokenCacheID)
-	fmt.Println(cluster.TokenCacheID)
+
+	cache := &ints.ClusterTokenCache{}
+
+	if err := ctxDB.Where("id = ?", cluster.TokenCacheID).First(&cache).Error; err != nil {
+		return nil, err
+	}
+
+	cluster.TokenCache = *cache
 
 	err := repo.DecryptClusterData(cluster, repo.key)
 

--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -273,9 +273,17 @@ func (repo *ClusterRepository) UpdateClusterTokenCache(
 			return nil, err
 		}
 	} else {
-		tokenCache.ClusterID = cluster.ID
-		tokenCache.ID = cluster.TokenCacheID
-		if err := ctxDB.Save(tokenCache).Error; err != nil {
+		prev := &ints.ClusterTokenCache{}
+
+		if err := ctxDB.Where("id = ?", cluster.TokenCacheID).First(prev).Error; err != nil {
+			return nil, err
+		}
+
+		prev.Token = tokenCache.Token
+		prev.Expiry = tokenCache.Expiry
+		prev.ClusterID = cluster.ID
+
+		if err := ctxDB.Save(prev).Error; err != nil {
 			return nil, err
 		}
 	}

--- a/server/api/integration_handler.go
+++ b/server/api/integration_handler.go
@@ -280,7 +280,7 @@ func (app *App) HandleOverwriteAWSIntegration(w http.ResponseWriter, r *http.Req
 		// clear the token
 		cluster.TokenCache.Token = []byte("")
 
-		cluster, err = app.Repo.Cluster.UpdateClusterTokenCache(cluster.TokenCache)
+		cluster, err = app.Repo.Cluster.UpdateClusterTokenCache(&cluster.TokenCache)
 
 		if err != nil {
 			app.handleErrorDataWrite(err, w)

--- a/server/api/integration_handler.go
+++ b/server/api/integration_handler.go
@@ -280,7 +280,7 @@ func (app *App) HandleOverwriteAWSIntegration(w http.ResponseWriter, r *http.Req
 		// clear the token
 		cluster.TokenCache.Token = []byte("")
 
-		cluster, err = app.Repo.Cluster.UpdateClusterTokenCache(&cluster.TokenCache)
+		cluster, err = app.Repo.Cluster.UpdateClusterTokenCache(cluster.TokenCache)
 
 		if err != nil {
 			app.handleErrorDataWrite(err, w)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## What is the current behavior?

Token cache slows down the dashboard because gorm one-to-one selects more data than it should be.

## What is the new behavior?

One-to-one is now done manually, so things should be faster.
