### PR TITLE
[POR-319] Add support for environment groups for preview environments

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -143,6 +143,8 @@ type ApplicationConfig struct {
 		Buildpacks []string
 	}
 
+	EnvGroups []string
+
 	Values map[string]interface{}
 }
 
@@ -310,6 +312,7 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		LocalDockerfile: appConfig.Build.Dockerfile,
 		OverrideTag:     tag,
 		Method:          deploy.DeployBuildType(method),
+		EnvGroups:       appConfig.EnvGroups,
 	}
 
 	if shouldCreate {

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -478,6 +478,13 @@ func (c *CreateAgent) getMergedValues(overrideValues map[string]interface{}) (st
 		return "", nil, err
 	}
 
+	err = coalesceEnvGroups(c.Client, c.CreateOpts.ProjectID, c.CreateOpts.ClusterID,
+		c.CreateOpts.Namespace, c.CreateOpts.EnvGroups, values)
+
+	if err != nil {
+		return "", nil, err
+	}
+
 	// merge existing values with overriding values
 	mergedValues := utils.CoalesceValues(values, overrideValues)
 

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -137,7 +137,10 @@ func NewDeployAgent(client *client.Client, app string, opts *DeployOpts) (*Deplo
 
 	deployAgent.tag = opts.OverrideTag
 
-	return deployAgent, nil
+	err = coalesceEnvGroups(deployAgent.client, deployAgent.opts.ProjectID, deployAgent.opts.ClusterID,
+		deployAgent.opts.Namespace, deployAgent.opts.EnvGroups, deployAgent.release.Config)
+
+	return deployAgent, err
 }
 
 type GetBuildEnvOpts struct {

--- a/cli/cmd/deploy/shared.go
+++ b/cli/cmd/deploy/shared.go
@@ -1,5 +1,14 @@
 package deploy
 
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/api/types"
+)
+
 // SharedOpts are common options for build, create, and deploy agents
 type SharedOpts struct {
 	ProjectID       uint
@@ -10,4 +19,75 @@ type SharedOpts struct {
 	OverrideTag     string
 	Method          DeployBuildType
 	AdditionalEnv   map[string]string
+	EnvGroups       []string
+}
+
+func getEnvGroupNameVersion(group string) (string, uint, error) {
+	if !strings.Contains(group, "@") {
+		return group, 0, nil
+	}
+
+	envGroupSpl := strings.Split(group, "@")
+	envGroupName := envGroupSpl[0]
+	envGroupVersion := uint64(0)
+
+	envGroupVersion, err := strconv.ParseUint(envGroupSpl[1], 10, 32)
+
+	if err != nil {
+		return "", 0, err
+	}
+
+	return envGroupName, uint(envGroupVersion), nil
+}
+
+func coalesceEnvGroups(
+	client *api.Client,
+	projectID, clusterID uint,
+	namespace string,
+	envGroups []string,
+	config map[string]interface{},
+) error {
+	for _, group := range envGroups {
+		if group == "" {
+			continue
+		}
+
+		envGroupName, envGroupVersion, err := getEnvGroupNameVersion(group)
+
+		if err != nil {
+			return err
+		}
+
+		envGroup, err := client.GetEnvGroup(
+			context.Background(),
+			projectID,
+			clusterID,
+			namespace,
+			&types.GetEnvGroupRequest{
+				Name:    envGroupName,
+				Version: envGroupVersion,
+			},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		envConfig, err := getNestedMap(config, "container", "env", "normal")
+
+		if err != nil || envConfig == nil {
+			envConfig = make(map[string]interface{})
+		}
+
+		for k, v := range envGroup.Variables {
+			envConfig[k] = v
+		}
+
+		containerMap, _ := config["container"].(map[string]interface{})
+		envMap, _ := containerMap["env"].(map[string]interface{})
+
+		envMap["normal"] = envConfig
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

A `porter.yaml` file for preview environments can now add env groups.

## Technical Spec/Implementation Notes

To add env group(s), the `porter.yaml` file needs `config.envgroups` string array. For example
```yaml
version: v1
resources:
  - name: sample
    source:
      name: web
    config:
      envgroups:
      - my-env-group
```

Just like env groups' versioning, this PR adds the support for versioned env groups like `my-env-group@1`, which translates to using version `1` of env group `my-env-group`.