### PR TITLE
Parse the job timeout value properly when waiting for a job to finish

### DIFF
--- a/cli/cmd/job.go
+++ b/cli/cmd/job.go
@@ -168,7 +168,7 @@ func waitForJob(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 
 	// attempt to parse out the timeout value for the job, given by `sidecar.timeout`
 	// if it does not exist, we set the default to 30 minutes
-	timeoutVal := getJobTimeoutValue(jobRelease.Release.Config)
+	timeoutVal := GetJobTimeoutValue(jobRelease.Release.Config)
 
 	color.New(color.FgYellow).Printf("Waiting for timeout seconds %.1f\n", timeoutVal.Seconds())
 
@@ -229,7 +229,7 @@ func getJobMatchingRevision(revision uint, jobs []v1.Job) *v1.Job {
 	return nil
 }
 
-func getJobTimeoutValue(values map[string]interface{}) time.Duration {
+func GetJobTimeoutValue(values map[string]interface{}) time.Duration {
 	defaultTimeout := time.Minute * 60
 	sidecarInter, ok := values["sidecar"]
 
@@ -249,7 +249,7 @@ func getJobTimeoutValue(values map[string]interface{}) time.Duration {
 		return defaultTimeout
 	}
 
-	timeoutVal, ok := timeoutInter.(int64)
+	timeoutVal, ok := timeoutInter.(float64)
 
 	if !ok {
 		return defaultTimeout


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Job timeout value parsed as `int64` rather than `float64`. 

## What is the new behavior?

Parse as `float64` instead to prevent the job timeouts from using the default. 

## Technical Spec/Implementation Notes
