### PR TITLE
[POR-104] Show logs from exited pods

### DIFF
--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -536,15 +536,12 @@ func (a *Agent) GetPodLogs(namespace string, name string, rw *websocket.Websocke
 
 	// see if container is ready and able to open a stream. If not, wait for container
 	// to be ready.
-	err, isExited := a.waitForPod(pod)
+	err, _ = a.waitForPod(pod)
 
 	if err != nil && goerrors.Is(err, IsNotFoundError) {
 		return IsNotFoundError
 	} else if err != nil {
 		return fmt.Errorf("Cannot get logs from pod %s: %s", name, err.Error())
-	} else if isExited {
-		// if exited, we return nil and simply close the stream
-		return nil
 	}
 
 	container := pod.Spec.Containers[0].Name


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Logs from exited pods are not shown.  

## What is the new behavior?

Attempt to stream logs from exited pods. 

## Technical Spec/Implementation Notes
