### PR TITLE
[POR-65] autoscroll to top after clicking continue from source settings

### DIFF
--- a/dashboard/src/main/home/launch/launch-flow/SettingsPage.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/SettingsPage.tsx
@@ -54,8 +54,6 @@ class SettingsPage extends Component<PropsType, StateType> {
   };
 
   componentDidMount() {
-    window.scrollBy(0, -window.innerHeight);
-
     // Retrieve tab options
     let tabOptions = [] as ChoiceType[];
     this.props.form?.tabs.map((tab: any, i: number) => {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

The scroll was leading some users to not see some of the meaningful form inputs. Removing the scroll the screen should always be on top.