### PR TITLE
Fix issue where latest Helm release is not populated

### DIFF
--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -67,7 +67,7 @@ func (a *Agent) ListReleases(
 			if versionExists && currVersionExists {
 				currVersion, currErr := strconv.Atoi(currVersionStr)
 				version, err := strconv.Atoi(versionStr)
-				if currErr != nil && err != nil && currVersion < version {
+				if currErr == nil && err == nil && currVersion < version {
 					latestMap[id] = secret
 				}
 			}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When multiple Helm releases are in a definite state, such as `failed` or `deployed`, the latest version isn't found successfully. 

## What is the new behavior?

Fixes issue above. 

## Technical Spec/Implementation Notes

Accidentally cased on `err != nil` rather than `err == nil` to decide whether or not to overwrite. 
