### PR TITLE
[POR-225] Fix fetching of crashed pod logs

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
@@ -103,26 +103,26 @@ export default class Logs extends Component<PropsType, StateType> {
       );
     }
 
-    // if (
-    //   this.getPodStatus(selectedPod.status) === "failed" &&
-    //   this.state.logs.length === 0
-    // ) {
-    //   return (
-    //     <Message>
-    //       No logs to display from this pod.
-    //       <Highlight
-    //         onClick={() => {
-    //           this.setState({ getPreviousLogs: true }, () => {
-    //             this.refreshLogs();
-    //           });
-    //         }}
-    //       >
-    //         <i className="material-icons">autorenew</i>
-    //         Get logs from crashed pod
-    //       </Highlight>
-    //     </Message>
-    //   );
-    // }
+    if (
+      this.getPodStatus(selectedPod.status) === "failed" &&
+      this.state.logs.length === 0
+    ) {
+      return (
+        <Message>
+          No logs to display from this pod.
+          <Highlight
+            onClick={() => {
+              this.setState({ getPreviousLogs: true }, () => {
+                this.refreshLogs();
+              });
+            }}
+          >
+            <i className="material-icons">autorenew</i>
+            Get logs from crashed pod
+          </Highlight>
+        </Message>
+      );
+    }
 
     if (this.state.logs.length == 0) {
       return (
@@ -172,7 +172,7 @@ export default class Logs extends Component<PropsType, StateType> {
       );
     }
 
-    this.ws.onopen = () => {};
+    this.ws.onopen = () => { };
 
     this.ws.onmessage = (evt: MessageEvent) => {
       let ansiLog = Anser.ansiToJson(evt.data);
@@ -202,9 +202,9 @@ export default class Logs extends Component<PropsType, StateType> {
       );
     };
 
-    this.ws.onerror = (err: ErrorEvent) => {};
+    this.ws.onerror = (err: ErrorEvent) => { };
 
-    this.ws.onclose = () => {};
+    this.ws.onclose = () => { };
   };
 
   refreshLogs = () => {
@@ -365,7 +365,7 @@ export default class Logs extends Component<PropsType, StateType> {
               <input
                 type="checkbox"
                 checked={this.state.scroll}
-                onChange={() => {}}
+                onChange={() => { }}
               />
               Scroll to Bottom
             </Scroll>
@@ -409,7 +409,7 @@ export default class Logs extends Component<PropsType, StateType> {
             <input
               type="checkbox"
               checked={this.state.scroll}
-              onChange={() => {}}
+              onChange={() => { }}
             />
             Scroll to Bottom
           </Scroll>

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -568,9 +568,11 @@ func (a *Agent) GetPodLogs(namespace string, name string, showPreviousLogs bool,
 		return fmt.Errorf("Cannot get logs from pod %s: %s", name, err.Error())
 	}
 
-	// see if container is ready and able to open a stream. If not, wait for container
-	// to be ready.
-	err, _ = a.waitForPod(pod)
+	if !showPreviousLogs {
+		// see if container is ready and able to open a stream. If not, wait for container
+		// to be ready.
+		err, _ = a.waitForPod(pod)
+	}
 
 	if err != nil && goerrors.Is(err, IsNotFoundError) {
 		return IsNotFoundError


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Currently there is no way to get the logs of a previously crashed pod.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The user now has the ability to choose to fetch the previously crashed pod's logs.

## Technical Spec/Implementation Notes
