### PR TITLE
[Improvement] Change method to get job runs on expanded chart

### DIFF
--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -185,3 +185,7 @@ type GetJobRunsRequest struct {
 	Status string `schema:"status"`
 	Sort   string `schema:"sort"`
 }
+
+type StreamJobRunsRequest struct {
+	Name string `schema:"name"`
+}

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobList.tsx
@@ -1,13 +1,12 @@
-import React, { Component } from "react";
+import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
 import api from "shared/api";
 import { Context } from "shared/Context";
 import JobResource from "./JobResource";
-import ConfirmOverlay from "components/ConfirmOverlay";
-import { withAuth, WithAuthProps } from "shared/auth/AuthorizationHoc";
+import useAuth from "shared/auth/useAuth";
 
-type PropsType = WithAuthProps & {
+type PropsType = {
   jobs: any[];
   setJobs: (job: any) => void;
   expandJob: any;
@@ -17,72 +16,20 @@ type PropsType = WithAuthProps & {
   repositoryUrl?: string;
 };
 
-type StateType = {
-  deletionCandidate: any;
-  deletionJob: any;
-};
+const JobListFC = (props: PropsType): JSX.Element => {
+  const [isAuthorized] = useAuth();
+  const {
+    currentCluster,
+    currentProject,
+    setCurrentOverlay,
+    setCurrentError,
+  } = useContext(Context);
+  const [deletionCandidate, setDeletionCandidate] = useState(null);
+  const [deletionJob, setDeletionJob] = useState(null);
 
-class JobList extends Component<PropsType, StateType> {
-  state = {
-    deletionCandidate: null as any,
-    deletionJob: null as any,
-  };
-
-  renderJobList = () => {
-    if (this.props.jobs.length === 0) {
-      return (
-        <Placeholder>
-          <i className="material-icons">category</i>
-          There are no jobs currently running.
-        </Placeholder>
-      );
-    } else {
-      return (
-        <>
-          {this.props.jobs.map((job: any, i: number) => {
-            return (
-              <JobResource
-                key={job?.metadata?.name}
-                expandJob={this.props.expandJob}
-                job={job}
-                handleDelete={() => {
-                  this.setState({ deletionCandidate: job });
-                  this.context.setCurrentOverlay({
-                    message: `Are you sure you want to delete this job run?`,
-                    onYes: this.deleteJob,
-                    onNo: () => {
-                      this.setState({ deletionCandidate: null });
-                      this.context.setCurrentOverlay(null);
-                    },
-                  });
-                }}
-                deleting={
-                  this.state.deletionJob?.metadata?.name == job.metadata?.name
-                }
-                readOnly={
-                  !this.props.isAuthorized("job", "", [
-                    "get",
-                    "update",
-                    "delete",
-                  ])
-                }
-                isDeployedFromGithub={this.props.isDeployedFromGithub}
-                repositoryUrl={this.props.repositoryUrl}
-                currentChartVersion={this.props.currentChartVersion}
-                latestChartVersion={this.props.latestChartVersion}
-              />
-            );
-          })}
-        </>
-      );
-    }
-  };
-
-  deleteJob = () => {
-    let { currentCluster, currentProject, setCurrentError } = this.context;
-    let job = this.state.deletionCandidate;
-    this.context.setCurrentOverlay(null);
-
+  const deleteJob = () => {
+    let job = deletionCandidate;
+    setCurrentOverlay(null);
     api
       .deleteJob(
         "<token>",
@@ -95,10 +42,8 @@ class JobList extends Component<PropsType, StateType> {
         }
       )
       .then((res) => {
-        this.setState({
-          deletionJob: this.state.deletionCandidate,
-          deletionCandidate: null,
-        });
+        setDeletionJob(deletionCandidate);
+        setDeletionCandidate(null);
       })
       .catch((err) => {
         let parsedErr = err?.response?.data?.error;
@@ -109,14 +54,50 @@ class JobList extends Component<PropsType, StateType> {
       });
   };
 
-  render() {
-    return <JobListWrapper>{this.renderJobList()}</JobListWrapper>;
+  if (!props.jobs?.length) {
+    return (
+      <JobListWrapper>
+        <Placeholder>
+          <i className="material-icons">category</i>
+          There are no jobs currently running.
+        </Placeholder>
+      </JobListWrapper>
+    );
   }
-}
 
-JobList.contextType = Context;
+  return (
+    <JobListWrapper>
+      {props.jobs.map((job: any, i: number) => {
+        return (
+          <JobResource
+            key={job?.metadata?.name}
+            expandJob={props.expandJob}
+            job={job}
+            handleDelete={() => {
+              setDeletionCandidate(job);
+              setCurrentOverlay({
+                message: "Are you sure you want to delete this job run?",
+                onYes: deleteJob,
+                onNo: () => {
+                  setDeletionCandidate(null);
+                  setCurrentOverlay(null);
+                },
+              });
+            }}
+            deleting={deletionJob?.metadata?.name == job.metadata?.name}
+            readOnly={!isAuthorized("job", "", ["get", "update", "delete"])}
+            isDeployedFromGithub={props.isDeployedFromGithub}
+            repositoryUrl={props.repositoryUrl}
+            currentChartVersion={props.currentChartVersion}
+            latestChartVersion={props.latestChartVersion}
+          />
+        );
+      })}
+    </JobListWrapper>
+  );
+};
 
-export default withAuth(JobList);
+export default JobListFC;
 
 const Placeholder = styled.div`
   width: 100%;

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobList.tsx
@@ -42,7 +42,7 @@ const JobListFC = (props: PropsType): JSX.Element => {
     canPreviousPage,
   } = usePagination({
     count: props.jobs?.length,
-    initialPageSize: 10,
+    initialPageSize: 30,
   });
 
   const deleteJob = () => {
@@ -116,7 +116,8 @@ const JobListFC = (props: PropsType): JSX.Element => {
           })}
       </JobListWrapper>
       <FlexEnd style={{ marginTop: "15px" }}>
-        <PageCountWrapper>
+        {/* Disable the page count selector until find a fix for their styles */}
+        {/* <PageCountWrapper>
           Page size:
           <Selector
             activeValue={String(pageSize)}
@@ -141,13 +142,13 @@ const JobListFC = (props: PropsType): JSX.Element => {
             setActiveValue={(val) => setPageSize(Number(val))}
             width="70px"
           ></Selector>
-        </PageCountWrapper>
+        </PageCountWrapper> */}
         <PaginationActionsWrapper>
           <PaginationAction disabled={!canPreviousPage} onClick={prevPage}>
             {"<"}
           </PaginationAction>
           <PageCounter>
-            {page} of {totalPages}
+            Page {page} of {totalPages}
           </PageCounter>
           <PaginationAction disabled={!canNextPage} onClick={nextPage}>
             {">"}

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobResource.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobResource.tsx
@@ -427,7 +427,7 @@ const CommandString = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 300px;
+  max-width: 200px;
   color: #ffffff55;
   margin-right: 27px;
   font-family: monospace;

--- a/dashboard/src/shared/hooks/usePagination.ts
+++ b/dashboard/src/shared/hooks/usePagination.ts
@@ -1,0 +1,103 @@
+/**
+ * Improved version using as base the usePagination hook by gh user @damiisdandy
+ * Base hook on his repo https://github.com/damiisdandy/use-pagination
+ */
+
+import { useState } from "react";
+
+interface UsePaginationProps {
+  count: number;
+  initialPageSize?: number;
+}
+
+interface UsePaginationReturn {
+  page: number;
+  totalPages: number;
+  setPage: (page: number) => void;
+  nextPage: () => void;
+  prevPage: () => void;
+  firstContentIndex: number;
+  lastContentIndex: number;
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+  canNextPage: boolean;
+  canPreviousPage: boolean;
+}
+
+type UsePagination = (props: UsePaginationProps) => UsePaginationReturn;
+
+const usePagination: UsePagination = ({ count, initialPageSize }) => {
+  const [pageSize, setPageSize] = useState(() => {
+    if (typeof initialPageSize === "number" && initialPageSize !== NaN) {
+      return initialPageSize;
+    }
+
+    return 10;
+  });
+
+  const [page, setPage] = useState(1);
+  // number of pages in total (total items / content on each page)
+  const pageCount = Math.ceil(count / pageSize);
+  // index of last item of current page
+  const lastContentIndex = page * pageSize;
+  // index of first item of current page
+  const firstContentIndex = lastContentIndex - pageSize;
+
+  // change page based on direction either front or back
+  const changePage = (direction: boolean) => {
+    setPage((state) => {
+      // move forward
+      if (direction) {
+        // if page is the last page, do nothing
+        if (state === pageCount) {
+          return state;
+        }
+        return state + 1;
+        // go back
+      } else {
+        // if page is the first page, do nothing
+        if (state === 1) {
+          return state;
+        }
+        return state - 1;
+      }
+    });
+  };
+
+  const setPageSAFE = (num: number) => {
+    // if number is greater than number of pages, set to last page
+    if (num > pageCount) {
+      setPage(pageCount);
+      // if number is less than 1, set page to first page
+    } else if (num < 1) {
+      setPage(1);
+    } else {
+      setPage(num);
+    }
+  };
+
+  const setPageSizeSAFE = (pageSize: number) => {
+    if (typeof initialPageSize === "number" && initialPageSize !== NaN) {
+      setPageSize(pageSize);
+    }
+  };
+
+  const canNextPage = page <= pageCount - 1;
+  const canPreviousPage = page > 1;
+
+  return {
+    totalPages: pageCount,
+    nextPage: () => changePage(true),
+    prevPage: () => changePage(false),
+    setPage: setPageSAFE,
+    firstContentIndex,
+    lastContentIndex,
+    page,
+    pageSize,
+    setPageSize: setPageSizeSAFE,
+    canNextPage,
+    canPreviousPage,
+  };
+};
+
+export default usePagination;

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -744,12 +744,18 @@ func (a *Agent) StreamJobs(namespace string, selectors string, rw *websocket.Web
 					return
 				}
 
+				labelSelector := "meta.helm.sh/release-name"
+
+				if selectors != "" {
+					labelSelector = selectors
+				}
+
 				jobs, err := a.Clientset.BatchV1().Jobs(namespace).List(
 					ctx,
 					metav1.ListOptions{
 						Limit:         100,
 						Continue:      continueVal,
-						LabelSelector: "meta.helm.sh/release-name",
+						LabelSelector: labelSelector,
 					},
 				)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users with jobs that have been run more than 100 times, can see a slowdown of the application making it almost unusable for more than 10 seconds in the best case.


## What is the new behavior?

Implemented a websocket that will stream the job runs by chunks to reduce the amount of time it takes to download the payload as well as a pagination system to reduce the amount of items rendered on the frontend at once.


