### PR TITLE
[POR-62] Frontend crashes on repo launch to non-default namespace

### DIFF
--- a/dashboard/src/main/CurrentError.tsx
+++ b/dashboard/src/main/CurrentError.tsx
@@ -26,11 +26,15 @@ export default class CurrentError extends Component<PropsType, StateType> {
   }
 
   render() {
+    let currentError = this.props.currentError;
+    if (!React.isValidElement(this.props.currentError)) {
+      currentError = String(this.props.currentError);
+    }
     if (this.props.currentError) {
       if (!this.state.expanded) {
         return (
           <StyledCurrentError>
-            <ErrorText>Error: {this.props.currentError}</ErrorText>
+            <ErrorText>Error: {currentError}</ErrorText>
             <ExpandButton onClick={() => this.setState({ expanded: true })}>
               <i className="material-icons">launch</i>
             </ExpandButton>
@@ -53,7 +57,7 @@ export default class CurrentError extends Component<PropsType, StateType> {
         <Overlay>
           <ExpandedError>
             Porter encountered an error. Full error log:
-            <CodeBlock>{this.props.currentError}</CodeBlock>
+            <CodeBlock>{currentError}</CodeBlock>
             <ExpandButtonAlt onClick={() => this.setState({ expanded: false })}>
               <i className="material-icons">remove</i>
             </ExpandButtonAlt>


### PR DESCRIPTION
## Pull request type


Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When controllers request fails, the CurrentError component was trying to render an object, which ended up in throwing an error by react.

## What is the new behavior?

Prevent from inside the CurrentError component to render anything that is not a valid react element

## Technical Spec/Implementation Notes
