### PR TITLE
[POR-52] Update revision number in URL for charts

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -97,9 +97,7 @@ const Chart: React.FunctionComponent<Props> = ({
         let urlParams = new URLSearchParams(location.search);
         let cluster = urlParams.get("cluster");
         let route = `${match.url}/${cluster}/${chart.namespace}/${chart.name}`;
-        pushFiltered({ location, history }, route, ["project_id"], {
-          chart_revision: chart.version,
-        });
+        pushFiltered({ location, history }, route, ["project_id"]);
       }}
     >
       <Title>

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChartWrapper.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChartWrapper.tsx
@@ -33,15 +33,17 @@ class ExpandedChartWrapper extends Component<PropsType, StateType> {
     let { namespace, chartName } = match.params as any;
     let { currentProject, currentCluster } = this.context;
     if (currentProject && currentCluster) {
-      // TODO: add query for retrieving max revision #
-      const lastCheckedRevision = getQueryParam(this.props, "chart_revision");
-
       api
         .getChart(
           "<token>",
+          {},
           {
-          },
-          { id: currentProject.id, namespace: namespace, cluster_id: currentCluster.id ,name: chartName, revision: Number(lastCheckedRevision), }
+            id: currentProject.id,
+            namespace: namespace,
+            cluster_id: currentCluster.id,
+            name: chartName,
+            revision: 0,
+          }
         )
         .then((res) => {
           this.setState({ currentChart: res.data, loading: false });


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

Adding the chart revision to the URL was sometimes confusing for the users as the query param was not updated. Now we can remove the query param and just get the last chart version every time

