### PR TITLE
[FIX] Updated hash function for webpack

### DIFF
--- a/dashboard/webpack.config.js
+++ b/dashboard/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = () => {
       filename: "bundle.js",
       path: path.resolve(__dirname, "build"),
       publicPath: "/",
+      hashFunction: "xxhash64",
     },
     devServer: {
       historyApiFallback: true,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Trying to fix error on staging pipeline

`--openssl-legacy-provider is not allowed in NODE_OPTIONS`

Reference links: 


https://github.com/facebook/docusaurus/issues/5778#issuecomment-951225065

[Reddit solution to problem](https://www.reddit.com/r/webdev/comments/qd14bm/comment/hhje1dr/?utm_source=share&utm_medium=web2x&context=3)