### PR TITLE
Fix multi-account ECR permissions

### DIFF
--- a/api/server/handlers/registry/get_token.go
+++ b/api/server/handlers/registry/get_token.go
@@ -98,8 +98,6 @@ func (c *RegistryGetECRTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 
 				token = *output.AuthorizationData[0].AuthorizationToken
 				expiresAt = output.AuthorizationData[0].ExpiresAt
-
-				break
 			}
 		}
 	}

--- a/api/server/handlers/registry/get_token.go
+++ b/api/server/handlers/registry/get_token.go
@@ -98,6 +98,8 @@ func (c *RegistryGetECRTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 
 				token = *output.AuthorizationData[0].AuthorizationToken
 				expiresAt = output.AuthorizationData[0].ExpiresAt
+
+				break
 			}
 		}
 	}

--- a/api/types/registry.go
+++ b/api/types/registry.go
@@ -108,7 +108,8 @@ type GetRegistryGCRTokenRequest struct {
 }
 
 type GetRegistryECRTokenRequest struct {
-	Region string `schema:"region"`
+	Region    string `schema:"region"`
+	AccountID string `schema:"account_id"`
 }
 
 type GetRegistryDOCRTokenRequest struct {

--- a/cli/cmd/docker/auth.go
+++ b/cli/cmd/docker/auth.go
@@ -154,7 +154,8 @@ func (a *AuthGetter) GetECRCredentials(serverURL string, projID uint) (user stri
 	} else {
 		// get a token from the server
 		tokenResp, err := a.Client.GetECRAuthorizationToken(context.Background(), projID, &types.GetRegistryECRTokenRequest{
-			Region: matches[3],
+			Region:    matches[3],
+			AccountID: matches[0],
 		})
 
 		if err != nil {

--- a/cli/cmd/docker/auth.go
+++ b/cli/cmd/docker/auth.go
@@ -155,7 +155,7 @@ func (a *AuthGetter) GetECRCredentials(serverURL string, projID uint) (user stri
 		// get a token from the server
 		tokenResp, err := a.Client.GetECRAuthorizationToken(context.Background(), projID, &types.GetRegistryECRTokenRequest{
 			Region:    matches[3],
-			AccountID: matches[0],
+			AccountID: matches[1],
 		})
 
 		if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Invalid tokens will sometimes be generated for multiple registry accounts within the same ECR region belonging to the same project. 

## What is the new behavior?

Match the token based on the account ID, if it's passed in the request.

## Technical Spec/Implementation Notes
