### PR TITLE
[FIX] Generate link on invite list throwing errors

### DIFF
--- a/dashboard/src/main/home/project-settings/InviteList.tsx
+++ b/dashboard/src/main/home/project-settings/InviteList.tsx
@@ -252,7 +252,7 @@ const InvitePage: React.FunctionComponent<Props> = ({}) => {
                 onClick={() =>
                   replaceInvite(
                     row.values.email,
-                    row.values.id,
+                    row.original.id,
                     row.values.kind
                   )
                 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When a user clicks on generate link after expires the frontend makes two calls, one to create the invite again and the second one to remove the expired one. The second one is throwing errors and when a user refreshes the page they can see multiple invites to the same user.

## What is the new behavior?

Fixed a param on the second call that was causing the 500. Now the two api calls are being made properly and the user can generate the link safely.

## Technical Spec/Implementation Notes
