### PR TITLE
[FIX] Disable owner filtering on invite list

### DIFF
--- a/dashboard/src/main/home/project-settings/InviteList.tsx
+++ b/dashboard/src/main/home/project-settings/InviteList.tsx
@@ -100,10 +100,12 @@ const InvitePage: React.FunctionComponent<Props> = ({}) => {
       collaborators
         // Parse role id to number
         .map((c) => ({ ...c, id: Number(c.id) }))
-        // Sort them so the owner will be first allways
-        .sort((curr, prev) => curr.id - prev.id)
-        // Remove the owner from list
-        .slice(1)
+        // COMMENTED OUT AS IT WAS REMOVING ACTUAL USERS AND NOT OWNERS.
+        //
+        // // Sort them so the owner will be first allways
+        // .sort((curr, prev) => curr.id - prev.id)
+        // // Remove the owner from list
+        // .slice(1)
         // Parse the remainings to InviteType
         .map((c) => ({
           email: c.email,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The owner of the project was removed from the invite/collaborator list as it didn't make any sense to display it. This caused an issue where some random collaborator was removed instead of the owner.

## What is the new behavior?

The filter was disabled to prevent non-owner users to be removed from the collaborator list

## Technical Spec/Implementation Notes
