### PR TITLE
Fix HPA queries based on `kube-state-metrics` updates

### DIFF
--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -163,7 +163,7 @@ func QueryPrometheus(
 			appLabel = ksmSvc.ObjectMeta.Labels["app.kubernetes.io/instance"]
 		}
 
-		query = createHPACurrentReplicasQuery(metricName, opts.Name, opts.Namespace, appLabel, hpaMetricName)
+		query = createHPACurrentReplicasQuery(metricName, opts.Name, opts.Namespace, "namespace", appLabel, hpaMetricName)
 	}
 
 	if opts.ShouldSum {
@@ -295,7 +295,7 @@ func getSelectionRegex(kind, name string) (string, error) {
 }
 
 func createHPAAbsoluteCPUThresholdQuery(cpuMetricName, metricName, podSelectionRegex, hpaName, namespace, appLabel, hpaMetricName string) string {
-	kubeMetricsPodSelector := getKubeMetricsPodSelector(podSelectionRegex, namespace)
+	kubeMetricsPodSelector := getKubeMetricsPodSelector(podSelectionRegex, namespace, "namespace")
 
 	kubeMetricsHPASelector := fmt.Sprintf(
 		`%s="%s",namespace="%s",metric_name="cpu",metric_target_type="utilization"`,
@@ -334,57 +334,89 @@ func createHPAAbsoluteCPUThresholdQuery(cpuMetricName, metricName, podSelectionR
 }
 
 func createHPAAbsoluteMemoryThresholdQuery(memMetricName, metricName, podSelectionRegex, hpaName, namespace, appLabel, hpaMetricName string) string {
-	kubeMetricsPodSelector := getKubeMetricsPodSelector(podSelectionRegex, namespace)
+	kubeMetricsPodSelectorOne := getKubeMetricsPodSelector(podSelectionRegex, namespace, "namespace")
+	kubeMetricsPodSelectorTwo := getKubeMetricsPodSelector(podSelectionRegex, namespace, "exported_namespace")
 
-	kubeMetricsHPASelector := fmt.Sprintf(
+	kubeMetricsHPASelectorOne := fmt.Sprintf(
 		`%s="%s",namespace="%s",metric_name="memory",metric_target_type="utilization"`,
 		hpaMetricName,
 		hpaName,
 		namespace,
 	)
 
+	kubeMetricsHPASelectorTwo := fmt.Sprintf(
+		`%s="%s",exported_namespace="%s",metric_name="memory",metric_target_type="utilization"`,
+		hpaMetricName,
+		hpaName,
+		namespace,
+	)
+
 	if memMetricName == "kube_pod_container_resource_requests" {
-		kubeMetricsPodSelector += `,resource="memory",unit="byte"`
+		kubeMetricsPodSelectorOne += `,resource="memory",unit="byte"`
+		kubeMetricsPodSelectorTwo += `,resource="memory",unit="byte"`
 	}
 
 	// the kube-state-metrics queries are less prone to error if the field app_kubernetes_io_instance is matched
 	// as well
 	if appLabel != "" {
-		kubeMetricsPodSelector += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
-		kubeMetricsHPASelector += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
+		kubeMetricsPodSelectorOne += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
+		kubeMetricsPodSelectorTwo += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
+		kubeMetricsHPASelectorOne += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
+		kubeMetricsHPASelectorTwo += fmt.Sprintf(`,app_kubernetes_io_instance="%s"`, appLabel)
 	}
 
-	requestMem := fmt.Sprintf(
+	requestMemOne := fmt.Sprintf(
 		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
 		hpaMetricName,
 		memMetricName,
-		kubeMetricsPodSelector,
+		kubeMetricsPodSelectorOne,
 		hpaMetricName,
 		hpaName,
 	)
 
-	targetMemUtilThreshold := fmt.Sprintf(
+	targetMemUtilThresholdOne := fmt.Sprintf(
 		`%s{%s} / 100`,
 		metricName,
-		kubeMetricsHPASelector,
+		kubeMetricsHPASelectorOne,
 	)
 
-	return fmt.Sprintf(`%s * on(%s) %s`, requestMem, hpaMetricName, targetMemUtilThreshold)
+	requestMemTwo := fmt.Sprintf(
+		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
+		hpaMetricName,
+		memMetricName,
+		kubeMetricsPodSelectorTwo,
+		hpaMetricName,
+		hpaName,
+	)
+
+	targetMemUtilThresholdTwo := fmt.Sprintf(
+		`%s{%s} / 100`,
+		metricName,
+		kubeMetricsHPASelectorTwo,
+	)
+
+	return fmt.Sprintf(
+		`(%s * on(%s) %s) or (%s * on(%s) %s)`,
+		requestMemOne, hpaMetricName, targetMemUtilThresholdOne,
+		requestMemTwo, hpaMetricName, targetMemUtilThresholdTwo,
+	)
 }
 
-func getKubeMetricsPodSelector(podSelectionRegex, namespace string) string {
+func getKubeMetricsPodSelector(podSelectionRegex, namespace, namespaceLabel string) string {
 	return fmt.Sprintf(
-		`pod=~"%s",namespace="%s",container!="POD",container!=""`,
+		`pod=~"%s",%s="%s",container!="POD",container!=""`,
 		podSelectionRegex,
+		namespaceLabel,
 		namespace,
 	)
 }
 
-func createHPACurrentReplicasQuery(metricName, hpaName, namespace, appLabel, hpaMetricName string) string {
+func createHPACurrentReplicasQuery(metricName, hpaName, namespace, namespaceLabel, appLabel, hpaMetricName string) string {
 	kubeMetricsHPASelector := fmt.Sprintf(
-		`%s="%s",namespace="%s"`,
+		`%s="%s",%s="%s"`,
 		hpaMetricName,
 		hpaName,
+		namespaceLabel,
 		namespace,
 	)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

HPA metrics (autoscaling lines and # of replicas) don't render because the exported `kube` metrics now use `exported_namespace` rather than `namespace` labels.

## What is the new behavior?

Add both queries, separated with an `or` statement. 

## Technical Spec/Implementation Notes
