### PR TITLE
[FIX] Fixed cron parser date and added UTC time disclaimer to cron description

### DIFF
--- a/dashboard/src/components/porter-form/field-components/CronInput.tsx
+++ b/dashboard/src/components/porter-form/field-components/CronInput.tsx
@@ -69,7 +69,8 @@ const CronInput: React.FC<CronField> = (props) => {
             {CronParser.toString(variables[variable], {
               throwExceptionOnParseError: false,
               verbose: true,
-            })}
+            })}{" "}
+            UTC
           </>
         )}
       </Label>

--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -106,7 +106,7 @@ const Chart: React.FunctionComponent<Props> = ({
   let interval = null;
   if (chart?.config?.schedule?.enabled) {
     interval = CronParser.parseExpression(chart?.config?.schedule.value, {
-      currentDate: new Date(),
+      utc: true,
     });
   }
 

--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -374,7 +374,7 @@ const ChartList: React.FunctionComponent<Props> = ({
           firstInterval = CronParser.parseExpression(
             a?.config?.schedule.value,
             {
-              currentDate: new Date(),
+              utc: true,
             }
           );
         }
@@ -384,7 +384,7 @@ const ChartList: React.FunctionComponent<Props> = ({
           secondInterval = CronParser.parseExpression(
             b?.config?.schedule.value,
             {
-              currentDate: new Date(),
+              utc: true,
             }
           );
         }

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -136,7 +136,7 @@ export const ExpandedJobChartFC: React.FC<{
     let interval = null;
     if (chart?.config?.schedule.enabled) {
       interval = CronParser.parseExpression(chart?.config?.schedule.value, {
-        currentDate: new Date(),
+        utc: true,
       });
     }
     // @ts-ignore
@@ -184,7 +184,8 @@ export const ExpandedJobChartFC: React.FC<{
               Runs{" "}
               {CronPrettifier.toString(
                 chart?.config?.schedule.value
-              ).toLowerCase()}
+              ).toLowerCase()}{" "}
+              UTC
               <Dot
                 style={{
                   color: "#ffffff88",


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the user adds a cron to a job, there's a small description that will show when the cron will run. Right now is not clear what timezone this description is on.

## What is the new behavior?

Added a UTC text to the end of the cron description as well as date fixes for the next runs time.

## Technical Spec/Implementation Notes
