### PR TITLE
[POR-71] Return 404 on pod not found for logs

### DIFF
--- a/api/server/handlers/namespace/delete_pod.go
+++ b/api/server/handlers/namespace/delete_pod.go
@@ -1,6 +1,8 @@
 package namespace
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/porter-dev/porter/api/server/authz"
@@ -9,6 +11,7 @@ import (
 	"github.com/porter-dev/porter/api/server/shared/config"
 	"github.com/porter-dev/porter/api/server/shared/requestutils"
 	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/kubernetes"
 	"github.com/porter-dev/porter/internal/models"
 )
 
@@ -39,7 +42,14 @@ func (c *DeletePodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err = agent.DeletePod(namespace, name)
 
-	if err != nil {
+	if targetErr := kubernetes.IsNotFoundError; errors.Is(err, targetErr) {
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
+			fmt.Errorf("pod %s/%s was not found", namespace, name),
+			http.StatusNotFound,
+		))
+
+		return
+	} else if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}

--- a/api/server/handlers/namespace/stream_pod_logs.go
+++ b/api/server/handlers/namespace/stream_pod_logs.go
@@ -1,6 +1,8 @@
 package namespace
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/porter-dev/porter/api/server/authz"
@@ -10,6 +12,7 @@ import (
 	"github.com/porter-dev/porter/api/server/shared/config"
 	"github.com/porter-dev/porter/api/server/shared/requestutils"
 	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/kubernetes"
 	"github.com/porter-dev/porter/internal/models"
 )
 
@@ -51,7 +54,14 @@ func (c *StreamPodLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	err = agent.GetPodLogs(namespace, name, conn)
 
-	if err != nil {
+	if targetErr := kubernetes.IsNotFoundError; errors.Is(err, targetErr) {
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
+			fmt.Errorf("pod %s/%s was not found", namespace, name),
+			http.StatusNotFound,
+		))
+
+		return
+	} else if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -486,11 +486,17 @@ func (a *Agent) GetPodsByLabel(selector string, namespace string) (*v1.PodList, 
 
 // DeletePod deletes a pod by name and namespace
 func (a *Agent) DeletePod(namespace string, name string) error {
-	return a.Clientset.CoreV1().Pods(namespace).Delete(
+	err := a.Clientset.CoreV1().Pods(namespace).Delete(
 		context.TODO(),
 		name,
 		metav1.DeleteOptions{},
 	)
+
+	if err != nil && errors.IsNotFound(err) {
+		return IsNotFoundError
+	}
+
+	return err
 }
 
 // GetPodLogs streams real-time logs from a given pod.

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -502,8 +502,10 @@ func (a *Agent) GetPodLogs(namespace string, name string, conn *websocket.Conn) 
 		metav1.GetOptions{},
 	)
 
-	if err != nil {
-		return fmt.Errorf("Cannot get pod %s: %s", name, err.Error())
+	if err != nil && errors.IsNotFound(err) {
+		return IsNotFoundError
+	} else if err != nil {
+		return fmt.Errorf("Cannot get logs from pod %s: %s", name, err.Error())
 	}
 
 	container := pod.Spec.Containers[0].Name


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

500 internal server error is returned when a pod is not found, either on logs or on delete. 

## What is the new behavior?

Return 404 when a pod is not found. 

## Technical Spec/Implementation Notes
