### PR TITLE
[BUGFIX] Hide porter agent from community addons and circular dependency on chart deploy

### DIFF
--- a/dashboard/src/main/home/launch/Launch.tsx
+++ b/dashboard/src/main/home/launch/Launch.tsx
@@ -26,6 +26,8 @@ const tabOptions = [
   { label: "Community Add-ons", value: "community" },
 ];
 
+const HIDDEN_CHARTS = ["porter-agent"];
+
 type PropsType = RouteComponentProps & {};
 
 type StateType = {
@@ -74,7 +76,9 @@ class Templates extends Component<PropsType, StateType> {
         };
       });
       sortedVersionData.sort((a: any, b: any) => (a.name > b.name ? 1 : -1));
-
+      sortedVersionData = sortedVersionData.filter(
+        (template: any) => !HIDDEN_CHARTS.includes(template?.name)
+      );
       this.setState({ addonTemplates: sortedVersionData, error: false });
     } catch (error) {
       this.setState({ loading: false, error: true });

--- a/dashboard/src/main/home/launch/launch-flow/SettingsPage.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/SettingsPage.tsx
@@ -175,7 +175,7 @@ class SettingsPage extends Component<PropsType, StateType> {
           </Placeholder>
           <SaveButton
             text="Deploy"
-            onClick={onSubmit}
+            onClick={() => onSubmit({})}
             status={saveValuesStatus}
             makeFlush={true}
           />


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Porter agent is currently showing over the community addons.
When user tries to deploy a chart that doesn't have any form.yaml attached it throws a circular dependency error

## What is the new behavior?

Hide porter agent from community addons so the user can only install it from the events tab 
Fixed circular dependency error.

## Technical Spec/Implementation Notes
