### PR TITLE
[POR-312] Add support for waitForJob in porter.yaml

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -320,14 +320,21 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 	if d.source.Name == "job" && appConfig.WaitForJob {
 		color.New(color.FgYellow).Printf("Waiting for job '%s' to finish\n", resource.Name)
 
+		prevProject := config.Project
+		prevCluster := config.Cluster
 		name = resource.Name
 		namespace = d.target.Namespace
+		config.Project = d.target.Project
+		config.Cluster = d.target.Cluster
 
 		err = waitForJob(nil, client, []string{})
 
 		if err != nil {
 			return nil, err
 		}
+
+		config.Project = prevProject
+		config.Cluster = prevCluster
 	}
 
 	return resource, err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now have support for a `waitForJob` field in the `config` section for jobs, set to `true` by default.

## Technical Spec/Implementation Notes
