### PR TITLE
Fix send on closed channel errors from websockets

### DIFF
--- a/api/server/shared/websocket/response_writer.go
+++ b/api/server/shared/websocket/response_writer.go
@@ -12,18 +12,20 @@ type WebsocketSafeReadWriter struct {
 	conn *websocket.Conn
 }
 
-func (w *WebsocketSafeReadWriter) WriteJSONWithChannel(v interface{}, errorChan chan<- error) {
+func (w *WebsocketSafeReadWriter) WriteJSONWithChannel(v interface{}) error {
 	err := w.conn.WriteJSON(v)
 
 	if err != nil {
 		if errOr(err, websocket.ErrCloseSent, syscall.EPIPE, syscall.ECONNRESET) {
 			// if close has been sent, or error is broken pipe error or connection reset, we want to
 			// send a message to the error channel to ensure closure but we ignore the error
-			errorChan <- nil
-		} else if err != nil {
-			errorChan <- err
+			return nil
 		}
+
+		return err
 	}
+
+	return nil
 }
 
 func (w *WebsocketSafeReadWriter) Write(data []byte) (int, error) {

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -854,7 +854,7 @@ func (a *Agent) StreamControllerStatus(kind string, selectors string, rw *websoc
 					Object:    newObj,
 					Kind:      strings.ToLower(kind),
 				}
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 			AddFunc: func(obj interface{}) {
 				msg := Message{
@@ -862,7 +862,7 @@ func (a *Agent) StreamControllerStatus(kind string, selectors string, rw *websoc
 					Object:    obj,
 					Kind:      strings.ToLower(kind),
 				}
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 			DeleteFunc: func(obj interface{}) {
 				msg := Message{
@@ -870,7 +870,7 @@ func (a *Agent) StreamControllerStatus(kind string, selectors string, rw *websoc
 					Object:    obj,
 					Kind:      strings.ToLower(kind),
 				}
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 		})
 
@@ -1027,7 +1027,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					Object:    helm_object,
 				}
 
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 			AddFunc: func(obj interface{}) {
 				secretObj, ok := obj.(*v1.Secret)
@@ -1053,7 +1053,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					Object:    helm_object,
 				}
 
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 			DeleteFunc: func(obj interface{}) {
 				secretObj, ok := obj.(*v1.Secret)
@@ -1079,7 +1079,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 					Object:    helm_object,
 				}
 
-				rw.WriteJSONWithChannel(msg, errorchan)
+				rw.WriteJSONWithChannel(msg)
 			},
 		})
 

--- a/internal/kubernetes/provisioner/resource_stream.go
+++ b/internal/kubernetes/provisioner/resource_stream.go
@@ -40,7 +40,7 @@ func ResourceStream(client *redis.Client, streamName string, rw *websocket.Webso
 			messages := xstream[0].Messages
 			lastID = messages[len(messages)-1].ID
 
-			rw.WriteJSONWithChannel(messages, errorchan)
+			rw.WriteJSONWithChannel(messages)
 		}
 	}()
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Backend panics with send on closed channel when WS pipe is broken. 

## What is the new behavior?

Fix panics. 

## Technical Spec/Implementation Notes
