### PR TITLE
[POR-289] Add option to set instance name that identifies GHA secrets/actions

### DIFF
--- a/api/server/handlers/release/create.go
+++ b/api/server/handlers/release/create.go
@@ -247,6 +247,7 @@ func createGitAction(
 
 	// create the commit in the git repo
 	gaRunner := &actions.GithubActions{
+		InstanceName:           config.ServerConf.InstanceName,
 		ServerURL:              config.ServerConf.ServerURL,
 		GithubOAuthIntegration: nil,
 		GithubAppID:            config.GithubAppConf.AppID,

--- a/api/server/shared/config/env/envconfs.go
+++ b/api/server/shared/config/env/envconfs.go
@@ -6,7 +6,14 @@ import "time"
 type ServerConf struct {
 	Debug bool `env:"DEBUG,default=false"`
 
-	ServerURL            string        `env:"SERVER_URL,default=http://localhost:8080"`
+	ServerURL string `env:"SERVER_URL,default=http://localhost:8080"`
+
+	// The instance name is used to set a name for integrations linked only by a project ID,
+	// in order to differentiate between the same project ID on different instances. For example,
+	// when writing a Github secret with `PORTER_TOKEN_<PROJECT_ID>`, setting this value will change
+	// this to `PORTER_TOKEN_<INSTANCE_NAME>_<PROJECT_ID>`
+	InstanceName string `env:"INSTANCE_NAME"`
+
 	Port                 int           `env:"SERVER_PORT,default=8080"`
 	StaticFilePath       string        `env:"STATIC_FILE_PATH,default=/porter/static"`
 	CookieName           string        `env:"COOKIE_NAME,default=porter"`

--- a/internal/integrations/ci/actions/actions.go
+++ b/internal/integrations/ci/actions/actions.go
@@ -21,7 +21,8 @@ import (
 )
 
 type GithubActions struct {
-	ServerURL string
+	ServerURL    string
+	InstanceName string
 
 	GithubOAuthIntegration *models.GitRepo
 	GitRepoName            string
@@ -339,12 +340,23 @@ func (g *GithubActions) getBuildEnvSecretName() string {
 }
 
 func (g *GithubActions) getPorterYMLFileName() string {
+	if g.InstanceName != "" {
+		return fmt.Sprintf("porter_%s_%s.yml", strings.Replace(
+			strings.ToLower(g.ReleaseName), "-", "_", -1),
+			strings.ToLower(g.InstanceName),
+		)
+	}
+
 	return fmt.Sprintf("porter_%s.yml", strings.Replace(
 		strings.ToLower(g.ReleaseName), "-", "_", -1),
 	)
 }
 
 func (g *GithubActions) getPorterTokenSecretName() string {
+	if g.InstanceName != "" {
+		return fmt.Sprintf("PORTER_TOKEN_%s_%d", strings.ToUpper(g.InstanceName), g.ProjectID)
+	}
+
 	return fmt.Sprintf("PORTER_TOKEN_%d", g.ProjectID)
 }
 


### PR DESCRIPTION
…names

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): improved multi-instance functionality

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If multiple Porter instances are connected to a repo, there may be a name collision on the written file names or secrets. For example, `PORTER_TOKEN_1` may be overwritten if another Porter instance has that token.

## What is the new behavior?

Add option to add an instance name to the Porter instance, using the env variable `INSTANCE_NAME`. 

## Technical Spec/Implementation Notes
