### PR TITLE
Check for other forms of the deployment name for blue-green deployments 

### DIFF
--- a/cli/cmd/bluegreen.go
+++ b/cli/cmd/bluegreen.go
@@ -120,7 +120,7 @@ func bluegreenSwitch(_ *types.GetAuthenticatedUserResponse, client *api.Client, 
 
 		// get the deployment which matches the new image tag
 		for _, depl := range depls.Items {
-			if depl.ObjectMeta.Name == fmt.Sprintf("%s-web-%s", app, tag) {
+			if depl.ObjectMeta.Name == fmt.Sprintf("%s-web-%s", app, tag) || depl.ObjectMeta.Name == fmt.Sprintf("%s-%s", app, tag) {
 				foundDeployment = true
 
 				// determine if the deployment has an appropriate number of ready replicas


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Deployment names don't always follow the `$name-web-$tag` syntax because of casing from the helm chart removing duplicate chart names.

## What is the new behavior?

Add casing for the alternate deployment name. 

## Technical Spec/Implementation Notes
