### PR TITLE
Add a global timeout to the job sidecar which terminates the job

### DIFF
--- a/services/job_sidecar_container/job_killer.sh
+++ b/services/job_sidecar_container/job_killer.sh
@@ -25,17 +25,19 @@ then
   grace_period_seconds=$2
   target=$3
   sidecar=$4
-  global_timeout=$5
 else
   grace_period_seconds=$1
   target=$2
   sidecar=$3
-  global_timeout=$4
 fi  
 
-if [ -n "$global_timeout" ]; then
+global_timeout=$TIMEOUT
+
+if [ -z "$global_timeout" ]; then
   global_timeout=3600
 fi
+
+echo "set global timeout value of $global_timeout"
 
 pattern="$(printf '[%s]%s' $(echo $target | cut -c 1) $(echo $target | cut -c 2-))"
 
@@ -100,18 +102,20 @@ target_pid_name=$(pgrep -f $pattern -l | grep -v 'job_killer.sh' | grep -v 'wait
 if [ -n "$target_pid" ]; then
     echo "targeting pids $target_pid matched by $target_pid_name"
     # schedule hard kill after global timeout
-    (sleep ${timeout}; graceful_shutdown $grace_period_seconds $target || true) &
-    local killer=${!}
+    is_global_shutdown=""
+    (sleep ${global_timeout}; echo "triggering global shutdown" && is_global_shutdown="true" && graceful_shutdown $grace_period_seconds $target || true) &
+    global_killer=${!}
     
     tail --pid=$target_pid -f /dev/null &
     child=$!
 
     wait "$child"
 
-    # cancel hard kill timer
-    sleep 0.1 && kill -9 ${killer} 2>/dev/null || true
-
-    graceful_shutdown $grace_period_seconds $target
+    if [ -z "$is_global_shutdown" ]; then
+      # cancel hard kill timer
+      sleep 0.1 && kill -9 ${global_killer} 2>/dev/null || true
+      graceful_shutdown $grace_period_seconds $target
+    fi
 else 
   echo "no process could be targeted within 10s, initiating shutdown"
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): jobs improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Jobs can run infinitely in some cases, if the main process does not exit. 

## What is the new behavior?

Add an option to the job sidecar to terminate the process if it does not exit. 

## Technical Spec/Implementation Notes
