### PR TITLE
[POR-287] Job last run status is incorrect

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -204,6 +204,11 @@ const ChartList: React.FunctionComponent<Props> = ({
       },
       onmessage: (evt: MessageEvent) => {
         let event = JSON.parse(evt.data);
+
+        if (event.event_type === "DELETE") {
+          return;
+        }
+
         let object = event.Object;
 
         if (_.get(object.metadata, ["annotations", "helm.sh/hook"])) {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Pod status shows an incorrect execution time.

## Technical Spec/Implementation Notes

K8s Job informer sends a DELETE event some time after the job was created (apparently has a max number of job statuses that can hold), the issue was on the FE where we weren't checking properly this case, and we were assuming all events were ADD/UPDATE, so whenever a DELETE event came up, the frontend would update the status as if that DELETE event was add or update 
