### PR TITLE
[fix] Fix Range error on table component

### DIFF
--- a/dashboard/src/components/Table.tsx
+++ b/dashboard/src/components/Table.tsx
@@ -41,6 +41,8 @@ export type TableProps = {
   enablePagination?: boolean;
 };
 
+const MIN_PAGE_SIZE = 1;
+
 const Table: React.FC<TableProps> = ({
   columns: columnsData,
   data,
@@ -73,6 +75,7 @@ const Table: React.FC<TableProps> = ({
     {
       columns: columnsData,
       data,
+      initialState: { pageSize: MIN_PAGE_SIZE },
     },
     useGlobalFilter,
     usePagination
@@ -80,7 +83,7 @@ const Table: React.FC<TableProps> = ({
 
   useEffect(() => {
     if (!enablePagination) {
-      setPageSize(data.length);
+      setPageSize(data.length || MIN_PAGE_SIZE);
     }
   }, [data, enablePagination]);
 

--- a/dashboard/src/components/Table.tsx
+++ b/dashboard/src/components/Table.tsx
@@ -75,7 +75,6 @@ const Table: React.FC<TableProps> = ({
     {
       columns: columnsData,
       data,
-      initialState: { pageSize: MIN_PAGE_SIZE },
     },
     useGlobalFilter,
     usePagination


### PR DESCRIPTION

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The usePagination hook provided by react-table, will try to use the given pageSize to calculate the amount of pages. This causes an issue when the pageSize is equal to 0, as it ends up making a division by 0 wich ends up in a NaN. When the usePagination hook tries to build the array of pages passes as length the NaN returned previously, which ends up in a `Range error: Invalid array length`

## What is the new behavior?

Added casing so the minimum value that the pageSize can have is 1 to avoid dividing by 0.