### PR TITLE
Fix several issues with `sidecar` container responsible for stopping jobs 

### DIFF
--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -152,7 +152,7 @@ func (repo *ClusterRepository) CreateCluster(
 
 	cluster.TokenCacheID = cluster.TokenCache.ID
 
-	if err := ctxDB.Save(cluster).Error; err != nil {
+	if err := ctxDB.Debug().Save(cluster).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/repository/gorm/cluster.go
+++ b/internal/repository/gorm/cluster.go
@@ -152,7 +152,7 @@ func (repo *ClusterRepository) CreateCluster(
 
 	cluster.TokenCacheID = cluster.TokenCache.ID
 
-	if err := ctxDB.Debug().Save(cluster).Error; err != nil {
+	if err := ctxDB.Save(cluster).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/repository/gorm/event.go
+++ b/internal/repository/gorm/event.go
@@ -1,7 +1,6 @@
 package gorm
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -92,8 +91,6 @@ func (repo *KubeEventRepository) CreateEvent(
 	if err := query.Model([]*models.KubeEvent{}).Count(&count).Error; err != nil {
 		return nil, err
 	}
-
-	fmt.Println("COUNT IS", event.Name, count)
 
 	// if the count is greater than 500, remove the lowest-order event to implement a
 	// basic fixed-length buffer
@@ -240,8 +237,6 @@ func (repo *KubeEventRepository) AppendSubEvent(event *models.KubeEvent, subEven
 	if err := query.Model([]*models.KubeSubEvent{}).Count(&count).Error; err != nil {
 		return err
 	}
-
-	fmt.Println("COUNT IS (subevents)", event.Name, count)
 
 	// if the count is greater than 20, remove the lowest-order events to implement a
 	// basic fixed-length buffer

--- a/internal/repository/gorm/event.go
+++ b/internal/repository/gorm/event.go
@@ -99,7 +99,7 @@ func (repo *KubeEventRepository) CreateEvent(
 	// basic fixed-length buffer
 	if count >= 500 {
 		// first, delete the matching sub events
-		err := repo.db.Debug().Exec(`
+		err := repo.db.Exec(`
 		  DELETE FROM kube_sub_events 
 		  WHERE kube_event_id IN (
 			SELECT id FROM kube_events k2 WHERE (k2.project_id = ? AND k2.cluster_id = ?) AND k2.id NOT IN (
@@ -113,7 +113,7 @@ func (repo *KubeEventRepository) CreateEvent(
 		}
 
 		// then, delete the matching events
-		err = repo.db.Debug().Exec(`
+		err = repo.db.Exec(`
 		  DELETE FROM kube_events 
 		  WHERE (project_id = ? AND cluster_id = ?) AND id NOT IN (
 			SELECT id FROM kube_events k2 WHERE (k2.project_id = ? AND k2.cluster_id = ?) ORDER BY k2.updated_at desc, k2.id desc LIMIT 499

--- a/services/job_sidecar_container/Dockerfile
+++ b/services/job_sidecar_container/Dockerfile
@@ -5,6 +5,6 @@ RUN apk --no-cache add procps coreutils
 
 COPY *.sh .
 
-RUN ["chmod", "+x", "./job_killer.sh", "./signal.sh", "./sidecar_killer.sh"]
+RUN ["chmod", "+x", "./job_killer.sh", "./signal.sh", "./sidecar_killer.sh", "./wait_for_job.sh"]
 
 ENTRYPOINT ["./job_killer.sh"]

--- a/services/job_sidecar_container/job_killer.sh
+++ b/services/job_sidecar_container/job_killer.sh
@@ -40,8 +40,6 @@ graceful_shutdown() {
 
     echo "searching for process pattern: $pattern"
 
-    # local target_pid_arr=$(ps x | grep -v './job_killer.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }' | sort)
-    # local target_pid=$target_pid_arr
     local target_pid=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait_for_job.sh' | grep -v 'grep' | awk '{ printf "%d ", $1 }' | sort)
     local list="$target_pid"
 

--- a/services/job_sidecar_container/sidecar_killer.sh
+++ b/services/job_sidecar_container/sidecar_killer.sh
@@ -7,13 +7,12 @@
 
 sidecar_pid=$(pgrep $1)
 
-
 if [ -n "$sidecar_pid" ]; then
     kill -TERM $sidecar_pid
 
     # schedule hard kill after 30 seconds
     (sleep 30; kill -9 -${sidecar_pid} 2>/dev/null || true) &
-    local killer=${!}
+    killer=${!}
 
     # wait for processes to finish
     wait ${sidecar_pid} 2>/dev/null || true

--- a/services/job_sidecar_container/wait_for_job.sh
+++ b/services/job_sidecar_container/wait_for_job.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Usage: wait_for_job.sh [process_pattern]
+#
+# This script waits for a job to be ready before exiting. 
+
+pattern=$1
+
+target_pid=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait_for_job.sh' | grep -v 'grep' | awk '{ printf "%d ", $1 }' | sort)
+
+
+# target_pid_arr=$(ps x | grep -v './job_killer.sh' | grep -v './wait_for_job.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }' | sort)
+# target_pid=$target_pid_arr
+
+while [ ! "$target_pid" ]; do 
+  sleep 0.1
+  target_pid=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait_for_job.sh' | grep -v 'grep' | awk '{ printf "%d ", $1 }' | sort)
+
+#   target_pid_arr=$(ps x | grep -v './job_killer.sh' | grep -v './wait_for_job.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }' | sort)
+#   target_pid=$target_pid_arr
+done

--- a/services/job_sidecar_container/wait_for_job.sh
+++ b/services/job_sidecar_container/wait_for_job.sh
@@ -8,14 +8,7 @@ pattern=$1
 
 target_pid=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait_for_job.sh' | grep -v 'grep' | awk '{ printf "%d ", $1 }' | sort)
 
-
-# target_pid_arr=$(ps x | grep -v './job_killer.sh' | grep -v './wait_for_job.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }' | sort)
-# target_pid=$target_pid_arr
-
 while [ ! "$target_pid" ]; do 
   sleep 0.1
   target_pid=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait_for_job.sh' | grep -v 'grep' | awk '{ printf "%d ", $1 }' | sort)
-
-#   target_pid_arr=$(ps x | grep -v './job_killer.sh' | grep -v './wait_for_job.sh' | grep "$pattern" | awk '{ printf "%d ", $1 }' | sort)
-#   target_pid=$target_pid_arr
 done


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

- `TERM` signal isn't propagated properly to additional sidecar containers like `cloud-sql-proxy`. 
- Stopping a job fails inconsistently when a matching process id isn't found. 
- We've set a static `sleep 10` to wait for job startup rather than listening for when the process is ready.

## What is the new behavior?

Fixes three issues above, implements more reliable stopping behavior and improved search for the job process id via `pgrep`. 

## Technical Spec/Implementation Notes
