### PR TITLE
Add `--force-push` to `porter update` to force push an image

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -173,6 +173,7 @@ type ApplicationConfig struct {
 
 	Build struct {
 		ForceBuild bool
+		ForcePush  bool
 		Method     string
 		Context    string
 		Dockerfile string
@@ -506,7 +507,7 @@ func (d *Driver) updateApplication(resource *models.Resource, client *api.Client
 			return nil, err
 		}
 
-		err = updateAgent.Push()
+		err = updateAgent.Push(appConf.Build.ForcePush)
 
 		if err != nil {
 			return nil, err

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -206,6 +206,7 @@ var dockerfile string
 var method string
 var stream bool
 var buildFlagsEnv []string
+var forcePush bool
 
 func init() {
 	buildFlagsEnv = []string{}
@@ -288,6 +289,20 @@ func init() {
 		"stream update logs to porter dashboard",
 	)
 
+	updateCmd.PersistentFlags().BoolVar(
+		&forceBuild,
+		"force-build",
+		false,
+		"set this to force build an image (only works on images that are not tagged with \"latest\")",
+	)
+
+	updateCmd.PersistentFlags().BoolVar(
+		&forcePush,
+		"force-push",
+		false,
+		"set this to force push an image (only works on images that are not tagged with \"latest\")",
+	)
+
 	updateCmd.AddCommand(updateGetEnvCmd)
 
 	updateGetEnvCmd.PersistentFlags().StringVar(
@@ -295,13 +310,6 @@ func init() {
 		"file",
 		"",
 		"file destination for .env files",
-	)
-
-	updateCmd.PersistentFlags().BoolVar(
-		&forceBuild,
-		"force-build",
-		false,
-		"set this to force build an image",
 	)
 
 	updateCmd.AddCommand(updateBuildCmd)
@@ -523,7 +531,7 @@ func updatePushWithAgent(updateAgent *deploy.DeployAgent) error {
 		})
 	}
 
-	if err := updateAgent.Push(); err != nil {
+	if err := updateAgent.Push(forcePush); err != nil {
 		if stream {
 			updateAgent.StreamEvent(types.SubEvent{
 				EventID: "push",

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -293,14 +293,14 @@ func init() {
 		&forceBuild,
 		"force-build",
 		false,
-		"set this to force build an image (only works on images that are not tagged with \"latest\")",
+		"set this to force build an image (images tagged with \"latest\" have this set by default)",
 	)
 
 	updateCmd.PersistentFlags().BoolVar(
 		&forcePush,
 		"force-push",
 		false,
-		"set this to force push an image (only works on images that are not tagged with \"latest\")",
+		"set this to force push an image (images tagged with \"latest\" have this set by default)",
 	)
 
 	updateCmd.AddCommand(updateGetEnvCmd)

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -279,9 +279,9 @@ func (c *CreateAgent) CreateFromDocker(
 		return "", err
 	}
 
-	if imageExists && imageTag != "default" && !forceBuild {
+	if imageExists && imageTag != "latest" && !forceBuild {
 		fmt.Printf("%s:%s already exists in the registry, so skipping build\n", imageURL, imageTag)
-	} else { // image does not exist or has tag default so we (re)build one
+	} else { // image does not exist or has tag "latest" so we (re)build one
 		env, err := GetEnvForRelease(c.Client, mergedValues, opts.ProjectID, opts.ClusterID, opts.Namespace)
 
 		if err != nil {

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -323,8 +323,12 @@ func (d *DeployAgent) Build(overrideBuildConfig *types.BuildConfig, forceBuild b
 }
 
 // Push pushes a local image to the remote repository linked in the release
-func (d *DeployAgent) Push() error {
-	return d.agent.PushImage(fmt.Sprintf("%s:%s", d.imageRepo, d.tag))
+func (d *DeployAgent) Push(forcePush bool) error {
+	if forcePush || d.tag == "latest" {
+		return d.agent.PushImage(fmt.Sprintf("%s:%s", d.imageRepo, d.tag))
+	}
+
+	return nil
 }
 
 // UpdateImageAndValues updates the current image for a release, along with new

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -324,11 +324,11 @@ func (d *DeployAgent) Build(overrideBuildConfig *types.BuildConfig, forceBuild b
 
 // Push pushes a local image to the remote repository linked in the release
 func (d *DeployAgent) Push(forcePush bool) error {
-	if forcePush || d.tag == "latest" {
-		return d.agent.PushImage(fmt.Sprintf("%s:%s", d.imageRepo, d.tag))
+	if !forcePush && d.tag != "latest" {
+		return nil
 	}
 
-	return nil
+	return d.agent.PushImage(fmt.Sprintf("%s:%s", d.imageRepo, d.tag))
 }
 
 // UpdateImageAndValues updates the current image for a release, along with new


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now we try to push all images even when they are not built.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now only push images when either `--force-push` is unset or image tag is `latest`.

## Technical Spec/Implementation Notes
