### PR TITLE
[POR-322] Try to circumvent Helm pending upgrade error

### DIFF
--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -254,7 +254,10 @@ func (a *Agent) UpgradeReleaseByValues(
 					}
 
 					return res, nil
-				}
+				} else {
+				  // return the error with a more detailed message, something like this:
+				  return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait 60 seconds to force an upgrade")
+				  }
 			}
 		}
 

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -255,8 +255,8 @@ func (a *Agent) UpgradeReleaseByValues(
 
 					return res, nil
 				} else {
-					// return the error with a more detailed message, something like this:
-					return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait 60 seconds to force an upgrade")
+					// ask the user to wait for about a minute before retrying for the above fix to kick in
+					return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait for 60 seconds to force an upgrade")
 				}
 			}
 		}

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -255,9 +255,9 @@ func (a *Agent) UpgradeReleaseByValues(
 
 					return res, nil
 				} else {
-				  // return the error with a more detailed message, something like this:
-				  return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait 60 seconds to force an upgrade")
-				  }
+					// return the error with a more detailed message, something like this:
+					return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait 60 seconds to force an upgrade")
+				}
 			}
 		}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Subsequent release upgrades might sometimes throw `another operation (install/upgrade/rollback) is in progress` error. This is a known issue as documented and tracked at https://github.com/helm/helm/issues/4558.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now try to circumvent this issue by updating the Helm secret value and set it to `failed` and retry upgrade.

## Technical Spec/Implementation Notes
