### PR TITLE
Updated the docs on client IP preservation

### DIFF
--- a/docs/guides/preserving-client-ip-addresses.md
+++ b/docs/guides/preserving-client-ip-addresses.md
@@ -1,5 +1,9 @@
 # AWS
 
+> 🚧 Update: December 10 2021
+>
+> Please note that clusters provisioned on Amazon EKS after December 10 2021 will have support for proxying external IPs configured by default.
+
 > 🚧
 > 
 > Changing this configuration may result in a few minutes of downtime. It is recommended to set up client IP addresses before the application is live, or update it during a maintenance window. For more information, see [this Github issue](https://github.com/porter-dev/porter/issues/632#issuecomment-832939982).


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): Docs

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [X] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Updated the docs on client IP preservation to include a note about this being a default for all EKS clusters provisioned after Dec 10 2021.

-->

## What is the new behavior?

Docs will now show a notice about EKS clusters preserving client IPs by default, negating the need for reconfiguring `ingress-nginx` on clusters created after December 10 2021.

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
NA
