### PR TITLE
Fix null text displayed on launch flow

### DIFF
--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -341,7 +341,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
 
     if (!templateName && !props.isCloning) {
       const newTemplateName = generateRandomName();
-      setTemplateName(newTemplateName)
+      setTemplateName(newTemplateName);
     }
 
     if (currentPage === "workflow" && currentTab === "porter") {
@@ -403,7 +403,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
         {renderIcon()}
         {!props.isCloning
           ? `New ${currentTemplateName} ${
-              currentTab === "porter" ? null : "Instance"
+              currentTab !== "porter" ? "Instance" : ""
             }`
           : `Cloning ${currentTemplateName} deployment: ${props.clonedChart.name}`}
       </TitleSection>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Bug introduced by #1192 where the word "null" was displayed right next to, for example, "New Job" on the launch flow

## What is the new behavior?

Removed the null word to show proper text

## Technical Spec/Implementation Notes

Template string was introduced on the last changes causing it to parse the null to string and inserting it into the text.
