### PR TITLE
Add `BUILDKIT_INLINE_CACHE` build arg to Docker builder

### DIFF
--- a/cli/cmd/docker/builder.go
+++ b/cli/cmd/docker/builder.go
@@ -62,6 +62,10 @@ func (a *Agent) BuildLocal(opts *BuildOpts) error {
 		buildArgs[key] = &valCopy
 	}
 
+	// attach BUILDKIT_INLINE_CACHE=1 by default, to take advantage of caching
+	inlineCacheVal := "1"
+	buildArgs["BUILDKIT_INLINE_CACHE"] = &inlineCacheVal
+
 	out, err := a.client.ImageBuild(context.Background(), tar, types.ImageBuildOptions{
 		Dockerfile: dockerfilePath,
 		BuildArgs:  buildArgs,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): caching improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Without this build arg, can't take advantage of caching within CI script. 

## What is the new behavior?

Add this build arg, should speed up builds automatically.

## Technical Spec/Implementation Notes
