### PR TITLE
[POR-212] Clicking "Continue" button after provisioning displays onboarding modal

### DIFF
--- a/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
+++ b/dashboard/src/main/home/modals/SkipProvisioningModal.tsx
@@ -9,7 +9,7 @@ import styled from "styled-components";
  * will open this modal to let user skip onboarding and keep using porter.
  */
 const SkipOnboardingModal = () => {
-  const { currentModalData, setCurrentModal } = useContext(Context);
+  const { currentModalData, setHasFinishedOnboarding } = useContext(Context);
 
   return (
     <>
@@ -22,10 +22,12 @@ const SkipOnboardingModal = () => {
         <ActionButton
           text="Yes, skip setup"
           color="#616FEEcc"
-          onClick={() =>
-            typeof currentModalData?.skipOnboarding === "function" &&
-            currentModalData.skipOnboarding()
-          }
+          onClick={() => {
+            if (typeof currentModalData?.skipOnboarding === "function") {
+              currentModalData.skipOnboarding();
+            }
+            setHasFinishedOnboarding(true);
+          }}
           status={""}
           clearPosition
         />

--- a/dashboard/src/main/home/onboarding/Onboarding.tsx
+++ b/dashboard/src/main/home/onboarding/Onboarding.tsx
@@ -135,7 +135,7 @@ const Onboarding = () => {
 
       const hasClusters = Array.isArray(clusters) && clusters.length;
 
-      if (hasClusters) {
+      if (hasClusters && !context.hasFinishedOnboarding) {
         setCurrentModal("SkipOnboardingModal", { skipOnboarding });
       }
     } catch (error) {

--- a/dashboard/src/main/home/onboarding/state/StepHandler.ts
+++ b/dashboard/src/main/home/onboarding/state/StepHandler.ts
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { useLocation } from "react-router";
+import { Context } from "shared/Context";
 import { useRouting } from "shared/routing";
 import { proxy, useSnapshot } from "valtio";
 import { StepKey, Steps } from "../types";
@@ -287,12 +288,15 @@ export const useSteps = (isParentLoading?: boolean) => {
   const snap = useSnapshot(StepHandler);
   const location = useLocation();
   const { pushFiltered } = useRouting();
+  const { setHasFinishedOnboarding } = useContext(Context);
+
   useEffect(() => {
     if (isParentLoading) {
       return;
     }
     if (snap.currentStepName === "clean_up") {
       StepHandler.actions.clearState();
+      setHasFinishedOnboarding(true);
     }
     pushFiltered(snap.currentStep.url, ["tab"]);
   }, [location.pathname, snap.currentStep?.url, isParentLoading]);


### PR DESCRIPTION


## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a frontend change, Prettier has been run

## What is the current behavior?

After finishing onboarding there's a bug where the "Continue onboarding" or "Skip onboarding" modal showed up when the user already finished up all the onboarding.

## What is the new behavior?

Set to global context that the onboarding finished from the onboarding process instead of relying on an API call
