### PR TITLE
[POR-69] Webhook not found should write 403 response

### DIFF
--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/porter-dev/porter/internal/analytics"
 	"github.com/porter-dev/porter/internal/helm"
 	"github.com/porter-dev/porter/internal/integrations/slack"
+	"gorm.io/gorm"
 )
 
 type WebhookHandler struct {
@@ -40,17 +41,32 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	release, err := c.Repo().Release().ReadReleaseByWebhookToken(token)
 
 	if err != nil {
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
-			fmt.Errorf("release not found with given webhook"),
-			http.StatusBadRequest,
-		))
+		if err == gorm.ErrRecordNotFound {
+			// throw forbidden error, since we don't want a way to verify if webhooks exist
+			c.HandleAPIError(w, r, apierrors.NewErrForbidden(
+				fmt.Errorf("release not found with given webhook"),
+			))
 
+			return
+		}
+
+		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}
 
 	cluster, err := c.Repo().Cluster().ReadCluster(release.ProjectID, release.ClusterID)
 
 	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			// throw forbidden error, since we don't want a way to verify if the cluster and project
+			// still exist for a cluster that's been deleted
+			c.HandleAPIError(w, r, apierrors.NewErrForbidden(
+				fmt.Errorf("cluster %d in project %d not found for upgrade webhook", release.ClusterID, release.ProjectID),
+			))
+
+			return
+		}
+
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}
@@ -69,6 +85,11 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rel, err := helmAgent.GetRelease(release.Name, 0, true)
+
+	if err != nil {
+		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		return
+	}
 
 	// repository is set to current repository by default
 	repository := rel.Config["image"].(map[string]interface{})["repository"]


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Webhook throws 404 error when not found. 

## What is the new behavior?

Webhook should throw 403 when not found. 

## Technical Spec/Implementation Notes
