### PR TITLE
Update base path for Docker builds to be consistent between `porter create`/`porter update`

### DIFF
--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -292,7 +292,13 @@ func (c *CreateAgent) CreateFromDocker(
 	}
 
 	if opts.Method == DeployBuildTypeDocker {
-		err = buildAgent.BuildDocker(agent, opts.LocalPath, opts.LocalPath, opts.LocalDockerfile, imageTag, "")
+		basePath, err := filepath.Abs(".")
+
+		if err != nil {
+			return "", err
+		}
+
+		err = buildAgent.BuildDocker(agent, basePath, opts.LocalPath, opts.LocalDockerfile, imageTag, "")
 	} else {
 		err = buildAgent.BuildPack(agent, opts.LocalPath, imageTag, "", extraBuildConfig)
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

`porter create` and `porter update` have different strategies for determining the Dockerfile location. `porter create` looks for a Dockerfile in the specified path relative to the build context, while `porter update` looks for a Dockerfile in the specified path relative to the root directory. 

## What is the new behavior?

Make it consistent between `porter create` and `porter update`. 

## Technical Spec/Implementation Notes
