### PR TITLE
[POR-250] Custom logger for pack to hide env vars from being printed

### DIFF
--- a/cli/cmd/pack/logger.go
+++ b/cli/cmd/pack/logger.go
@@ -1,0 +1,75 @@
+package pack
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/buildpacks/pack/logging"
+)
+
+type packLogger struct {
+	out *log.Logger
+}
+
+// Replicate the exact behavior of https://github.com/buildpacks/pack/blob/main/pkg/logging/logger_simple.go
+func newPackLogger() logging.Logger {
+	return &packLogger{
+		out: log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds),
+	}
+}
+
+const (
+	debugPrefix = "DEBUG:"
+	infoPrefix  = "INFO:"
+	warnPrefix  = "WARN:"
+	errorPrefix = "ERROR:"
+	prefixFmt   = "%-7s %s"
+)
+
+func (l *packLogger) Debug(msg string) {
+	l.out.Printf(prefixFmt, debugPrefix, msg)
+}
+
+func (l *packLogger) Debugf(format string, v ...interface{}) {
+	// We do not want to print the environment variables for now as they might
+	// contain sensitive information like client IDs and secrets
+	// Refer: https://github.com/buildpacks/pack/blob/main/internal/builder/builder.go#L349
+	if !strings.HasPrefix(format, "Provided Environment Variables") {
+		l.out.Printf(prefixFmt, debugPrefix, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *packLogger) Info(msg string) {
+	l.out.Printf(prefixFmt, infoPrefix, msg)
+}
+
+func (l *packLogger) Infof(format string, v ...interface{}) {
+	l.out.Printf(prefixFmt, infoPrefix, fmt.Sprintf(format, v...))
+}
+
+func (l *packLogger) Warn(msg string) {
+	l.out.Printf(prefixFmt, warnPrefix, msg)
+}
+
+func (l *packLogger) Warnf(format string, v ...interface{}) {
+	l.out.Printf(prefixFmt, warnPrefix, fmt.Sprintf(format, v...))
+}
+
+func (l *packLogger) Error(msg string) {
+	l.out.Printf(prefixFmt, errorPrefix, msg)
+}
+
+func (l *packLogger) Errorf(format string, v ...interface{}) {
+	l.out.Printf(prefixFmt, errorPrefix, fmt.Sprintf(format, v...))
+}
+
+func (l *packLogger) Writer() io.Writer {
+	return l.out.Writer()
+}
+
+func (l *packLogger) IsVerbose() bool {
+	return false
+}

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -18,7 +18,7 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig) er
 	context := context.Background()
 
 	//initialize a pack client
-	client, err := pack.NewClient()
+	client, err := pack.NewClient(pack.WithLogger(newPackLogger()))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Currently we use `pack`'s default logger which means that it prints environment variables that are passed to it and it can be seen in plaintext through Porter's GHA.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now have a custom logger for `pack` that will not print the above mentioned environment variables to potentially protect sensitive data to be leaked.

## Technical Spec/Implementation Notes
