### PR TITLE
Write unlimited usage response if usage tracking is disabled

### DIFF
--- a/api/server/handlers/project/get_usage.go
+++ b/api/server/handlers/project/get_usage.go
@@ -28,6 +28,15 @@ func NewProjectGetUsageHandler(
 func (p *ProjectGetUsageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proj, _ := r.Context().Value(types.ProjectScope).(*models.Project)
 
+	if !p.Config().ServerConf.UsageTrackingEnabled {
+		p.WriteResult(w, r, &types.GetProjectUsageResponse{
+			Limit:      types.EnterprisePlan,
+			IsExceeded: false,
+		})
+
+		return
+	}
+
 	res := &types.GetProjectUsageResponse{}
 
 	currUsage, limit, usageCache, err := usage.GetUsage(&usage.GetUsageOpts{


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If usage tracking is disabled, the usage endpoint still returns a usage response.

## What is the new behavior?

If usage tracking is disabled, return unlimited. 

## Technical Spec/Implementation Notes
