### PR TITLE
Fix env variable name to pipe errors to sentry

### DIFF
--- a/dashboard/src/shared/PorterErrorBoundary.tsx
+++ b/dashboard/src/shared/PorterErrorBoundary.tsx
@@ -16,7 +16,7 @@ const PorterErrorBoundary: React.FC<PorterErrorBoundaryProps> = ({
   children,
 }) => {
   const handleError = (error: Error, info: { componentStack: string }) => {
-    if (process.env.SENTRY_ENABLED) {
+    if (process.env.ENABLE_SENTRY) {
       Sentry.captureException(error, (scope) => {
         scope.setTags({
           error_boundary_location: errorBoundaryLocation,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

Errors weren't piped to sentry because the env variable used on the error boundary was an incorrect one