### PR TITLE
[FIX] Job list on expanded chart flashing information - websocket not waiting for http call

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -104,7 +104,7 @@ class ExpandedJobChart extends Component<PropsType, StateType> {
   };
 
   // Retrieve full chart data (includes form and values)
-  getChartData = async (chart: ChartType, revision: number) => {
+  getChartData = (chart: ChartType, revision: number) => {
     let { currentProject } = this.context;
     let { currentCluster, currentChart } = this.props;
 
@@ -507,10 +507,10 @@ class ExpandedJobChart extends Component<PropsType, StateType> {
     }));
   };
 
-  getJobs = async (chart: ChartType) => {
+  getJobs = (chart: ChartType) => {
     let { currentCluster, currentProject, setCurrentError } = this.context;
 
-    api
+    return api
       .getJobs(
         "<token>",
         {},


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

The getJobs function wasn't returning any promise, so when tried to make a .then the websocket wasn't actually waiting for anything