### PR TITLE
[FIX] Allow webpack to get environment variables from process

### DIFF
--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,2 +1,1 @@
 node_modules
-.env

--- a/dashboard/webpack.config.js
+++ b/dashboard/webpack.config.js
@@ -11,7 +11,10 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
 const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = () => {
-  const env = dotenv.config().parsed;
+  let env = dotenv.config().parsed;
+  if (!env) {
+    env = process.env;
+  }
   const envKeys = Object.keys(env).reduce((prev, next) => {
     prev[`process.env.${next}`] = JSON.stringify(env[next]);
     return prev;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Webpack Docker environment failing to load env vars

![image](https://user-images.githubusercontent.com/23369263/139498218-ff7a6ff7-fbe4-4b73-929f-1eb2e8ea4ff6.png)


## What is the new behavior?

If .dotenv doesn't find any env variables then we take the variables from process.env directly

