### PR TITLE
use cache from remote registry

### DIFF
--- a/cli/cmd/deploy/build.go
+++ b/cli/cmd/deploy/build.go
@@ -29,6 +29,7 @@ func (b *BuildAgent) BuildDocker(
 	buildCtx,
 	dockerfilePath,
 	tag string,
+	currentTag string,
 ) error {
 	buildCtx, dockerfilePath, isDockerfileInCtx, err := ResolveDockerPaths(
 		basePath,
@@ -43,6 +44,7 @@ func (b *BuildAgent) BuildDocker(
 	opts := &docker.BuildOpts{
 		ImageRepo:         b.imageRepo,
 		Tag:               tag,
+		CurrentTag:		   currentTag,
 		BuildContext:      buildCtx,
 		Env:               b.env,
 		DockerfilePath:    dockerfilePath,

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -281,7 +281,7 @@ func (c *CreateAgent) CreateFromDocker(
 	}
 
 	if opts.Method == DeployBuildTypeDocker {
-		err = buildAgent.BuildDocker(agent, opts.LocalPath, opts.LocalPath, opts.LocalDockerfile, "latest")
+		err = buildAgent.BuildDocker(agent, opts.LocalPath, opts.LocalPath, opts.LocalDockerfile, "latest", "")
 	} else {
 		err = buildAgent.BuildPack(agent, opts.LocalPath, "latest", nil)
 	}

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -238,10 +238,12 @@ func (d *DeployAgent) Build() error {
 		}
 	}
 
-	if d.tag == "" {
-		currImageSection := d.release.Config["image"].(map[string]interface{})
+	// retrieve current image to use for cache
+	currImageSection := d.release.Config["image"].(map[string]interface{})
+	currentTag := currImageSection["tag"].(string)
 
-		d.tag = currImageSection["tag"].(string)
+	if d.tag == "" {
+		d.tag = currentTag
 	}
 
 	err = d.pullCurrentReleaseImage()
@@ -269,6 +271,7 @@ func (d *DeployAgent) Build() error {
 			buildCtx,
 			d.dockerfilePath,
 			d.tag,
+			currentTag,
 		)
 	}
 

--- a/cli/cmd/docker/builder.go
+++ b/cli/cmd/docker/builder.go
@@ -21,6 +21,7 @@ import (
 type BuildOpts struct {
 	ImageRepo         string
 	Tag               string
+	CurrentTag		  string
 	BuildContext      string
 	DockerfilePath    string
 	IsDockerfileInCtx bool
@@ -66,6 +67,9 @@ func (a *Agent) BuildLocal(opts *BuildOpts) error {
 		BuildArgs:  buildArgs,
 		Tags: []string{
 			fmt.Sprintf("%s:%s", opts.ImageRepo, opts.Tag),
+		},
+		CacheFrom: []string{
+			fmt.Sprintf("%s:%s", opts.ImageRepo, opts.CurrentTag),
 		},
 		Remove: true,
 	})


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): CLI now uses the remote registry as the source of cache to speed up build times.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?
CLI uses docker cache during builds

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
