### PR TITLE
[POR-192] Add support to job sidecar for stopping other sidecar containers, like CloudSQL

### DIFF
--- a/services/job_sidecar_container/Dockerfile
+++ b/services/job_sidecar_container/Dockerfile
@@ -5,6 +5,6 @@ RUN apk --no-cache add procps coreutils
 
 COPY *.sh .
 
-RUN ["chmod", "+x", "./job_killer.sh", "./signal.sh"]
+RUN ["chmod", "+x", "./job_killer.sh", "./signal.sh", "./sidecar_killer.sh"]
 
 ENTRYPOINT ["./job_killer.sh"]

--- a/services/job_sidecar_container/job_killer.sh
+++ b/services/job_sidecar_container/job_killer.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Usage: job_killer.sh [-c]? [grace_period_seconds] [process_pattern]
+# Usage: job_killer.sh [-c]? [grace_period_seconds] [process_pattern] [sidecar]?
 #
 # This script waits for a termination signal and gracefully terminates another process before exiting. 
 # 
@@ -24,9 +24,11 @@ if $kill_child_procs
 then
   grace_period_seconds=$2
   target=$3
+  sidecar=$4
 else
   grace_period_seconds=$1
   target=$2
+  sidecar=$3
 fi  
 
 pattern="$(printf '[%s]%s' $(echo $target | cut -c 1) $(echo $target | cut -c 2-))"
@@ -87,4 +89,10 @@ if [ -n "$target_pid" ]; then
     child=$!
 
     wait "$child"
+fi
+
+# run the sidecar killer, this will terminate any additional sidecars if necessary
+if [ -n "$sidecar" ]; then
+    echo "killing sidecar command: $sidecar"
+    ./sidecar_killer.sh $sidecar
 fi

--- a/services/job_sidecar_container/sidecar_killer.sh
+++ b/services/job_sidecar_container/sidecar_killer.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Sends termination signal to other sidecar pods, meant to run as a pre-stop hook
+# or called by ./job_killer.sh.
+# 
+# Usage: ./sidecar_killer.sh [target_process]
+
+target=$1
+pattern="$(printf '[%s]%s' $(echo $target | cut -c 1) $(echo $target | cut -c 2-))"
+pid=$(ps x | grep -v './sidecar_killer.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }'); 
+kill -TERM $pid


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Sidecar containers, when added to the job manifests, aren't terminated when the main job exits. 

## What is the new behavior?

Add support to the job sidecar to kill additional sidecar containers when the main process exits. 

## Technical Spec/Implementation Notes
