### PR TITLE
[POR-72] Release not found in authz middleware should throw 404, not 500

### DIFF
--- a/api/server/authz/release.go
+++ b/api/server/authz/release.go
@@ -54,6 +54,8 @@ func (p *ReleaseScopedMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	release, err := helmAgent.GetRelease(name, int(version), false)
 
 	if err != nil {
+		// ugly casing since at the time of this commit Helm doesn't have an errors package.
+		// so we rely on the Helm error containing "not found"
 		if strings.Contains(err.Error(), "not found") {
 			apierrors.HandleAPIError(p.config, w, r, apierrors.NewErrPassThroughToClient(
 				fmt.Errorf("release not found"),

--- a/api/server/authz/release.go
+++ b/api/server/authz/release.go
@@ -2,7 +2,9 @@ package authz
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/porter-dev/porter/api/server/shared/apierrors"
 	"github.com/porter-dev/porter/api/server/shared/config"
@@ -52,7 +54,15 @@ func (p *ReleaseScopedMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	release, err := helmAgent.GetRelease(name, int(version), false)
 
 	if err != nil {
-		apierrors.HandleAPIError(p.config, w, r, apierrors.NewErrInternal(err))
+		if strings.Contains(err.Error(), "not found") {
+			apierrors.HandleAPIError(p.config, w, r, apierrors.NewErrPassThroughToClient(
+				fmt.Errorf("release not found"),
+				http.StatusNotFound,
+			))
+		} else {
+			apierrors.HandleAPIError(p.config, w, r, apierrors.NewErrInternal(err))
+		}
+
 		return
 	}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): API improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Not being able to find a specific release version throws 500 error. 

## What is the new behavior?

Return 404 when release is not found. 

## Technical Spec/Implementation Notes
