### PR TITLE
[BUGFIX] Fix error on releases endpoint

### DIFF
--- a/api/server/handlers/release/create.go
+++ b/api/server/handlers/release/create.go
@@ -135,7 +135,9 @@ func (c *CreateReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	_, err = createBuildConfig(c.Config(), release, request.BuildConfig)
+	if request.BuildConfig != nil {
+		_, err = createBuildConfig(c.Config(), release, request.BuildConfig)
+	}
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If the user tries to deploy a docker image directly, the releases endpoint throws 500 but the release is still being created

## What is the new behavior?

User is now able again to create releases from docker image without problems

## Technical Spec/Implementation Notes

With the last changes implemented by the buildpacks update, the releases endpoint was also receiving an optional parameter called BuildConfig, but on the handler, we never checked if that object was empty or not before trying to create a build config.

Added an if statement to check out if the build config actually exists
```
if request.BuildConfig != nil {
  _, err = createBuildConfig(c.Config(), release, request.BuildConfig)
}