### PR TITLE
Add option to the cluster model to turn off notifications

### DIFF
--- a/api/server/handlers/kube_events/create.go
+++ b/api/server/handlers/kube_events/create.go
@@ -113,6 +113,11 @@ func notifyPodCrashing(
 	cluster *models.Cluster,
 	event *types.CreateKubeEventRequest,
 ) error {
+	// if cluster has notifications turned off, don't alert
+	if cluster.NotificationsDisabled {
+		return nil
+	}
+
 	// attempt to get a matching Porter release to get the notification configuration
 	var conf *models.NotificationConfig
 	var notifConfig *types.NotificationConfig

--- a/api/server/handlers/release/ugprade.go
+++ b/api/server/handlers/release/ugprade.go
@@ -157,7 +157,9 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		notifyOpts.Status = slack.StatusHelmFailed
 		notifyOpts.Info = upgradeErr.Error()
 
-		notifier.Notify(notifyOpts)
+		if !cluster.NotificationsDisabled {
+			notifier.Notify(notifyOpts)
+		}
 
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 			upgradeErr,
@@ -171,7 +173,9 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		notifyOpts.Status = slack.StatusHelmDeployed
 		notifyOpts.Version = helmRelease.Version
 
-		notifier.Notify(notifyOpts)
+		if !cluster.NotificationsDisabled {
+			notifier.Notify(notifyOpts)
+		}
 	}
 
 	// update the github actions env if the release exists and is built from source

--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -172,7 +172,9 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		notifyOpts.Status = slack.StatusHelmFailed
 		notifyOpts.Info = err.Error()
 
-		notifier.Notify(notifyOpts)
+		if !cluster.NotificationsDisabled {
+			notifier.Notify(notifyOpts)
+		}
 
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 			err,
@@ -186,7 +188,9 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		notifyOpts.Status = slack.StatusHelmDeployed
 		notifyOpts.Version = rel.Version
 
-		notifier.Notify(notifyOpts)
+		if !cluster.NotificationsDisabled {
+			notifier.Notify(notifyOpts)
+		}
 	}
 
 	c.Config().AnalyticsClient.Track(analytics.ApplicationDeploymentWebhookTrack(&analytics.ApplicationDeploymentWebhookTrackOpts{

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -51,6 +51,8 @@ type Cluster struct {
 
 	InfraID uint `json:"infra_id"`
 
+	NotificationsDisabled bool `json:"notifications_disabled"`
+
 	// ------------------------------------------------------------------
 	// All fields below this line are encrypted before storage
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): notifications improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

There's no way to configure alerts on a per-cluster basis. 

## What is the new behavior?

Add option to configure alerts on a per-cluster basis, just to the database for now. Supporting a view on the frontend for these notifications (and eventually changing notification configuration per cluster, namespace, etc) will be the subject of a future PR. 

## Technical Spec/Implementation Notes
