### PR TITLE
[POR-245] Use the build-plan buildpack when using the Paketo builders

### DIFF
--- a/api/server/handlers/gitinstallation/get_buildpack.go
+++ b/api/server/handlers/gitinstallation/get_buildpack.go
@@ -27,7 +27,7 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 	builders[buildpacks.HerokuBuilder] = &buildpacks.BuilderInfo{
 		Name: "Heroku",
 		Builders: []string{
-			"heroku/buildpacks:20",
+			buildpacks.DefaultBuilder,
 			"heroku/buildpacks:18",
 		},
 	}

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/pack"
 	"github.com/porter-dev/porter/api/types"
 	"github.com/porter-dev/porter/cli/cmd/docker"
+	"github.com/porter-dev/porter/internal/integrations/buildpacks"
 )
 
 type Agent struct{}
@@ -33,7 +34,7 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig) er
 	buildOpts := pack.BuildOptions{
 		RelativeBaseDir: filepath.Dir(absPath),
 		Image:           fmt.Sprintf("%s:%s", opts.ImageRepo, opts.Tag),
-		Builder:         "paketobuildpacks/builder:full",
+		Builder:         buildpacks.DefaultBuilder,
 		AppPath:         opts.BuildContext,
 		TrustBuilder:    true,
 		Env:             opts.Env,

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/buildpacks/pack"
 	"github.com/porter-dev/porter/api/types"
@@ -44,6 +45,10 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig) er
 			buildOpts.Buildpacks = buildConfig.Buildpacks
 		}
 		// FIXME: use all the config vars
+	}
+
+	if strings.HasPrefix(buildOpts.Builder, "paketo") {
+		buildOpts.Buildpacks = append(buildOpts.Buildpacks, "porterhub/paketo-build-plan:latest")
 	}
 
 	return client.Build(context, buildOpts)

--- a/internal/integrations/buildpacks/shared.go
+++ b/internal/integrations/buildpacks/shared.go
@@ -32,6 +32,8 @@ const (
 	// Builders
 	PaketoBuilder = "paketo"
 	HerokuBuilder = "heroku"
+
+	DefaultBuilder = "heroku/buildpacks:20"
 )
 
 type BuildpackInfo struct {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

We currently do not support having `plan.toml` in projects. The CLI currently defaults to the `paketo` builder.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR introduces the buildpack that supports having `plan.toml` files in project root directories into the CLI whenever using the `paketo` builders. It also changes the default builder from `paketo` to `heroku`.

## Technical Spec/Implementation Notes
