### PR TITLE
[FIX] Job run table websocket disconnecting abruptly

### DIFF
--- a/dashboard/src/components/Table.tsx
+++ b/dashboard/src/components/Table.tsx
@@ -119,7 +119,6 @@ const Table: React.FC<TableProps> = ({
             >
               {/* TODO: This is actually broken, not sure why but we need the width to be properly setted, this is a temporary solution */}
               {row.cells.map((cell) => {
-                console.log(cell.getCellProps());
                 return (
                   <StyledTd
                     {...cell.getCellProps()}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Some users experience issues getting the job runs across all charts.

## What is the new behavior?

Avoid making a connection when the namespace is null and show a retry button in case the WebSocket throws an error
