### PR TITLE
[POR-251] `Certificates` Tab inside cert-manager chart crashes (type error)

### DIFF
--- a/dashboard/src/components/porter-form/field-components/ResourceList.tsx
+++ b/dashboard/src/components/porter-form/field-components/ResourceList.tsx
@@ -27,8 +27,15 @@ const ResourceList: React.FC<ResourceListField> = (props) => {
   };
 
   useEffect(() => {
+    if (
+      !formState?.variables?.currentChart?.name ||
+      !formState?.variables?.namespace
+    ) {
+      return () => {};
+    }
+
     let { group, version, resource } = props.context.config;
-    let apiEndpoint = `/api/projects/${currentProject.id}/clusters/${currentCluster.id}/namespaces/${formState.variables.namespace}/releases/${formState.variables.currentChart.name}/0/form_stream?`;
+    let apiEndpoint = `/api/projects/${currentProject.id}/clusters/${currentCluster.id}/namespaces/${formState?.variables?.namespace}/releases/${formState?.variables?.currentChart?.name}/0/form_stream?`;
     apiEndpoint += `resource=${resource}&group=${group}&version=${version}`;
 
     const wsConfig = {
@@ -81,7 +88,7 @@ const ResourceList: React.FC<ResourceListField> = (props) => {
     return () => {
       closeAllWebsockets();
     };
-  }, []);
+  }, [formState?.variables?.currentChart, formState?.variables?.namespace]);
 
   return (
     <ResourceListWrapper>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Each time a user wanted to renew certificates or even see the status of their certs the application just crashed out

## What is the new behavior?

Added null safe to the resource list component so it waits for the data to be loaded before trying to make any request.

## Technical Spec/Implementation Notes
