### PR TITLE
[FIX] Commit not showing on Job resource inside of Expanded Job Chart

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobResource.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/JobResource.tsx
@@ -275,7 +275,9 @@ export default class JobResource extends Component<PropsType, StateType> {
           to={`https://github.com/${this.props.repositoryUrl}/commit/${tag}`}
           onClick={(e) => e.preventDefault()}
           target="_blank"
-        ></DynamicLink>
+        >
+          {tag}
+        </DynamicLink>
       );
     }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

A job that is linked through github doesn't show the commit tag although it exists.

## What is the new behavior?

Fixed a misstypo where we weren't populating the link content with the tag so it just showed a 0 width component.

## Technical Spec/Implementation Notes
