### PR TITLE
Modified the text for the RDS connection modal box.

### DIFF
--- a/dashboard/src/main/home/modals/ConnectToDatabaseInstructionsModal.tsx
+++ b/dashboard/src/main/home/modals/ConnectToDatabaseInstructionsModal.tsx
@@ -11,7 +11,7 @@ const ConnectToDatabaseInstructionsModal = () => {
       In order to get connection credentials for your RDS Postgres database,
       select <b>Load from Env Group</b> when launching or updating your
       application. Then, select the rds-credentials-{currentModalData?.name}{" "}
-      database.
+      env group.
       <p>
         This will set the following environment variables in your application:
       </p>


### PR DESCRIPTION
Modified the text for the RDS connection modal to state that the user is selecting an env group with RDS connection creds, not a database.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Currently, the RDS connection modal box says `Then, select the <ENV_GROUP_NAME> database.`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR modifies the text in that modal to `Then, select the <ENV_GROUP_NAME> env group.`

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
