### PR TITLE
[fix] Fixed aws and gcp provisioner guide links

### DIFF
--- a/dashboard/src/main/home/provisioner/AWSFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/AWSFormSection.tsx
@@ -295,9 +295,7 @@ const AWSFormSectionFC: React.FC<PropsType> = (props) => {
       hosting: "aws",
     });
 
-    window.open(
-      "https://docs.getporter.dev/docs/getting-started-with-porter-on-aws"
-    );
+    window.open("https://docs.porter.run/getting-started/provisioning-on-aws");
   };
 
   return (

--- a/dashboard/src/main/home/provisioner/GCPFormSection.tsx
+++ b/dashboard/src/main/home/provisioner/GCPFormSection.tsx
@@ -279,7 +279,7 @@ const GCPFormSectionFC: React.FC<PropsType> = (props) => {
       hosting: "gcp",
     });
 
-    window.open("https://docs.getporter.dev/docs/getting-started-on-gcp");
+    window.open("https://docs.porter.run/getting-started/provisioning-on-gcp");
   };
 
   return (


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Guide links were broken on provisioner (not onboarding)

## What is the new behavior?

Replaced old links with new ones.

## Technical Spec/Implementation Notes
