### PR TITLE
[POR-369] Confirm from user when deploying from home directory

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -183,7 +183,7 @@ func createFull(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 		return err
 	}
 
-	if source == "local" && fullPath == homedir.HomeDir() {
+	if os.Getenv("GITHUB_ACTIONS") == "" && source == "local" && fullPath == homedir.HomeDir() {
 		proceed, err := utils.PromptConfirm("You are deploying your home directory. Do you want to continue?", false)
 
 		if err != nil {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -3,13 +3,16 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
 	api "github.com/porter-dev/porter/api/client"
 	"github.com/porter-dev/porter/api/types"
 	"github.com/porter-dev/porter/cli/cmd/deploy"
+	"github.com/porter-dev/porter/cli/cmd/utils"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/homedir"
 )
 
 // updateCmd represents the "porter update" base command when called
@@ -318,6 +321,24 @@ func init() {
 }
 
 func updateFull(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+	fullPath, err := filepath.Abs(localPath)
+
+	if err != nil {
+		return err
+	}
+
+	if source == "local" && fullPath == homedir.HomeDir() {
+		proceed, err := utils.PromptConfirm("You are deploying your home directory. Do you want to continue?", false)
+
+		if err != nil {
+			return err
+		}
+
+		if !proceed {
+			return nil
+		}
+	}
+
 	color.New(color.FgGreen).Println("Deploying app:", app)
 
 	updateAgent, err := updateGetAgent(client)

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -327,7 +327,7 @@ func updateFull(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 		return err
 	}
 
-	if source == "local" && fullPath == homedir.HomeDir() {
+	if os.Getenv("GITHUB_ACTIONS") == "" && source == "local" && fullPath == homedir.HomeDir() {
 		proceed, err := utils.PromptConfirm("You are deploying your home directory. Do you want to continue?", false)
 
 		if err != nil {

--- a/cli/cmd/utils/prompt.go
+++ b/cli/cmd/utils/prompt.go
@@ -92,3 +92,20 @@ func PromptMultiselect(prompt string, options []string) ([]string, error) {
 
 	return ans, err
 }
+
+func PromptConfirm(message string, defaultVal bool) (bool, error) {
+	value := false
+
+	prompt := &survey.Confirm{
+		Message: message,
+		Default: defaultVal,
+	}
+
+	err := survey.AskOne(prompt, &value)
+
+	if err != nil {
+		return false, err
+	}
+
+	return value, nil
+}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

When the CLI is run from a non-Github Actions runner context, we now ask for confirmation from the user before proceeding when they try to deploy from their home directory using the `porter create` or `porter update` commands.

## Technical Spec/Implementation Notes
