### PR TITLE
Fix env group cloning from preview env

### DIFF
--- a/api/client/k8s.go
+++ b/api/client/k8s.go
@@ -91,6 +91,27 @@ func (c *Client) GetEnvGroup(
 	return resp, err
 }
 
+func (c *Client) CloneEnvGroup(
+	ctx context.Context,
+	projectID, clusterID uint,
+	namespace string,
+	req *types.CloneEnvGroupRequest,
+) (*types.EnvGroup, error) {
+	resp := &types.EnvGroup{}
+
+	err := c.postRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/namespaces/%s/envgroup/clone",
+			projectID, clusterID,
+			namespace,
+		),
+		req,
+		resp,
+	)
+
+	return resp, err
+}
+
 func (c *Client) GetRelease(
 	ctx context.Context,
 	projectID, clusterID uint,

--- a/api/server/handlers/namespace/clone_env_group.go
+++ b/api/server/handlers/namespace/clone_env_group.go
@@ -46,7 +46,7 @@ func (c *CloneEnvGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	envGroup, err := envgroup.GetEnvGroup(agent, request.Name, request.Namespace, request.Version)
+	envGroup, err := envgroup.GetEnvGroup(agent, request.Name, namespace, request.Version)
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
@@ -59,7 +59,7 @@ func (c *CloneEnvGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	configMap, err := envgroup.CreateEnvGroup(agent, types.ConfigMapInput{
 		Name:      request.CloneName,
-		Namespace: namespace,
+		Namespace: request.Namespace,
 		Variables: envGroup.Variables,
 	})
 

--- a/api/server/router/namespace.go
+++ b/api/server/router/namespace.go
@@ -87,14 +87,14 @@ func getNamespaceRoutes(
 		Router:   r,
 	})
 
-	// GET /api/projects/{project_id}/clusters/{cluster_id}/namespaces/{namespace}/envgroups/list -> namespace.NewListEnvGroupsHandler
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/namespaces/{namespace}/envgroup/list -> namespace.NewListEnvGroupsHandler
 	listEnvGroupsEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
 			Verb:   types.APIVerbGet,
 			Method: types.HTTPVerbGet,
 			Path: &types.Path{
 				Parent:       basePath,
-				RelativePath: relPath + "/envgroups/list",
+				RelativePath: relPath + "/envgroup/list",
 			},
 			Scopes: []types.PermissionScope{
 				types.UserScope,
@@ -116,14 +116,14 @@ func getNamespaceRoutes(
 		Router:   r,
 	})
 
-	// GET /api/projects/{project_id}/clusters/{cluster_id}/namespaces/{namespace}/envgroups/clone -> namespace.NewCloneEnvGroupHandler
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/namespaces/{namespace}/envgroup/clone -> namespace.NewCloneEnvGroupHandler
 	cloneEnvGroupEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
-			Verb:   types.APIVerbGet,
-			Method: types.HTTPVerbGet,
+			Verb:   types.APIVerbCreate,
+			Method: types.HTTPVerbPost,
 			Path: &types.Path{
 				Parent:       basePath,
-				RelativePath: relPath + "/envgroups/clone",
+				RelativePath: relPath + "/envgroup/clone",
 			},
 			Scopes: []types.PermissionScope{
 				types.UserScope,

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -178,7 +178,7 @@ type ApplicationConfig struct {
 		Buildpacks []string
 	}
 
-	EnvGroups []string
+	EnvGroups []types.EnvGroupMeta
 
 	Values map[string]interface{}
 }

--- a/cli/cmd/deploy/shared.go
+++ b/cli/cmd/deploy/shared.go
@@ -2,9 +2,9 @@ package deploy
 
 import (
 	"context"
-	"strconv"
-	"strings"
+	"fmt"
 
+	"github.com/fatih/color"
 	api "github.com/porter-dev/porter/api/client"
 	"github.com/porter-dev/porter/api/types"
 )
@@ -19,43 +19,19 @@ type SharedOpts struct {
 	OverrideTag     string
 	Method          DeployBuildType
 	AdditionalEnv   map[string]string
-	EnvGroups       []string
-}
-
-func getEnvGroupNameVersion(group string) (string, uint, error) {
-	if !strings.Contains(group, "@") {
-		return group, 0, nil
-	}
-
-	envGroupSpl := strings.Split(group, "@")
-	envGroupName := envGroupSpl[0]
-	envGroupVersion := uint64(0)
-
-	envGroupVersion, err := strconv.ParseUint(envGroupSpl[1], 10, 32)
-
-	if err != nil {
-		return "", 0, err
-	}
-
-	return envGroupName, uint(envGroupVersion), nil
+	EnvGroups       []types.EnvGroupMeta
 }
 
 func coalesceEnvGroups(
 	client *api.Client,
 	projectID, clusterID uint,
 	namespace string,
-	envGroups []string,
+	envGroups []types.EnvGroupMeta,
 	config map[string]interface{},
 ) error {
 	for _, group := range envGroups {
-		if group == "" {
-			continue
-		}
-
-		envGroupName, envGroupVersion, err := getEnvGroupNameVersion(group)
-
-		if err != nil {
-			return err
+		if group.Name == "" {
+			return fmt.Errorf("env group name cannot be empty")
 		}
 
 		envGroup, err := client.GetEnvGroup(
@@ -64,12 +40,34 @@ func coalesceEnvGroups(
 			clusterID,
 			namespace,
 			&types.GetEnvGroupRequest{
-				Name:    envGroupName,
-				Version: envGroupVersion,
+				Name:    group.Name,
+				Version: group.Version,
 			},
 		)
 
-		if err != nil {
+		if err != nil && err.Error() == "env group not found" {
+			if group.Namespace == "" {
+				return fmt.Errorf("env group namespace cannot be empty")
+			}
+
+			color.New(color.FgBlue, color.Bold).
+				Printf("Env group '%s' does not exist in the target namespace '%s'\n", group.Name, namespace)
+			color.New(color.FgBlue, color.Bold).
+				Printf("Cloning env group '%s' from namespace '%s' to target namespace '%s'\n",
+					group.Name, group.Namespace, namespace)
+
+			envGroup, err = client.CloneEnvGroup(
+				context.Background(), projectID, clusterID, group.Namespace,
+				&types.CloneEnvGroupRequest{
+					Name:      group.Name,
+					Namespace: namespace,
+				},
+			)
+
+			if err != nil {
+				return err
+			}
+		} else if err != nil {
 			return err
 		}
 

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -474,11 +474,9 @@ const detectBuildpack = baseApi<
     branch: string;
   }
 >("GET", (pathParams) => {
-  return `/api/projects/${pathParams.project_id}/gitrepos/${
-    pathParams.git_repo_id
-  }/repos/${pathParams.kind}/${pathParams.owner}/${
-    pathParams.name
-  }/${encodeURIComponent(pathParams.branch)}/buildpack/detect`;
+  return `/api/projects/${pathParams.project_id}/gitrepos/${pathParams.git_repo_id
+    }/repos/${pathParams.kind}/${pathParams.owner}/${pathParams.name
+    }/${encodeURIComponent(pathParams.branch)}/buildpack/detect`;
 });
 
 const getBranchContents = baseApi<
@@ -494,11 +492,9 @@ const getBranchContents = baseApi<
     branch: string;
   }
 >("GET", (pathParams) => {
-  return `/api/projects/${pathParams.project_id}/gitrepos/${
-    pathParams.git_repo_id
-  }/repos/${pathParams.kind}/${pathParams.owner}/${
-    pathParams.name
-  }/${encodeURIComponent(pathParams.branch)}/contents`;
+  return `/api/projects/${pathParams.project_id}/gitrepos/${pathParams.git_repo_id
+    }/repos/${pathParams.kind}/${pathParams.owner}/${pathParams.name
+    }/${encodeURIComponent(pathParams.branch)}/contents`;
 });
 
 const getProcfileContents = baseApi<
@@ -514,11 +510,9 @@ const getProcfileContents = baseApi<
     branch: string;
   }
 >("GET", (pathParams) => {
-  return `/api/projects/${pathParams.project_id}/gitrepos/${
-    pathParams.git_repo_id
-  }/repos/${pathParams.kind}/${pathParams.owner}/${
-    pathParams.name
-  }/${encodeURIComponent(pathParams.branch)}/procfile`;
+  return `/api/projects/${pathParams.project_id}/gitrepos/${pathParams.git_repo_id
+    }/repos/${pathParams.kind}/${pathParams.owner}/${pathParams.name
+    }/${encodeURIComponent(pathParams.branch)}/procfile`;
 });
 
 const getBranches = baseApi<
@@ -1053,7 +1047,7 @@ const listEnvGroups = baseApi<
     cluster_id: number;
   }
 >("GET", (pathParams) => {
-  return `/api/projects/${pathParams.id}/clusters/${pathParams.cluster_id}/namespaces/${pathParams.namespace}/envgroups/list`;
+  return `/api/projects/${pathParams.id}/clusters/${pathParams.cluster_id}/namespaces/${pathParams.namespace}/envgroup/list`;
 });
 
 const listConfigMaps = baseApi<
@@ -1077,11 +1071,9 @@ const getEnvGroup = baseApi<
     version?: number;
   }
 >("GET", (pathParams) => {
-  return `/api/projects/${pathParams.id}/clusters/${
-    pathParams.cluster_id
-  }/namespaces/${pathParams.namespace}/envgroup?name=${pathParams.name}${
-    pathParams.version ? "&version=" + pathParams.version : ""
-  }`;
+  return `/api/projects/${pathParams.id}/clusters/${pathParams.cluster_id
+    }/namespaces/${pathParams.namespace}/envgroup?name=${pathParams.name}${pathParams.version ? "&version=" + pathParams.version : ""
+    }`;
 });
 
 const getConfigMap = baseApi<


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

No cloning of env group from preview env. Env groups do not support different namespaces.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Now supports env group cloning. New YAML schema:
```yaml
envgroups:
  - name: my-env-grp
    namespace: custom-namespace
  - name: another-env-grp
    namespace: default
```

## Technical Spec/Implementation Notes
