### PR TITLE
[POR-201] Let user skip onboarding if connects a cluster through the cli

### DIFF
--- a/dashboard/src/main/home/ModalHandler.tsx
+++ b/dashboard/src/main/home/ModalHandler.tsx
@@ -194,7 +194,7 @@ const ModalHandler: React.FC<{
           onRequestClose={() => setCurrentModal(null, null)}
           width="600px"
           height="240px"
-          title="Do you wanna skip onboarding?"
+          title="Would you like to skip project setup?"
         >
           <SkipOnboardingModal />
         </Modal>

--- a/dashboard/src/main/home/ModalHandler.tsx
+++ b/dashboard/src/main/home/ModalHandler.tsx
@@ -15,6 +15,7 @@ import RedirectToOnboardingModal from "./modals/RedirectToOnboardingModal";
 import UsageWarningModal from "./modals/UsageWarningModal";
 import api from "shared/api";
 import { AxiosError } from "axios";
+import SkipOnboardingModal from "./modals/SkipProvisioningModal";
 
 const ModalHandler: React.FC<{
   setRefreshClusters: (x: boolean) => void;
@@ -185,6 +186,17 @@ const ModalHandler: React.FC<{
           title="Usage Warning"
         >
           <UsageWarningModal />
+        </Modal>
+      )}
+
+      {modal === "SkipOnboardingModal" && (
+        <Modal
+          onRequestClose={() => setCurrentModal(null, null)}
+          width="600px"
+          height="240px"
+          title="Do you wanna skip onboarding?"
+        >
+          <SkipOnboardingModal />
         </Modal>
       )}
     </>

--- a/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
+++ b/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
@@ -1,0 +1,68 @@
+import InputRow from "components/form-components/InputRow";
+import SaveButton from "components/SaveButton";
+import React, { useContext } from "react";
+import { Context } from "shared/Context";
+import styled from "styled-components";
+
+/**
+ * If user goes to /onboarding and has clusters, the Onboarding component
+ * will open this modal to let user skip onboarding and keep using porter.
+ */
+const SkipOnboardingModal = () => {
+  const { currentModalData, setCurrentModal } = useContext(Context);
+
+  return (
+    <>
+      <Subtitle>
+        Looks like you already know how to setup your project!
+      </Subtitle>
+      <Subtitle>
+        We've found a cluster connected to your project, although you probably
+        know how to setup everything by your own, we still wanted to ask you!
+      </Subtitle>
+      <Subtitle>Do you wanna skip onboarding?</Subtitle>
+      <ActionsWrapper>
+        <ActionButton
+          text="Yes, take me out"
+          color="#616FEEcc"
+          onClick={() =>
+            typeof currentModalData?.skipOnboarding === "function" &&
+            currentModalData.skipOnboarding()
+          }
+          status={""}
+          clearPosition
+        />
+        <ActionButton
+          text="Continue onboarding"
+          color="#616FEEcc"
+          onClick={() => setCurrentModal(null, null)}
+          status={""}
+          clearPosition
+        />
+      </ActionsWrapper>
+    </>
+  );
+};
+
+export default SkipOnboardingModal;
+
+const ActionButton = styled(SaveButton)``;
+
+const ActionsWrapper = styled.div`
+  position: absolute;
+  bottom: 14px;
+  right: 14px;
+  display: flex;
+  ${ActionButton} {
+    margin-left: 5px;
+  }
+`;
+
+const Subtitle = styled.div`
+  margin-top: 23px;
+  font-family: "Work Sans", sans-serif;
+  font-size: 14px;
+  color: #aaaabb;
+  overflow: hidden;
+  margin-bottom: -10px;
+`;

--- a/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
+++ b/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
@@ -14,28 +14,18 @@ const SkipOnboardingModal = () => {
   return (
     <>
       <Subtitle>
-        Looks like you already know how to setup your project!
+        Porter has detected an existing Kubernetes cluster that was connected
+        via the CLI. For custom setups, you can skip the project setup flow.
       </Subtitle>
-      <Subtitle>
-        We've found a cluster connected to your project, although you probably
-        know how to setup everything by your own, we still wanted to ask you!
-      </Subtitle>
-      <Subtitle>Do you wanna skip onboarding?</Subtitle>
+      <Subtitle>Do you want to skip project setup?</Subtitle>
       <ActionsWrapper>
         <ActionButton
-          text="Yes, take me out"
+          text="Yes, skip setup"
           color="#616FEEcc"
           onClick={() =>
             typeof currentModalData?.skipOnboarding === "function" &&
             currentModalData.skipOnboarding()
           }
-          status={""}
-          clearPosition
-        />
-        <ActionButton
-          text="Continue onboarding"
-          color="#616FEEcc"
-          onClick={() => setCurrentModal(null, null)}
           status={""}
           clearPosition
         />

--- a/dashboard/src/main/home/onboarding/Onboarding.tsx
+++ b/dashboard/src/main/home/onboarding/Onboarding.tsx
@@ -115,6 +115,38 @@ const Onboarding = () => {
     }
   }, [context.user]);
 
+  const skipOnboarding = () => {
+    OFState.actions.goTo("clean_up");
+  };
+
+  const checkIfUserHasClusters = async () => {
+    const { setCurrentModal, currentProject } = context;
+
+    const project_id = currentProject?.id;
+
+    try {
+      if (typeof project_id !== "number") {
+        return;
+      }
+
+      const clusters = await api
+        .getClusters("<token>", {}, { id: project_id })
+        .then((res) => res?.data);
+
+      const hasClusters = Array.isArray(clusters) && clusters.length;
+
+      if (hasClusters) {
+        setCurrentModal("SkipOnboardingModal", { skipOnboarding });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    checkIfUserHasClusters();
+  }, [context?.currentProject?.id]);
+
   return (
     <StyledOnboarding>{isLoading ? <Loading /> : <Routes />}</StyledOnboarding>
   );


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Experienced users may want to connect a cluster directly through CLI just after creating a project, this is causing the user to be blocked even if they have a cluster connected successfully to the project

## What is the new behavior?

If we detect a cluster under the project we show the user a modal to skip the onboarding flow if they want.

![image](https://user-images.githubusercontent.com/23369263/141416784-523a6a47-3c79-425c-831f-68540185055a.png)
