### PR TITLE
Fix homebrew release file to prevent hardcoding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TAG: ${{ github.ref }}
       - name: Create and commit porter.rb file
         run: |
-          version=v0.6.1
+          version=${{steps.tag_name.outputs.tag}}
           name=porter_${{steps.tag_name.outputs.tag}}_Darwin_x86_64.zip
           curl -L https://github.com/porter-dev/porter/releases/download/${version}/porter_${version}_Darwin_x86_64.zip --output $name
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Homebrew release file hardcoded to `v0.6.1`. 

## What is the new behavior?

Remove hardcoding of homebrew release file to download correct release. 

## Technical Spec/Implementation Notes
