### PR TITLE
Remove custom docker client from pack client

### DIFF
--- a/cli/cmd/docker/agent.go
+++ b/cli/cmd/docker/agent.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -31,28 +30,6 @@ type Agent struct {
 	authGetter *AuthGetter
 	ctx        context.Context
 	label      string
-}
-
-// ImagePull overrides the default docker client ImagePull to inject registry credentials
-func (a *Agent) ImagePull(ctx context.Context, refStr string, options types.ImagePullOptions) (io.ReadCloser, error) {
-	opts, err := a.getPullOptions(refStr)
-
-	if err != nil {
-		return a.Client.ImagePull(ctx, refStr, options)
-	}
-
-	return a.Client.ImagePull(ctx, refStr, opts)
-}
-
-// ImagePush overrides the default docker client ImagePush to inject registry credentials
-func (a *Agent) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
-	opts, err := a.getPushOptions(image)
-
-	if err != nil {
-		return a.Client.ImagePush(ctx, image, options)
-	}
-
-	return a.Client.ImagePush(ctx, image, opts)
 }
 
 // CreateLocalVolumeIfNotExist creates a volume using driver type "local" with the

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -25,7 +25,7 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, dc
 	//initialize a pack client
 	logger := newPackLogger()
 
-	client, err := packclient.NewClient(packclient.WithLogger(logger), packclient.WithDockerClient(dc))
+	client, err := packclient.NewClient(packclient.WithLogger(logger))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Some builds fail as the custom docker client attempts to add GCR registry creds for public registries. 

## What is the new behavior?

Remove custom docker client for now. 

## Technical Spec/Implementation Notes
