### PR TITLE
fix: allow OpenBrowser to fail and inform user

### DIFF
--- a/cli/cmd/login/server.go
+++ b/cli/cmd/login/server.go
@@ -67,7 +67,7 @@ func Login(
 	err = utils.OpenBrowser(loginURL)
 
 	if err != nil {
-		return "", fmt.Errorf("Could not open browser: %v", err)
+		fmt.Printf("Could not open browser. Please navigate to the link manually.")
 	}
 
 	for {


### PR DESCRIPTION
fixes issue where OpenBrowser fails and exits the program despite showing
a manual link to access. This commit logs message instead of returning
error when OpenBrowser errors.

Fixes #1645

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed
- [x] cli change

## What is the current behavior?
CLI exits if `utils.OpenBrowser` returns an error. 

Issue Number: [#1645](https://github.com/porter-dev/porter/issues/1645)

-->

## What is the new behavior?
This modifies this to print a message instead of exiting the process. 
<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Doesn't seem to be any tests for the cli so I haven't added any for this, happy to add if desired.

## Technical Spec/Implementation Notes
