### PR TITLE
Add better provisioner logging for global stream parsing

### DIFF
--- a/provisioner/integrations/redis_stream/global.go
+++ b/provisioner/integrations/redis_stream/global.go
@@ -126,12 +126,14 @@ func GlobalStreamListener(
 			id, exists := msg.Values["id"]
 
 			if !exists {
+				config.Logger.Debug().Msg("skipping message parsing as id does not exist")
 				continue
 			}
 
 			workspaceID, ok := id.(string)
 
 			if !ok {
+				config.Logger.Debug().Msg("skipping message parsing as workspace id does not exist")
 				continue
 			}
 
@@ -139,24 +141,30 @@ func GlobalStreamListener(
 			name, err := models.ParseWorkspaceID(workspaceID)
 
 			if err != nil {
+				config.Logger.Debug().Msg(fmt.Sprintf("could not parse workspace ID: %s %s", workspaceID, err.Error()))
 				continue
 			}
+
+			config.Logger.Debug().Msg(fmt.Sprintf("reading infra %d and operation %s for project %d", name.InfraID, name.OperationUID, name.ProjectID))
 
 			infra, err := repo.Infra().ReadInfra(name.ProjectID, name.InfraID)
 
 			if err != nil {
+				config.Logger.Debug().Msg(fmt.Sprintf("could not read infra %d in project %d: %s", name.InfraID, name.ProjectID, err.Error()))
 				continue
 			}
 
 			operation, err := repo.Infra().ReadOperation(name.InfraID, name.OperationUID)
 
 			if err != nil {
+				config.Logger.Debug().Msg(fmt.Sprintf("could not read operation %s, infra %d in project %d: %s", name.OperationUID, name.InfraID, name.ProjectID, err.Error()))
 				continue
 			}
 
 			statusVal, exists := msg.Values["status"]
 
 			if !exists {
+				config.Logger.Debug().Msg("skipping message parsing as status does not exist")
 				continue
 			}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): logging improvements

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No logs for why a message sent to the global Redis stream might be skipped. 

## What is the new behavior?

Add more logging for the global Redis stream. 

## Technical Spec/Implementation Notes
