### PR TITLE
Use the registry tag if the preview environment build method is `registry` 

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -289,6 +289,19 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		tag = commit.Sha[:7]
 	}
 
+	// if the method is registry and a tag is defined, we use the provided tag
+	if appConfig.Build.Method == "registry" {
+		imageSpl := strings.Split(appConfig.Build.Image, ":")
+
+		if len(imageSpl) == 2 {
+			tag = imageSpl[1]
+		}
+
+		if tag == "" {
+			tag = "latest"
+		}
+	}
+
 	sharedOpts := &deploy.SharedOpts{
 		ProjectID:       d.target.Project,
 		ClusterID:       d.target.Cluster,
@@ -451,6 +464,11 @@ func (d *Driver) updateApplication(resource *models.Resource, client *api.Client
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// if the build method is registry and the image is set, use the image and compute the tag
+	if appConf.Build.Method == "registry" {
+
 	}
 
 	err = updateAgent.UpdateImageAndValues(appConf.Values)

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -466,11 +466,6 @@ func (d *Driver) updateApplication(resource *models.Resource, client *api.Client
 		}
 	}
 
-	// if the build method is registry and the image is set, use the image and compute the tag
-	if appConf.Build.Method == "registry" {
-
-	}
-
 	err = updateAgent.UpdateImageAndValues(appConf.Values)
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If a image repo url with a tag is specified via the `build.image` parameter for preview environments, the tag gets overwritten by the env var when it shouldn't be. 

## What is the new behavior?

Keep the tag specified by `build.image` is the build method is `registry`. 

## Technical Spec/Implementation Notes
