### PR TITLE
[POR-58] Frontend crashes on (cluster dashboard) -> (applications) -> (launch template)

### DIFF
--- a/dashboard/src/main/home/launch/Launch.tsx
+++ b/dashboard/src/main/home/launch/Launch.tsx
@@ -126,10 +126,10 @@ class Templates extends Component<PropsType, StateType> {
           return;
         }
         // If its not web worker or job it means is an addon, and for now it's not supported
-        if (!["web", "worker", "job"].includes(release?.chart?.metadata?.name)) {
-          this.context.setCurrentError(
-            "Addons don't support cloning yet!"
-          );
+        if (
+          !["web", "worker", "job"].includes(release?.chart?.metadata?.name)
+        ) {
+          this.context.setCurrentError("Addons don't support cloning yet!");
           this.props.history.push("/dashboard");
           return;
         }
@@ -162,13 +162,13 @@ class Templates extends Component<PropsType, StateType> {
   }
 
   isTryingToClone = () => {
-    const queryParams = getQueryParams({ location });
+    const queryParams = getQueryParams(this.props);
     return queryParams.has("shouldClone");
   };
 
   areCloneQueryParamsValid = () => {
     const qp = getQueryParams(this.props);
-
+    console.log(qp);
     const requiredParams = [
       "release_namespace",
       "release_template_version",
@@ -195,8 +195,7 @@ class Templates extends Component<PropsType, StateType> {
 
     return api.getChart<ChartTypeWithExtendedConfig>(
       "<token>",
-      {
-      },
+      {},
       {
         id: this.context.currentProject.id,
         name: queryParams.get("release_name"),

--- a/dashboard/src/shared/routing.tsx
+++ b/dashboard/src/shared/routing.tsx
@@ -59,9 +59,7 @@ export const pushFiltered = (
 
 export const getQueryParams = (props: any) => {
   const searchParams = props.location.search;
-  if (searchParams) {
-    return new URLSearchParams(searchParams);
-  }
+  return new URLSearchParams(searchParams);
 };
 
 export const getQueryParam = (props: any, paramName: string) => {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

After going to cluster dashboard if the user goes immediately to launch, the application will crash.

## What is the new behavior?

Doesn't crash anymore

## Technical Spec/Implementation Notes

The previous implementation of getQueryParams returned undefined if the search string was empty, this was causing for the function .has() to not exist.
