### PR TITLE
add option to set cf token for cli

### DIFF
--- a/cli/cmd/login/server.go
+++ b/cli/cmd/login/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -98,6 +99,11 @@ func ExchangeToken(host, code string) (string, error) {
 	// create a request with the authorization code
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/json; charset=utf-8")
+
+	// look for a cloudflare access token specifically for Porter
+	if cfToken := os.Getenv("PORTER_CF_ACCESS_TOKEN"); cfToken != "" {
+		req.Header.Set("cf-access-token", cfToken)
+	}
 
 	client := &http.Client{
 		Timeout: time.Minute,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

It isn't possible to authenticate via the CLI to Porter instances protected by Cloudflare. 

## What is the new behavior?

Add an option to enable CF authorization tokens on the CLI. 

## Technical Spec/Implementation Notes
