### PR TITLE
[FIX] Logs stream being closed before stablishing connection

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/Logs.tsx
@@ -402,9 +402,7 @@ const useLogs = (
   useEffect(() => {
     console.log("Selected pod updated");
     if (currentPod?.metadata?.name === currentPodName.current) {
-      return () => {
-        closeAllWebsockets();
-      };
+      return () => {};
     }
     currentPodName.current = currentPod?.metadata?.name;
     const currentContainers =
@@ -412,21 +410,18 @@ const useLogs = (
 
     setContainers(currentContainers);
     setCurrentContainer(currentContainers[0]);
-    return () => {
-      closeAllWebsockets();
-    };
   }, [currentPod]);
 
   // Retrieve all previous logs for containers
   useEffect(() => {
+    if (!Array.isArray(containers)) {
+      return;
+    }
+
     closeAllWebsockets();
 
     setPrevLogs({});
     setLogs({});
-
-    if (!Array.isArray(containers)) {
-      return;
-    }
 
     getSystemLogs();
     containers.forEach((containerName) => {
@@ -438,7 +433,17 @@ const useLogs = (
         setupWebsocket(containerName, websocketKey);
       }
     });
+
+    return () => {
+      closeAllWebsockets();
+    };
   }, [containers]);
+
+  useEffect(() => {
+    return () => {
+      closeAllWebsockets();
+    };
+  }, []);
 
   const currentLogs = useMemo(() => {
     return logs[currentContainer] || [];


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

Due to a bad return on a useEffect, the logs stream was being closed before establishing connection, which cause issues for some users seeing "no logs for this pod" although it probably had.

