### PR TITLE
Notify for all critical job events

### DIFF
--- a/api/server/handlers/kube_events/create.go
+++ b/api/server/handlers/kube_events/create.go
@@ -119,7 +119,7 @@ func notifyPodCrashing(
 			Namespace:   event.Namespace,
 			Info:        fmt.Sprintf("%s:%s", event.Reason, event.Message),
 			URL: fmt.Sprintf(
-				"%s/jobs/%s?project_id=%d",
+				"%s/jobs?cluster=%s&project_id=%d",
 				config.ServerConf.ServerURL,
 				url.PathEscape(cluster.Name),
 				cluster.ProjectID,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): change alerting behavior

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Jobs aren't notifying on error because the owner name doesn't map on directly to a Porter release. 

## What is the new behavior?

If the owner type is a job, always notify -- usually jobs aren't critical for alerting, 5 min rolling windows don't make sense since they aren't deployments. 

## Technical Spec/Implementation Notes
