### PR TITLE
[POR-277] `porter run` should read from `--namespace` properly

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -325,7 +325,7 @@ func executeRunEphemeral(config *PorterRunSharedConfig, namespace, name, contain
 	req := config.RestClient.Post().
 		Resource("pods").
 		Name(podName).
-		Namespace("default").
+		Namespace(namespace).
 		SubResource("attach")
 
 	req.Param("stdin", "true")

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -45,13 +45,13 @@ services:
       - 6379:6379
     volumes:
       - database:/var/lib/postgresql/data
-  chartmuseum:
-    image: docker.io/bitnami/chartmuseum:0-debian-10
-    container_name: chartmuseum
-    ports:
-      - 5000:8080
-    volumes:
-      - chartmuseum:/bitnami/data
+  # chartmuseum:
+  #   image: docker.io/bitnami/chartmuseum:0-debian-10
+  #   container_name: chartmuseum
+  #   ports:
+  #     - 5000:8080
+  #   volumes:
+  #     - chartmuseum:/bitnami/data
   nginx:
     image: nginx:mainline-alpine
     container_name: nginx


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When executing `porter run` with the ephemeral pod option, the `--namespace` flag isn't propagated to the TTY stream request. 

## What is the new behavior?

Propagate `--namespace` option properly. 

## Technical Spec/Implementation Notes
