### PR TITLE
Add small preview environment improvements to apply command

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -386,6 +386,8 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		color.New(color.FgYellow).Printf("Skipping creation for %s as onlyCreate is set to true\n", resource.Name)
 	}
 
 	if err = d.assignOutput(resource, client); err != nil {

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -171,9 +171,14 @@ type Target struct {
 type ApplicationConfig struct {
 	WaitForJob bool
 
+	// If set to true, this does not run an update, it only creates the initial application and job,
+	// skipping subsequent updates
+	OnlyCreate bool
+
 	Build struct {
 		ForceBuild bool
 		ForcePush  bool
+		UseCache   bool
 		Method     string
 		Context    string
 		Dockerfile string
@@ -358,6 +363,15 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		OverrideTag:     tag,
 		Method:          deploy.DeployBuildType(method),
 		EnvGroups:       appConfig.EnvGroups,
+		UseCache:        appConfig.Build.UseCache,
+	}
+
+	if appConfig.Build.UseCache {
+		err := setDockerConfig(client)
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if shouldCreate {
@@ -366,7 +380,7 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if !appConfig.OnlyCreate {
 		resource, err = d.updateApplication(resource, client, sharedOpts, appConfig)
 
 		if err != nil {
@@ -378,7 +392,7 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		return nil, err
 	}
 
-	if d.source.Name == "job" && appConfig.WaitForJob {
+	if d.source.Name == "job" && appConfig.WaitForJob && (shouldCreate || !appConfig.OnlyCreate) {
 		color.New(color.FgYellow).Printf("Waiting for job '%s' to finish\n", resource.Name)
 
 		prevProject := config.Project
@@ -507,10 +521,12 @@ func (d *Driver) updateApplication(resource *models.Resource, client *api.Client
 			return nil, err
 		}
 
-		err = updateAgent.Push(appConf.Build.ForcePush)
+		if !appConf.Build.UseCache {
+			err = updateAgent.Push(appConf.Build.ForcePush)
 
-		if err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -327,10 +327,12 @@ func (c *CreateAgent) CreateFromDocker(
 			return "", err
 		}
 
-		err = agent.PushImage(fmt.Sprintf("%s:%s", imageURL, imageTag))
+		if !opts.SharedOpts.UseCache {
+			err = agent.PushImage(fmt.Sprintf("%s:%s", imageURL, imageTag))
 
-		if err != nil {
-			return "", err
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/cli/cmd/job.go
+++ b/cli/cmd/job.go
@@ -170,6 +170,8 @@ func waitForJob(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 	// if it does not exist, we set the default to 30 minutes
 	timeoutVal := getJobTimeoutValue(jobRelease.Release.Config)
 
+	color.New(color.FgYellow).Printf("Waiting for timeout seconds %d\n", timeoutVal.Seconds())
+
 	// if no job exists with the given revision, wait for the timeout value
 	timeWait := time.Now().Add(timeoutVal)
 

--- a/cli/cmd/job.go
+++ b/cli/cmd/job.go
@@ -166,8 +166,12 @@ func waitForJob(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 		return pausedErr
 	}
 
-	// if no job exists with the given revision, wait up to 30 minutes
-	timeWait := time.Now().Add(30 * time.Minute)
+	// attempt to parse out the timeout value for the job, given by `sidecar.timeout`
+	// if it does not exist, we set the default to 30 minutes
+	timeoutVal := getJobTimeoutValue(jobRelease.Release.Config)
+
+	// if no job exists with the given revision, wait for the timeout value
+	timeWait := time.Now().Add(timeoutVal)
 
 	for time.Now().Before(timeWait) {
 		// get the jobs for that job chart
@@ -221,4 +225,33 @@ func getJobMatchingRevision(revision uint, jobs []v1.Job) *v1.Job {
 	}
 
 	return nil
+}
+
+func getJobTimeoutValue(values map[string]interface{}) time.Duration {
+	defaultTimeout := time.Minute * 60
+	sidecarInter, ok := values["sidecar"]
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	sidecarVal, ok := sidecarInter.(map[string]interface{})
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	timeoutInter, ok := sidecarVal["timeout"]
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	timeoutVal, ok := timeoutInter.(int64)
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	return time.Second * time.Duration(timeoutVal)
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): preview env improvements

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently the following issues are arising:
- The timeout value of 30 minutes set for job timeouts is too short. 
- Some applications/jobs should only run during creation, not updates (i.e. database seeding jobs).
- Buildpack builds should have the option for using the buildpack cache. 

## What is the new behavior?

Adds the following improvements:
- Job waits should respect the timeout value set in the job config (`sidecar.timeout`). 
- Add `build.createOnly` as an option to only run during creation, not updates. 
- Add `build.useCache` as an option to re-use the pack cache between preview environments. 

## Technical Spec/Implementation Notes
