### PR TITLE
[Fix] Fix job run table showing error text when last stream status was "finished"

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/JobRunTable.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/JobRunTable.tsx
@@ -114,11 +114,13 @@ const JobRunTable: React.FC<Props> = ({
   const [jobRuns, setJobRuns] = useState<JobRun[]>(null);
   const [hasError, setHasError] = useState(false);
   const tmpJobRuns = useRef([]);
+  const lastStreamStatus = useRef("");
   const { openWebsocket, newWebsocket, closeAllWebsockets } = useWebsockets();
 
   const getJobRuns = () => {
     closeAllWebsockets();
     tmpJobRuns.current = [];
+    lastStreamStatus.current = "";
     setJobRuns(null);
     setHasError(false);
     const websocketId = `job-runs-for-all-charts-ws`;
@@ -132,6 +134,7 @@ const JobRunTable: React.FC<Props> = ({
         if (data.streamStatus === "finished") {
           setHasError(false);
           setJobRuns(tmpJobRuns.current);
+          lastStreamStatus.current = data.streamStatus;
           return;
         }
 
@@ -349,7 +352,7 @@ const JobRunTable: React.FC<Props> = ({
     return tmp;
   }, [jobRuns, lastRunStatus, sortType]);
 
-  if (hasError) {
+  if (hasError && lastStreamStatus.current !== "finished") {
     return (
       <ErrorWrapper>
         Couldn't retrieve jobs, please try again.{" "}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Some users may find that in safari the stream to get all the job runs throws an error even though the stream was successfully finished.

## What is the new behavior?

Added a ref to keep the latest stream status so if it's finished the user will not see the error.

## Technical Spec/Implementation Notes
