### PR TITLE
[POR-268] Use amd64 for Docker images by default

### DIFF
--- a/cli/cmd/docker/agent.go
+++ b/cli/cmd/docker/agent.go
@@ -243,6 +243,7 @@ func (a *Agent) getPullOptions(image string) (types.ImagePullOptions, error) {
 
 	return types.ImagePullOptions{
 		RegistryAuth: authConfigEncoded,
+		Platform:     "linux/amd64",
 	}, nil
 }
 

--- a/cli/cmd/docker/builder.go
+++ b/cli/cmd/docker/builder.go
@@ -71,7 +71,8 @@ func (a *Agent) BuildLocal(opts *BuildOpts) error {
 		CacheFrom: []string{
 			fmt.Sprintf("%s:%s", opts.ImageRepo, opts.CurrentTag),
 		},
-		Remove: true,
+		Remove:   true,
+		Platform: "linux/amd64",
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

By default Docker images built on Apple Silicon default to `arm64`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Use the `amd64` arch by default for all Docker images.

## Technical Spec/Implementation Notes
