### PR TITLE
[FIX] Replace underscores by hyphens on repo suffix for preview environments

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -424,7 +424,7 @@ func (d *Driver) createApplication(resource *models.Resource, client *api.Client
 
 	if repoName := os.Getenv("PORTER_REPO_NAME"); repoName != "" {
 		if repoOwner := os.Getenv("PORTER_REPO_OWNER"); repoOwner != "" {
-			repoSuffix = fmt.Sprintf("%s-%s", repoOwner, repoName)
+			repoSuffix = strings.ReplaceAll(fmt.Sprintf("%s-%s", repoOwner, repoName), "_", "-")
 		}
 	}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Repository names that might have underscores, will break the apply command as it doesn't follow k8s naming guidelines.

## What is the new behavior?

All underscores will now be replaced by hyphens.

## Technical Spec/Implementation Notes
