### PR TITLE
[POR-48] Randomly generated name on addons fill automatically when name is deleted

### DIFF
--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -339,7 +339,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
       );
     }
 
-    if (!templateName && !props.isCloning) {
+    if (!templateName && !props.isCloning && currentTab === "porter") {
       const newTemplateName = generateRandomName();
       setTemplateName(newTemplateName);
     }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Random template name was being generated on each render if the current section to be displayed is settings. This is useful for flows that set the name on a previous step, but for addons or cloning is not the case.

## What is the new behavior?

Added casing to only generate the name if the deployment flow is for a new application and not for any addon or cloned app
