### PR TITLE
refresh environments list when query changes

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/EnvironmentList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/EnvironmentList.tsx
@@ -150,7 +150,7 @@ const EnvironmentList = () => {
     return () => {
       isSubscribed = false;
     };
-  }, [currentProject, currentCluster]);
+  }, [currentProject, currentCluster, location.search]);
 
   useEffect(() => {
     setHasPermissionsLoaded(false);

--- a/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/components/ConnectNewRepo.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/components/ConnectNewRepo.tsx
@@ -16,7 +16,7 @@ import { useRouting } from "shared/routing";
 const porterYamlDocsLink =
   "https://docs.porter.run/preview-environments/porter-yaml-reference";
 
-const ConnectNewRepo: React.FC = (props) => {
+const ConnectNewRepo: React.FC = () => {
   const { currentProject, currentCluster, setCurrentError } = useContext(
     Context
   );

--- a/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/components/ConnectNewRepo.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/preview-environments/components/ConnectNewRepo.tsx
@@ -16,7 +16,7 @@ import { useRouting } from "shared/routing";
 const porterYamlDocsLink =
   "https://docs.porter.run/preview-environments/porter-yaml-reference";
 
-const ConnectNewRepo: React.FC = () => {
+const ConnectNewRepo: React.FC = (props) => {
   const { currentProject, currentCluster, setCurrentError } = useContext(
     Context
   );


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

"Enable preview environments" placeholder doesn't disappear until a hard refresh, after enabling it the first time. 

## What is the new behavior?

Query for list of environments after connecting a new repository to preview environments.

## Technical Spec/Implementation Notes
