### PR TITLE
Don't notify on successful job deployments through Slack alerter

### DIFF
--- a/api/server/handlers/release/ugprade.go
+++ b/api/server/handlers/release/ugprade.go
@@ -167,10 +167,12 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	notifyOpts.Status = slack.StatusHelmDeployed
-	notifyOpts.Version = helmRelease.Version
+	if helmRelease.Chart != nil && helmRelease.Chart.Metadata.Name != "job" {
+		notifyOpts.Status = slack.StatusHelmDeployed
+		notifyOpts.Version = helmRelease.Version
 
-	notifier.Notify(notifyOpts)
+		notifier.Notify(notifyOpts)
+	}
 
 	// update the github actions env if the release exists and is built from source
 	if cName := helmRelease.Chart.Metadata.Name; cName == "job" || cName == "web" || cName == "worker" {

--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -182,10 +182,12 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notifyOpts.Status = slack.StatusHelmDeployed
-	notifyOpts.Version = rel.Version
+	if rel.Chart != nil && rel.Chart.Metadata.Name != "job" {
+		notifyOpts.Status = slack.StatusHelmDeployed
+		notifyOpts.Version = rel.Version
 
-	notifier.Notify(notifyOpts)
+		notifier.Notify(notifyOpts)
+	}
 
 	c.Config().AnalyticsClient.Track(analytics.ApplicationDeploymentWebhookTrack(&analytics.ApplicationDeploymentWebhookTrackOpts{
 		ImageURI: fmt.Sprintf("%v", repository),


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Successful job deployments have little meaning because they don't correspond to a successful job run, only a config change. 

## What is the new behavior?

Stop notifying on successful job deployments. 

## Technical Spec/Implementation Notes
