### PR TITLE
[BUGFIX] Fix null is not iterable on buildpacks list

### DIFF
--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -254,11 +254,9 @@ export const BuildpackSelection: React.FC<{
   const [stacks, setStacks] = useState<string[]>(null);
   const [selectedStack, setSelectedStack] = useState<string>(null);
 
-  const [selectedBuildpacks, setSelectedBuildpacks] = useState<Buildpack[]>(
-    null
-  );
+  const [selectedBuildpacks, setSelectedBuildpacks] = useState<Buildpack[]>([]);
   const [availableBuildpacks, setAvailableBuildpacks] = useState<Buildpack[]>(
-    null
+    []
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Frontend throws an error when the API doesn't detect any buildpack automatically.

## Technical Spec/Implementation Notes

Modified initial object for selected buildpacks and available buildpacks so it doesn't try to iterate null, now the initial object is an array so if the API doesn't detect a buildpack the selectedBuildpacks will be able to iterate without problems