### PR TITLE
[POR-314] Update CLI installation instructions in the dashboard

### DIFF
--- a/dashboard/src/main/home/modals/ClusterInstructionsModal.tsx
+++ b/dashboard/src/main/home/modals/ClusterInstructionsModal.tsx
@@ -28,40 +28,21 @@ export default class ClusterInstructionsModal extends Component<
       case 0:
         return (
           <Placeholder>
-            1. To install the Porter CLI, first retrieve the latest binary:
+            1. To install the Porter CLI, run the following in your terminal:
             <Code>
-              &#123;
-              <br />
-              name=$(curl -s
-              https://api.github.com/repos/porter-dev/porter/releases/latest |
-              grep "browser_download_url.*/porter_.*_Darwin_x86_64\.zip" | cut
-              -d ":" -f 2,3 | tr -d \")
-              <br />
-              name=$(basename $name)
-              <br />
-              curl -L
-              https://github.com/porter-dev/porter/releases/latest/download/$name
-              --output $name
-              <br />
-              unzip -a $name
-              <br />
-              rm $name
-              <br />
-              &#125;
+              /bin/bash -c "$(curl -fsSL https://install.porter.run)"
             </Code>
-            2. Move the file into your bin:
+            Alternatively, on macOS you can use Homebrew:
             <Code>
-              chmod +x ./porter
-              <br />
-              sudo mv ./porter /usr/local/bin/porter
+              brew install porter-dev/porter/porter
             </Code>
-            3. Log in to the Porter CLI:
+            2. Log in to the Porter CLI:
             <Code>
               porter config set-host {location.protocol + "//" + location.host}
               <br />
               porter auth login
             </Code>
-            4. Configure the Porter CLI and link your current context:
+            3. Configure the Porter CLI and link your current context:
             <Code>
               porter config set-project {this.context.currentProject.id}
               <br />

--- a/dashboard/src/main/home/onboarding/steps/ProvisionResources/forms/_ConnectExternalCluster.tsx
+++ b/dashboard/src/main/home/onboarding/steps/ProvisionResources/forms/_ConnectExternalCluster.tsx
@@ -48,7 +48,7 @@ const ConnectExternalCluster: React.FC<Props> = ({
           }
         }
       });
-    } catch (error) {}
+    } catch (error) { }
   };
 
   useEffect(() => {
@@ -64,45 +64,26 @@ const ConnectExternalCluster: React.FC<Props> = ({
       case 0:
         return (
           <Placeholder>
-            1. To install the Porter CLI, first retrieve the latest binary:
+            1. To install the Porter CLI, run the following in your terminal:
             <Code>
-              &#123;
-              <br />
-              name=$(curl -s
-              https://api.github.com/repos/porter-dev/porter/releases/latest |
-              grep "browser_download_url.*/porter_.*_Darwin_x86_64\.zip" | cut
-              -d ":" -f 2,3 | tr -d \")
-              <br />
-              name=$(basename $name)
-              <br />
-              curl -L
-              https://github.com/porter-dev/porter/releases/latest/download/$name
-              --output $name
-              <br />
-              unzip -a $name
-              <br />
-              rm $name
-              <br />
-              &#125;
+              /bin/bash -c "$(curl -fsSL https://install.porter.run)"
             </Code>
-            2. Move the file into your bin:
+            Alternatively, on macOS you can use Homebrew:
             <Code>
-              chmod +x ./porter
-              <br />
-              sudo mv ./porter /usr/local/bin/porter
+              brew install porter-dev/porter/porter
             </Code>
           </Placeholder>
         );
       case 1:
         return (
           <Placeholder>
-            3. Log in to the Porter CLI:
+            2. Log in to the Porter CLI:
             <Code>
               porter config set-host {location.protocol + "//" + location.host}
               <br />
               porter auth login
             </Code>
-            4. Configure the Porter CLI and link your current context:
+            3. Configure the Porter CLI and link your current context:
             <Code>
               porter config set-project {project.id}
               <br />


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Update

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

The dashboard uses the old CLI installation instructions.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The dashboard uses the new CLI installation instructions for https://install.porter.run.

## Technical Spec/Implementation Notes
