### PR TITLE
Fix secret env group cloning

### DIFF
--- a/api/server/handlers/namespace/clone_env_group.go
+++ b/api/server/handlers/namespace/clone_env_group.go
@@ -70,7 +70,7 @@ func (c *CloneEnvGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	for key, val := range secret.Data {
-		vars[key] = string(val)
+		secretVars[key] = string(val)
 	}
 
 	configMap, err := envgroup.CreateEnvGroup(agent, types.ConfigMapInput{


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Secret env vars aren't cloned properly to different namespaces. 

## What is the new behavior?

Clone secrets properly to different namespaces. 

## Technical Spec/Implementation Notes
