### PR TITLE
Add fallback field to blue-green deployment spec

### DIFF
--- a/cli/cmd/bluegreen.go
+++ b/cli/cmd/bluegreen.go
@@ -141,17 +141,19 @@ func bluegreenSwitch(_ *types.GetAuthenticatedUserResponse, client *api.Client, 
 					if currActiveImage == "" {
 						err = deployAgent.UpdateImageAndValues(map[string]interface{}{
 							"bluegreen": map[string]interface{}{
-								"enabled":        true,
-								"activeImageTag": tag,
-								"imageTags":      []string{tag},
+								"enabled":                  true,
+								"disablePrimaryDeployment": true,
+								"activeImageTag":           tag,
+								"imageTags":                []string{tag},
 							},
 						})
 					} else {
 						err = deployAgent.UpdateImageAndValues(map[string]interface{}{
 							"bluegreen": map[string]interface{}{
-								"enabled":        true,
-								"activeImageTag": tag,
-								"imageTags":      []string{currActiveImage, tag},
+								"enabled":                  true,
+								"disablePrimaryDeployment": true,
+								"activeImageTag":           tag,
+								"imageTags":                []string{currActiveImage, tag},
 							},
 						})
 					}
@@ -192,9 +194,10 @@ func bluegreenSwitch(_ *types.GetAuthenticatedUserResponse, client *api.Client, 
 
 	err = deployAgent.UpdateImageAndValues(map[string]interface{}{
 		"bluegreen": map[string]interface{}{
-			"enabled":        true,
-			"activeImageTag": tag,
-			"imageTags":      []string{tag},
+			"enabled":                  true,
+			"disablePrimaryDeployment": true,
+			"activeImageTag":           tag,
+			"imageTags":                []string{tag},
 		},
 	})
 

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -347,9 +347,10 @@ func (d *DeployAgent) UpdateImageAndValues(overrideValues map[string]interface{}
 	// this has been modified already and inserted into overrideValues.
 	if activeBlueGreenTagVal != "" && activeBlueGreenTagVal != d.tag {
 		mergedValues["bluegreen"] = map[string]interface{}{
-			"enabled":        true,
-			"activeImageTag": activeBlueGreenTagVal,
-			"imageTags":      []string{activeBlueGreenTagVal, d.tag},
+			"enabled":                  true,
+			"disablePrimaryDeployment": true,
+			"activeImageTag":           activeBlueGreenTagVal,
+			"imageTags":                []string{activeBlueGreenTagVal, d.tag},
 		}
 	}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): blue-green depl improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Since `"disablePrimaryDeployment": true` is not set when updating `bluegreen` deployments, the default deployment gets rendered by Helm. 

## What is the new behavior?

Set `"disablePrimaryDeployment": true` on updates. 

## Technical Spec/Implementation Notes
