### PR TITLE
[POR-47] Hide clone button for add-ons (or fix)

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/SettingsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/SettingsSection.tsx
@@ -287,6 +287,19 @@ const SettingsSection: React.FC<PropsType> = ({
     return false;
   };
 
+  const canBeCloned = () => {
+    if(chartWasDeployedWithGithub()) {
+      return false;
+    }
+
+    // If its not web worker or job it means is an addon, and for now it's not supported
+    if (!["web", "worker", "job"].includes(currentChart?.chart?.metadata?.name)) {
+      return false
+    }
+
+    return true
+  }
+
   return (
     <Wrapper>
       {!loadingWebhookToken ? (
@@ -294,7 +307,7 @@ const SettingsSection: React.FC<PropsType> = ({
           {renderWebhookSection()}
           <NotificationSettingsSection currentChart={currentChart} />
           {/* Prevent the clone button to be rendered in github deployed charts */}
-          {!chartWasDeployedWithGithub() && (
+          {canBeCloned() && (
             <>
               <Heading>Clone deployment</Heading>
               <Helper>

--- a/dashboard/src/main/home/launch/Launch.tsx
+++ b/dashboard/src/main/home/launch/Launch.tsx
@@ -125,6 +125,14 @@ class Templates extends Component<PropsType, StateType> {
           this.props.history.push("/dashboard");
           return;
         }
+        // If its not web worker or job it means is an addon, and for now it's not supported
+        if (!["web", "worker", "job"].includes(release?.chart?.metadata?.name)) {
+          this.context.setCurrentError(
+            "Addons don't support cloning yet!"
+          );
+          this.props.history.push("/dashboard");
+          return;
+        }
       }
 
       this.setState(


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the new behavior?

Cloning for addons not supported, added casing for not showing button and prevent users to create a URL to clone some addon.

This last item means that rn the user can create a custom URL by hand to clone some application, and that's why we need casing on the Launch component as well to prevent some type of cloning not supported.