### PR TITLE
[POR-293] Add support for manually injecting env to build/deploy cli commands

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	api "github.com/porter-dev/porter/api/client"
@@ -204,8 +205,11 @@ var tag string
 var dockerfile string
 var method string
 var stream bool
+var buildFlagsEnv []string
 
 func init() {
+	buildFlagsEnv = []string{}
+
 	rootCmd.AddCommand(updateCmd)
 
 	updateCmd.PersistentFlags().StringVar(
@@ -260,6 +264,14 @@ func init() {
 		"dockerfile",
 		"",
 		"the path to the dockerfile",
+	)
+
+	updateCmd.PersistentFlags().StringArrayVarP(
+		&buildFlagsEnv,
+		"env",
+		"e",
+		[]string{},
+		"Build-time environment variable, in the form 'VAR=VALUE'. These are not available at image runtime.",
 	)
 
 	updateCmd.PersistentFlags().StringVar(
@@ -382,6 +394,15 @@ func updateGetAgent(client *api.Client) (*deploy.DeployAgent, error) {
 		buildMethod = deploy.DeployBuildType(method)
 	}
 
+	// add additional env, if they exist
+	additionalEnv := make(map[string]string)
+
+	for _, buildEnv := range buildFlagsEnv {
+		if strSplArr := strings.SplitN(buildEnv, "=", 2); len(strSplArr) >= 2 {
+			additionalEnv[strSplArr[0]] = strSplArr[1]
+		}
+	}
+
 	// initialize the update agent
 	return deploy.NewDeployAgent(client, app, &deploy.DeployOpts{
 		SharedOpts: &deploy.SharedOpts{
@@ -392,6 +413,7 @@ func updateGetAgent(client *api.Client) (*deploy.DeployAgent, error) {
 			LocalDockerfile: dockerfile,
 			OverrideTag:     tag,
 			Method:          buildMethod,
+			AdditionalEnv:   additionalEnv,
 		},
 		Local: source != "github",
 	})

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -272,6 +272,11 @@ func (c *CreateAgent) CreateFromDocker(
 		env = map[string]string{}
 	}
 
+	// add additional env based on options
+	for key, val := range opts.SharedOpts.AdditionalEnv {
+		env[key] = val
+	}
+
 	buildAgent := &BuildAgent{
 		SharedOpts:  opts.SharedOpts,
 		client:      c.Client,

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -142,7 +142,18 @@ func NewDeployAgent(client *client.Client, app string, opts *DeployOpts) (*Deplo
 
 // GetBuildEnv retrieves the build env from the release config and returns it
 func (d *DeployAgent) GetBuildEnv() (map[string]string, error) {
-	return GetEnvFromConfig(d.release.Config)
+	env, err := GetEnvFromConfig(d.release.Config)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// add additional env based on options
+	for key, val := range d.opts.SharedOpts.AdditionalEnv {
+		env[key] = val
+	}
+
+	return env, nil
 }
 
 // SetBuildEnv sets the build env vars in the process so that other commands can

--- a/cli/cmd/deploy/shared.go
+++ b/cli/cmd/deploy/shared.go
@@ -9,4 +9,5 @@ type SharedOpts struct {
 	LocalDockerfile string
 	OverrideTag     string
 	Method          DeployBuildType
+	AdditionalEnv   map[string]string
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe): 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No way to override or add build-time environment variables for `porter create` and `porter update` commands. 

## What is the new behavior?

Add `--env` flag, which sets only build-time env for the `create` and `update` commands. Example:

```
porter update get-env --app test-get-env --env BUILD_TIME=var1 --env BUILD_TIME_2=var2
```

Output:

```
TEST0=testing0
TEST1=testing1
BUILD_TIME=var1
BUILD_TIME_2=var2
```

## Technical Spec/Implementation Notes
