### PR TITLE
[hotfix] Add `repository` field back to webhook and add error handling for release

### DIFF
--- a/api/server/authz/release.go
+++ b/api/server/authz/release.go
@@ -37,7 +37,7 @@ type ReleaseScopedMiddleware struct {
 func (p *ReleaseScopedMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	helmAgent, err := p.agentGetter.GetHelmAgent(r, cluster)
+	helmAgent, err := p.agentGetter.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		apierrors.HandleAPIError(p.config, w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/create_namespace.go
+++ b/api/server/handlers/cluster/create_namespace.go
@@ -37,7 +37,7 @@ func (c *CreateNamespaceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/delete_namespace.go
+++ b/api/server/handlers/cluster/delete_namespace.go
@@ -36,7 +36,7 @@ func (c *DeleteNamespaceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/detect_prometheus_installed.go
+++ b/api/server/handlers/cluster/detect_prometheus_installed.go
@@ -29,7 +29,7 @@ func NewDetectPrometheusInstalledHandler(
 func (c *DetectPrometheusInstalledHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/get.go
+++ b/api/server/handlers/cluster/get.go
@@ -36,7 +36,7 @@ func (c *ClusterGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Cluster: cluster.ToClusterType(),
 	}
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/get_node.go
+++ b/api/server/handlers/cluster/get_node.go
@@ -33,7 +33,7 @@ func (c *GetNodeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 	name, _ := requestutils.GetURLParamString(r, types.URLParamNodeName)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/get_pod_metrics.go
+++ b/api/server/handlers/cluster/get_pod_metrics.go
@@ -39,7 +39,7 @@ func (c *GetPodMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/get_pods.go
+++ b/api/server/handlers/cluster/get_pods.go
@@ -38,7 +38,7 @@ func (c *GetPodsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/list_namespaces.go
+++ b/api/server/handlers/cluster/list_namespaces.go
@@ -30,7 +30,7 @@ func NewListNamespacesHandler(
 func (c *ListNamespacesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/list_nginx_ingresses.go
+++ b/api/server/handlers/cluster/list_nginx_ingresses.go
@@ -31,7 +31,7 @@ func NewListNGINXIngressesHandler(
 func (c *ListNGINXIngressesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/list_nodes.go
+++ b/api/server/handlers/cluster/list_nodes.go
@@ -31,7 +31,7 @@ func NewListNodesHandler(
 func (c *ListNodesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/stream_helm_release.go
+++ b/api/server/handlers/cluster/stream_helm_release.go
@@ -44,7 +44,7 @@ func (c *StreamHelmReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/cluster/stream_status.go
+++ b/api/server/handlers/cluster/stream_status.go
@@ -45,7 +45,7 @@ func (c *StreamStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/job/delete.go
+++ b/api/server/handlers/job/delete.go
@@ -28,7 +28,7 @@ func NewDeleteHandler(
 
 func (c *DeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamJobName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/job/get_pods.go
+++ b/api/server/handlers/job/get_pods.go
@@ -30,7 +30,7 @@ func NewGetPodsHandler(
 
 func (c *GetPodsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamJobName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/job/stop.go
+++ b/api/server/handlers/job/stop.go
@@ -28,7 +28,7 @@ func NewStopHandler(
 
 func (c *StopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamJobName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/namespace/create_configmap.go
+++ b/api/server/handlers/namespace/create_configmap.go
@@ -42,7 +42,7 @@ func (c *CreateConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/delete_configmap.go
+++ b/api/server/handlers/namespace/delete_configmap.go
@@ -38,7 +38,7 @@ func (c *DeleteConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/delete_pod.go
+++ b/api/server/handlers/namespace/delete_pod.go
@@ -31,7 +31,7 @@ func NewDeletePodHandler(
 
 func (c *DeletePodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamPodName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/namespace/get_configmap.go
+++ b/api/server/handlers/namespace/get_configmap.go
@@ -38,7 +38,7 @@ func (c *GetConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/get_ingress.go
+++ b/api/server/handlers/namespace/get_ingress.go
@@ -33,7 +33,7 @@ func NewGetIngressHandler(
 
 func (c *GetIngressHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamIngressName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/namespace/get_pod_events.go
+++ b/api/server/handlers/namespace/get_pod_events.go
@@ -30,7 +30,7 @@ func NewGetPodEventsHandler(
 
 func (c *GetPodEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 	name, _ := requestutils.GetURLParamString(r, types.URLParamPodName)
 	namespace, _ := requestutils.GetURLParamString(r, types.URLParamNamespace)
 

--- a/api/server/handlers/namespace/list_configmaps.go
+++ b/api/server/handlers/namespace/list_configmaps.go
@@ -31,7 +31,7 @@ func (c *ListConfigMapsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/list_releases.go
+++ b/api/server/handlers/namespace/list_releases.go
@@ -38,7 +38,7 @@ func (c *ListReleasesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/rename_configmap.go
+++ b/api/server/handlers/namespace/rename_configmap.go
@@ -43,7 +43,7 @@ func (c *RenameConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/stream_pod_logs.go
+++ b/api/server/handlers/namespace/stream_pod_logs.go
@@ -45,7 +45,7 @@ func (c *StreamPodLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/namespace/update_configmap.go
+++ b/api/server/handlers/namespace/update_configmap.go
@@ -39,7 +39,7 @@ func (c *UpdateConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	namespace := r.Context().Value(types.NamespaceScope).(string)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/create.go
+++ b/api/server/handlers/release/create.go
@@ -53,7 +53,7 @@ func (c *CreateReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		},
 	))
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/create_addon.go
+++ b/api/server/handlers/release/create_addon.go
@@ -46,7 +46,7 @@ func (c *CreateAddonHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	))
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/create_subdomain.go
+++ b/api/server/handlers/release/create_subdomain.go
@@ -34,7 +34,7 @@ func (c *CreateSubdomainHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	name, _ := requestutils.GetURLParamString(r, types.URLParamReleaseName)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/delete.go
+++ b/api/server/handlers/release/delete.go
@@ -34,7 +34,7 @@ func (c *DeleteReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_all_pods.go
+++ b/api/server/handlers/release/get_all_pods.go
@@ -35,7 +35,7 @@ func (c *GetAllPodsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_controllers.go
+++ b/api/server/handlers/release/get_controllers.go
@@ -39,7 +39,7 @@ func (c *GetControllersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_history.go
+++ b/api/server/handlers/release/get_history.go
@@ -32,7 +32,7 @@ func NewGetReleaseHistoryHandler(
 func (c *GetReleaseHistoryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_job_status.go
+++ b/api/server/handlers/release/get_job_status.go
@@ -31,7 +31,7 @@ func NewGetJobsStatusHandler(
 func (c *GetJobsStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_jobs.go
+++ b/api/server/handlers/release/get_jobs.go
@@ -33,7 +33,7 @@ func NewGetJobsHandler(
 func (c *GetJobsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
-	agent, err := c.GetAgent(r, cluster)
+	agent, err := c.GetAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/ugprade.go
+++ b/api/server/handlers/release/ugprade.go
@@ -45,7 +45,7 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/update_image_batch.go
+++ b/api/server/handlers/release/update_image_batch.go
@@ -35,7 +35,7 @@ func NewUpdateImageBatchHandler(
 func (c *UpdateImageBatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/update_rollback.go
+++ b/api/server/handlers/release/update_rollback.go
@@ -36,7 +36,7 @@ func (c *RollbackReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 	helmRelease, _ := r.Context().Value(types.ReleaseScope).(*release.Release)
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	helmAgent, err := c.GetHelmAgent(r, cluster, "")
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -71,7 +71,9 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	helmAgent, err := c.GetHelmAgent(r, cluster)
+	// in this case, we retrieve the agent by passing in the namespace field directly, since
+	// it cannot be detected from the URL
+	helmAgent, err := c.GetHelmAgent(r, cluster, release.Namespace)
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/types/release.go
+++ b/api/types/release.go
@@ -73,6 +73,10 @@ const URLParamToken URLParam = "token"
 
 type WebhookRequest struct {
 	Commit string `schema:"commit"`
+
+	// NOTICE: deprecated. This field should no longer be used; it is not supported
+	// internally.
+	Repository string `schema:"repository"`
 }
 
 type GetGHATemplateRequest struct {

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -48,14 +48,18 @@ func (a *Agent) GetRelease(
 
 	release, err := cmd.Run(name)
 
-	if getDeps {
+	if err != nil {
+		return nil, err
+	}
+
+	if getDeps && release.Chart != nil && release.Chart.Metadata != nil {
 		for _, dep := range release.Chart.Metadata.Dependencies {
 			depExists := false
 
 			for _, currDep := range release.Chart.Dependencies() {
 				// we just case on name for now -- there might be edge cases we're missing
 				// but this will cover 99% of cases
-				if dep.Name == currDep.Name() {
+				if dep != nil && currDep != nil && dep.Name == currDep.Name() {
 					depExists = true
 					break
 				}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Webhooks throw `400` error when including `repository` field. Releases panic when not found and `getDependencies` is true. Non-default namespace webhooks do not work. 

## What is the new behavior?

- Add back `repository` field, although it is unused.
- Prevent panics when release is not found and `getDependencies` is `true`
- Allow non-default namespace webhooks to work. 

## Technical Spec/Implementation Notes
