### PR TITLE
[POR-73] Prevent internal server errors on reading infra logs

### DIFF
--- a/internal/kubernetes/provisioner/resource_stream.go
+++ b/internal/kubernetes/provisioner/resource_stream.go
@@ -18,7 +18,7 @@ func ResourceStream(client *redis.Client, streamName string, conn *websocket.Con
 
 			if err != nil {
 				defer conn.Close()
-				errorchan <- err
+				errorchan <- nil
 				return
 			}
 		}
@@ -28,7 +28,6 @@ func ResourceStream(client *redis.Client, streamName string, conn *websocket.Con
 		lastID := "0-0"
 
 		for {
-
 			xstream, err := client.XRead(
 				context.Background(),
 				&redis.XReadArgs{


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

500 internal server error is thrown on expected websocket closes. 

## What is the new behavior?

Don't check for errors from gorilla websockets on close. 

## Technical Spec/Implementation Notes
