### PR TITLE
[fix] Update IronPlans subscription via DELETE and then POST endpoints

### DIFF
--- a/ee/billing/ironplans.go
+++ b/ee/billing/ironplans.go
@@ -269,12 +269,15 @@ func (c *Client) CreateOrUpdateSubscription(teamID, planID string) error {
 
 	// if subscription ID is not empty, perform a PUT request to update the subscription
 	if teamResp.Subscription.ID != "" {
-		err = c.putRequest(fmt.Sprintf("/subscriptions/v1/%s", teamResp.Subscription.ID), subReq, nil)
-	} else {
-		err = c.postRequest("/subscriptions/v1", subReq, nil)
+		// delete the subscription
+		err = c.deleteRequest(fmt.Sprintf("/subscriptions/v1/%s/purge/", teamResp.Subscription.ID), nil, nil)
+
+		if err != nil {
+			return err
+		}
 	}
 
-	return err
+	return c.postRequest("/subscriptions/v1", subReq, nil)
 }
 
 func (c *Client) GetExistingPublicPlan(planName string) (string, error) {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

IronPlans subscription updated via `PUT` endpoint if it already exists. 

## What is the new behavior?

Update the IronPlans subscription via a `DELETE` endpoint instead. 

## Technical Spec/Implementation Notes
