### PR TITLE
[FIX] Updated dockerfiles to use node 16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,12 +37,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Webpack build environment
 # -------------------------
-FROM node:lts as build-webpack
+FROM node:16 as build-webpack
 WORKDIR /webpack
 
 COPY ./dashboard ./
-
-RUN node --version
 
 RUN npm install -g npm@8.1
 

--- a/ee/docker/ee.Dockerfile
+++ b/ee/docker/ee.Dockerfile
@@ -38,12 +38,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Webpack build environment
 # -------------------------
-FROM node:lts as build-webpack
+FROM node:16 as build-webpack
 WORKDIR /webpack
 
 COPY ./dashboard ./
 
-RUN npm i
+RUN npm install -g npm@8.1
+
+RUN npm i --legacy-peer-deps
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

node:lts is apparently using node 17 which causes some issues on webpack 4

```
#32 [build-webpack 5/5] RUN npm run build
#32 sha256:993bdbb59050301af411e41663d2b703bf86c4355185c2acd174209c05e7416d
#32 1.435 
#32 1.435 > dashboard@0.1.0 build
#32 1.435 > NODE_ENV="production" webpack
#32 1.435 
#32 3.635 Error: Digest method not supported
#32 3.635     at new Hash (node:internal/crypto/hash:67:19)
#32 3.635     at Object.createHash (node:crypto:130:10)
#32 3.635     at module.exports (/webpack/node_modules/webpack/lib/util/createHash.js:135:53)
#32 3.635     at NormalModule._initBuildHash (/webpack/node_modules/webpack/lib/NormalModule.js:417:16)
#32 3.635     at handleParseError (/webpack/node_modules/webpack/lib/NormalModule.js:471:10)
#32 3.635     at /webpack/node_modules/webpack/lib/NormalModule.js:503:5
#32 3.635     at /webpack/node_modules/webpack/lib/NormalModule.js:358:12
#32 3.635     at /webpack/node_modules/loader-runner/lib/LoaderRunner.js:373:3
#32 3.635     at iterateNormalLoaders (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
#32 3.635     at iterateNormalLoaders (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
#32 3.635     at /webpack/node_modules/loader-runner/lib/LoaderRunner.js:236:3
#32 3.635     at runSyncOrAsync (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:130:11)
#32 3.635     at iterateNormalLoaders (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
#32 3.635     at Array.<anonymous> (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
#32 3.635     at Storage.finished (/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
#32 3.635     at /webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
#32 3.635     at /webpack/node_modules/graceful-fs/graceful-fs.js:123:16
#32 3.635     at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3)
#32 4.341 node:internal/crypto/hash:67
#32 4.341   this[kHandle] = new _Hash(algorithm, xofLen);
#32 4.341                   ^
#32 4.341 
#32 4.341 Error: Digest method not supported
#32 4.341     at new Hash (node:internal/crypto/hash:67:19)
#32 4.341     at Object.createHash (node:crypto:130:10)
#32 4.341     at module.exports (/webpack/node_modules/webpack/lib/util/createHash.js:135:53)
#32 4.341     at NormalModule._initBuildHash (/webpack/node_modules/webpack/lib/NormalModule.js:417:16)
#32 4.341     at handleParseError (/webpack/node_modules/webpack/lib/NormalModule.js:471:10)
#32 4.341     at /webpack/node_modules/webpack/lib/NormalModule.js:503:5
#32 4.341     at /webpack/node_modules/webpack/lib/NormalModule.js:358:12
#32 4.341     at /webpack/node_modules/loader-runner/lib/LoaderRunner.js:373:3
#32 4.341     at iterateNormalLoaders (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
#32 4.341     at iterateNormalLoaders (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
#32 4.341     at /webpack/node_modules/loader-runner/lib/LoaderRunner.js:236:3
#32 4.341     at context.callback (/webpack/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
#32 4.341     at /webpack/node_modules/babel-loader/lib/index.js:59:71
#32 ERROR: executor failed running [/bin/sh -c npm run build]: exit code: 1
