### PR TITLE
Add fix for closing of `/dev/stderr` when `pack` is run multiple times

### DIFF
--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -17,18 +17,23 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-type Agent struct{}
+var sharedPackClient *packclient.Client
 
-func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, cacheImage string) error {
+func init() {
+	var err error
 	//initialize a pack client
 	logger := newPackLogger()
 
-	client, err := packclient.NewClient(packclient.WithLogger(logger))
+	sharedPackClient, err = packclient.NewClient(packclient.WithLogger(logger))
 
 	if err != nil {
-		return err
+		panic(err)
 	}
+}
 
+type Agent struct{}
+
+func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, cacheImage string) error {
 	absPath, err := filepath.Abs(opts.BuildContext)
 
 	if err != nil {
@@ -138,5 +143,5 @@ func (a *Agent) Build(opts *docker.BuildOpts, buildConfig *types.BuildConfig, ca
 		buildOpts.Buildpacks = append(buildOpts.Buildpacks, "heroku/procfile@1.0.0")
 	}
 
-	return client.Build(context.Background(), buildOpts)
+	return sharedPackClient.Build(context.Background(), buildOpts)
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If `pack` is run multiple times (i.e. `packclient.Build` called twice) and it's using the build cache, commands start hanging and failing with:

```
Error: executing lifecycle: write /dev/stderr: file already closed
```

This may be due to a specific log line:

```
Unable to delete previous cache image: DELETE https://<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/v2/web-test-default/manifests/sha256:<SHA>: unexpected status code 404 Not Found
```

It's likely that either `pack` or an dependency is effectively calling `os.Stderr.Close()` -- but when I pipe to `Stdout` instead, it seems that `Stdout` gets closed as well. For some reason using an `ioutil.Discard` writer when `Unable to delete previous cache image` prevents this error from occurring completely. 

Not sure entirely what's going on, but as pack is planning to remove cache deletion this may not be an issue in future versions of pack. 

## What is the new behavior?

We've added a discard writer when matching the `Unable to delete previous cache image` log line. 

## Technical Spec/Implementation Notes
