### PR TITLE
Prevent builds on deployments to a registry

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -414,40 +414,43 @@ func (d *Driver) updateApplication(resource *models.Resource, client *api.Client
 		return nil, err
 	}
 
-	buildEnv, err := updateAgent.GetBuildEnv(&deploy.GetBuildEnvOpts{
-		UseNewConfig: true,
-		NewConfig:    appConf.Values,
-	})
+	// if the build method is registry, we do not trigger a build
+	if appConf.Build.Method != "registry" {
+		buildEnv, err := updateAgent.GetBuildEnv(&deploy.GetBuildEnvOpts{
+			UseNewConfig: true,
+			NewConfig:    appConf.Values,
+		})
 
-	if err != nil {
-		return nil, err
-	}
-
-	err = updateAgent.SetBuildEnv(buildEnv)
-
-	if err != nil {
-		return nil, err
-	}
-
-	var buildConfig *types.BuildConfig
-
-	if appConf.Build.Builder != "" {
-		buildConfig = &types.BuildConfig{
-			Builder:    appConf.Build.Builder,
-			Buildpacks: appConf.Build.Buildpacks,
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	err = updateAgent.Build(buildConfig)
+		err = updateAgent.SetBuildEnv(buildEnv)
 
-	if err != nil {
-		return nil, err
-	}
+		if err != nil {
+			return nil, err
+		}
 
-	err = updateAgent.Push()
+		var buildConfig *types.BuildConfig
 
-	if err != nil {
-		return nil, err
+		if appConf.Build.Builder != "" {
+			buildConfig = &types.BuildConfig{
+				Builder:    appConf.Build.Builder,
+				Buildpacks: appConf.Build.Buildpacks,
+			}
+		}
+
+		err = updateAgent.Build(buildConfig)
+
+		if err != nil {
+			return nil, err
+		}
+
+		err = updateAgent.Push()
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = updateAgent.UpdateImageAndValues(appConf.Values)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Local deploy process attempts to pull an image when the build type is set to `registry`. 

## What is the new behavior?

Do not pull image or build when build type is set to `registry`. 

## Technical Spec/Implementation Notes
