### PR TITLE
[POR-93] Fix `GetTemplate` endpoint to case on empty `repo_url` param

### DIFF
--- a/api/server/handlers/template/get.go
+++ b/api/server/handlers/template/get.go
@@ -45,6 +45,10 @@ func (t *TemplateGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		version = ""
 	}
 
+	if request.RepoURL == "" {
+		request.RepoURL = t.Config().ServerConf.DefaultApplicationHelmRepoURL
+	}
+
 	chart, err := loader.LoadChartPublic(request.RepoURL, name, version)
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When `repo_url` is blank, the `GetTemplate` handler returns a `500` error. 

## What is the new behavior?

When `repo_url` is blank, the `GetTemplate` handler should use the application url by default. 

## Technical Spec/Implementation Notes
