### PR TITLE
[POR-50] Support running job manually from the CLI

### DIFF
--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -278,8 +278,9 @@ func (d *DeployAgent) UpdateImageAndValues(overrideValues map[string]interface{}
 	// overwrite the tag based on a new image
 	currImageSection := mergedValues["image"].(map[string]interface{})
 
-	// if this is a job chart, set "paused" to false so that the job doesn't run
-	if d.release.Chart.Name() == "job" {
+	// if this is a job chart, set "paused" to false so that the job doesn't run, unless
+	// the user has explicitly overriden the "paused" field
+	if _, exists := overrideValues["paused"]; d.release.Chart.Name() == "job" && !exists {
 		mergedValues["paused"] = true
 	}
 

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -273,16 +273,16 @@ func (d *DeployAgent) Push() error {
 // reuses the configuration set for the application. If overrideValues is not nil,
 // it will merge the overriding values with the existing configuration.
 func (d *DeployAgent) UpdateImageAndValues(overrideValues map[string]interface{}) error {
+	// if this is a job chart, set "paused" to false so that the job doesn't run, unless
+	// the user has explicitly overriden the "paused" field
+	if _, exists := overrideValues["paused"]; d.release.Chart.Name() == "job" && !exists {
+		overrideValues["paused"] = true
+	}
+
 	mergedValues := utils.CoalesceValues(d.release.Config, overrideValues)
 
 	// overwrite the tag based on a new image
 	currImageSection := mergedValues["image"].(map[string]interface{})
-
-	// if this is a job chart, set "paused" to false so that the job doesn't run, unless
-	// the user has explicitly overriden the "paused" field
-	if _, exists := overrideValues["paused"]; d.release.Chart.Name() == "job" && !exists {
-		mergedValues["paused"] = true
-	}
 
 	// if the current image section is hello-porter, the image must be overriden
 	if currImageSection["repository"] == "public.ecr.aws/o1j4x7p4/hello-porter" ||


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): improvement to CLI

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

`porter update` currently blocks manual job runs, even when the following is passed explicitly via the `--values` flag:

```yaml
paused: false
```

## What is the new behavior?

If `paused` is set explicitly, allow manual job execution from the CLI. 

## Technical Spec/Implementation Notes
