### PR TITLE
[BUGFIX] Added guardrail in case detected or available buildpacks come null

### DIFF
--- a/dashboard/src/components/repo-selector/ActionDetails.tsx
+++ b/dashboard/src/components/repo-selector/ActionDetails.tsx
@@ -308,9 +308,12 @@ export const BuildpackSelection: React.FC<{
 
         setStacks(defaultBuilder.builders);
         setSelectedStack(defaultStack);
-
-        setSelectedBuildpacks(detectedBuildpacks);
-        setAvailableBuildpacks(availableBuildpacks);
+        if (!Array.isArray(detectedBuildpacks)) {
+          setSelectedBuildpacks([]);
+        }
+        if (!Array.isArray(availableBuildpacks)) {
+          setAvailableBuildpacks([]);
+        }
       })
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

Currently if the endpoint returns a null on detected or available buildpacks the frontend throws error when trying to add a buildpack to the stack