### PR TITLE
Simplify pack caching to use the same repository

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -211,7 +211,6 @@ var stream bool
 var buildFlagsEnv []string
 var forcePush bool
 var useCache bool
-var cacheImage string
 
 func init() {
 	buildFlagsEnv = []string{}
@@ -232,13 +231,6 @@ func init() {
 		"use-cache",
 		false,
 		"Whether to use cache (currently in beta)",
-	)
-
-	updateCmd.PersistentFlags().StringVar(
-		&cacheImage,
-		"cache-image",
-		"",
-		"Image repo URI to use for the cache image",
 	)
 
 	updateCmd.PersistentFlags().StringVar(
@@ -469,7 +461,6 @@ func updateGetAgent(client *api.Client) (*deploy.DeployAgent, error) {
 			Method:          buildMethod,
 			AdditionalEnv:   additionalEnv,
 			UseCache:        useCache,
-			CacheImageRepo:  cacheImage,
 		},
 		Local: source != "github",
 	})
@@ -565,7 +556,7 @@ func updateBuildWithAgent(updateAgent *deploy.DeployAgent) error {
 }
 
 func updatePushWithAgent(updateAgent *deploy.DeployAgent) error {
-	if useCache && cacheImage != "" {
+	if useCache {
 		color.New(color.FgGreen).Println("Skipping image push for", app, "as use-cache is set")
 
 		return nil

--- a/cli/cmd/deploy/build.go
+++ b/cli/cmd/deploy/build.go
@@ -83,7 +83,7 @@ func (b *BuildAgent) BuildPack(dockerAgent *docker.Agent, dst, tag, prevTag stri
 	}
 
 	// call builder
-	return packAgent.Build(opts, buildConfig, dockerAgent, fmt.Sprintf("%s:%s", b.CacheImageRepo, "pack-cache"))
+	return packAgent.Build(opts, buildConfig, fmt.Sprintf("%s:%s", b.imageRepo, "pack-cache"))
 }
 
 // ResolveDockerPaths returns a path to the dockerfile that is either relative or absolute, and a path

--- a/cli/cmd/deploy/shared.go
+++ b/cli/cmd/deploy/shared.go
@@ -20,7 +20,6 @@ type SharedOpts struct {
 	AdditionalEnv   map[string]string
 	EnvGroups       []types.EnvGroupMeta
 	UseCache        bool
-	CacheImageRepo  string
 }
 
 func coalesceEnvGroups(

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -15,13 +15,11 @@ import (
 	"github.com/porter-dev/porter/cli/cmd/docker"
 	"github.com/porter-dev/porter/cli/cmd/github"
 	"k8s.io/client-go/util/homedir"
-
-	"github.com/docker/docker/client"
 )
 
 type Agent struct{}
 
-func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, dc client.CommonAPIClient, cacheImage string) error {
+func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, cacheImage string) error {
 	//initialize a pack client
 	logger := newPackLogger()
 
@@ -43,6 +41,7 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, dc
 		Builder:         "paketobuildpacks/builder:full",
 		AppPath:         opts.BuildContext,
 		Env:             opts.Env,
+		GroupID:         0,
 	}
 
 	if opts.UseCache {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): usability improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

`pack` builds are currently required to use a separate repository for caching. 

## What is the new behavior?

Attempt to use the same `pack` cache repository as the main application.  

## Technical Spec/Implementation Notes
