### PR TITLE
Rewrite ListRelease endpoint to query secrets directly, rather than using Helm

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -74,7 +74,6 @@ const ChartList: React.FunctionComponent<Props> = ({
             "pending-install",
             "pending-upgrade",
             "pending-rollback",
-            "superseded",
             "failed",
           ],
         },

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -34,14 +34,12 @@ func (a *Agent) ListReleases(
 	filter *types.ReleaseListFilter,
 ) ([]*release.Release, error) {
 	lsel := fmt.Sprintf("owner=helm,status in (%s)", strings.Join(filter.StatusFilter, ","))
-	fsel := fmt.Sprintf("type=helm.sh/release.v1")
 
 	// list secrets
 	secretList, err := a.K8sAgent.Clientset.CoreV1().Secrets(namespace).List(
 		context.Background(),
 		v1.ListOptions{
 			LabelSelector: lsel,
-			FieldSelector: fsel,
 		},
 	)
 

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -1,7 +1,10 @@
 package helm
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/porter-dev/porter/internal/helm/loader"
@@ -9,6 +12,8 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/helm/pkg/chartutil"
 
 	"github.com/porter-dev/porter/api/types"
@@ -28,11 +33,63 @@ func (a *Agent) ListReleases(
 	namespace string,
 	filter *types.ReleaseListFilter,
 ) ([]*release.Release, error) {
-	cmd := action.NewList(a.ActionConfig)
+	lsel := fmt.Sprintf("owner=helm,status in (%s)", strings.Join(filter.StatusFilter, ","))
+	fsel := fmt.Sprintf("type=helm.sh/release.v1")
 
-	filter.Apply(cmd)
+	// list secrets
+	secretList, err := a.K8sAgent.Clientset.CoreV1().Secrets(namespace).List(
+		context.Background(),
+		v1.ListOptions{
+			LabelSelector: lsel,
+			FieldSelector: fsel,
+		},
+	)
 
-	return cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// before decoding to helm release, only keep the latest releases for each chart
+	latestMap := make(map[string]corev1.Secret)
+
+	for _, secret := range secretList.Items {
+		relName, relNameExists := secret.Labels["name"]
+
+		if !relNameExists {
+			continue
+		}
+
+		id := fmt.Sprintf("%s/%s", secret.Namespace, relName)
+
+		if currLatest, exists := latestMap[id]; exists {
+			// get version
+			currVersionStr, currVersionExists := currLatest.Labels["version"]
+			versionStr, versionExists := secret.Labels["version"]
+
+			if versionExists && currVersionExists {
+				currVersion, currErr := strconv.Atoi(currVersionStr)
+				version, err := strconv.Atoi(versionStr)
+				if currErr != nil && err != nil && currVersion < version {
+					latestMap[id] = secret
+				}
+			}
+		} else {
+			latestMap[id] = secret
+		}
+	}
+
+	chartList := []string{}
+	res := make([]*release.Release, 0)
+
+	for _, secret := range latestMap {
+		rel, isErr, err := kubernetes.ParseSecretToHelmRelease(secret, chartList)
+
+		if !isErr && err == nil {
+			res = append(res, rel)
+		}
+	}
+
+	return res, nil
 }
 
 // GetRelease returns the info of a release.

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -876,7 +876,7 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func parseSecretToHelmRelease(secret v1.Secret, chartList []string) (*rspb.Release, bool, error) {
+func ParseSecretToHelmRelease(secret v1.Secret, chartList []string) (*rspb.Release, bool, error) {
 	if secret.Type != "helm.sh/release.v1" {
 		return nil, true, nil
 	}
@@ -934,7 +934,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					return
 				}
 
-				helm_object, isNotHelmRelease, err := parseSecretToHelmRelease(*secretObj, chartList)
+				helm_object, isNotHelmRelease, err := ParseSecretToHelmRelease(*secretObj, chartList)
 
 				if isNotHelmRelease && err == nil {
 					return
@@ -960,7 +960,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					return
 				}
 
-				helm_object, isNotHelmRelease, err := parseSecretToHelmRelease(*secretObj, chartList)
+				helm_object, isNotHelmRelease, err := ParseSecretToHelmRelease(*secretObj, chartList)
 
 				if isNotHelmRelease && err == nil {
 					return
@@ -986,7 +986,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					return
 				}
 
-				helm_object, isNotHelmRelease, err := parseSecretToHelmRelease(*secretObj, chartList)
+				helm_object, isNotHelmRelease, err := ParseSecretToHelmRelease(*secretObj, chartList)
 
 				if isNotHelmRelease && err == nil {
 					return


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): optimization

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Calling the `action.List` method from the Helm packages is inefficient as it queries for every secret without using Field or Label selectors, and decodes every release. 

## What is the new behavior?

Write our own implementation for listing releases. This implementation includes a label selector for certain statuses and a field selector for Helm secrets. It also only decodes the latest release, rather than every release. 

## Technical Spec/Implementation Notes
