### PR TITLE
[POR-82] `UserId` field not passed through many metrics

### DIFF
--- a/api/server/handlers/provision/provision_docr.go
+++ b/api/server/handlers/provision/provision_docr.go
@@ -69,6 +69,7 @@ func (c *ProvisionDOCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Suffix:          suffix,
 		Status:          types.StatusCreating,
 		DOIntegrationID: request.DOIntegrationID,
+		CreatedByUserID: user.ID,
 	}
 
 	// handle write to the database

--- a/api/server/handlers/provision/provision_doks.go
+++ b/api/server/handlers/provision/provision_doks.go
@@ -69,6 +69,7 @@ func (c *ProvisionDOKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Suffix:          suffix,
 		Status:          types.StatusCreating,
 		DOIntegrationID: request.DOIntegrationID,
+		CreatedByUserID: user.ID,
 	}
 
 	// handle write to the database

--- a/api/server/handlers/provision/provision_ecr.go
+++ b/api/server/handlers/provision/provision_ecr.go
@@ -69,6 +69,7 @@ func (c *ProvisionECRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Suffix:           suffix,
 		Status:           types.StatusCreating,
 		AWSIntegrationID: request.AWSIntegrationID,
+		CreatedByUserID:  user.ID,
 	}
 
 	// handle write to the database

--- a/api/server/handlers/provision/provision_eks.go
+++ b/api/server/handlers/provision/provision_eks.go
@@ -69,6 +69,7 @@ func (c *ProvisionEKSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Suffix:           suffix,
 		Status:           types.StatusCreating,
 		AWSIntegrationID: request.AWSIntegrationID,
+		CreatedByUserID:  user.ID,
 	}
 
 	// handle write to the database

--- a/api/server/handlers/provision/provision_gcr.go
+++ b/api/server/handlers/provision/provision_gcr.go
@@ -69,6 +69,7 @@ func (c *ProvisionGCRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Suffix:           suffix,
 		Status:           types.StatusCreating,
 		GCPIntegrationID: request.GCPIntegrationID,
+		CreatedByUserID:  user.ID,
 	}
 
 	// handle write to the database

--- a/api/server/handlers/provision/provision_gke.go
+++ b/api/server/handlers/provision/provision_gke.go
@@ -69,6 +69,7 @@ func (c *ProvisionGKEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Suffix:           suffix,
 		Status:           types.StatusCreating,
 		GCPIntegrationID: request.GCPIntegrationID,
+		CreatedByUserID:  user.ID,
 	}
 
 	// handle write to the database


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Infra does not populate `CreatedByUserID` field, which is required by metrics. 

## What is the new behavior?

Populate `CreatedByUserID` field. 

## Technical Spec/Implementation Notes
