### PR TITLE
Add `waitForJob` option to the `update-config` driver

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -18,6 +18,7 @@ import (
 	"github.com/porter-dev/porter/api/types"
 	"github.com/porter-dev/porter/cli/cmd/config"
 	"github.com/porter-dev/porter/cli/cmd/deploy"
+	"github.com/porter-dev/porter/cli/cmd/deploy/wait"
 	"github.com/porter-dev/porter/cli/cmd/preview"
 	"github.com/porter-dev/porter/internal/templater/utils"
 	"github.com/porter-dev/switchboard/pkg/drivers"
@@ -400,7 +401,12 @@ func (d *Driver) applyApplication(resource *models.Resource, client *api.Client,
 		cliConf.Project = d.target.Project
 		cliConf.Cluster = d.target.Cluster
 
-		err = waitForJob(nil, client, []string{})
+		err = wait.WaitForJob(client, &wait.WaitOpts{
+			ProjectID: cliConf.Project,
+			ClusterID: cliConf.Cluster,
+			Namespace: namespace,
+			Name:      name,
+		})
 
 		if err != nil {
 			return nil, err

--- a/cli/cmd/deploy/wait/job.go
+++ b/cli/cmd/deploy/wait/job.go
@@ -1,0 +1,130 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/fatih/color"
+	api "github.com/porter-dev/porter/api/client"
+	v1 "k8s.io/api/batch/v1"
+)
+
+type WaitOpts struct {
+	ProjectID, ClusterID uint
+	Namespace, Name      string
+}
+
+// WaitForJob waits for a job with a given name/namespace to complete its run
+func WaitForJob(client *api.Client, opts *WaitOpts) error {
+	// get the job release
+	jobRelease, err := client.GetRelease(context.Background(), opts.ProjectID, opts.ClusterID, opts.Namespace, opts.Name)
+
+	if err != nil {
+		return err
+	}
+
+	// make sure the job chart has a manual job running
+	pausedVal, ok := jobRelease.Release.Config["paused"]
+	pausedErr := fmt.Errorf("this job template is not currently running a manual job")
+
+	if !ok {
+		return pausedErr
+	}
+
+	if pausedValBool, ok := pausedVal.(bool); ok && pausedValBool {
+		return pausedErr
+	}
+
+	// attempt to parse out the timeout value for the job, given by `sidecar.timeout`
+	// if it does not exist, we set the default to 30 minutes
+	timeoutVal := getJobTimeoutValue(jobRelease.Release.Config)
+
+	color.New(color.FgYellow).Printf("Waiting for timeout seconds %.1f\n", timeoutVal.Seconds())
+
+	// if no job exists with the given revision, wait for the timeout value
+	timeWait := time.Now().Add(timeoutVal)
+
+	for time.Now().Before(timeWait) {
+		// get the jobs for that job chart
+		jobs, err := client.GetJobs(context.Background(), opts.ProjectID, opts.ClusterID, opts.Namespace, opts.Name)
+
+		if err != nil {
+			return err
+		}
+
+		job := getJobMatchingRevision(uint(jobRelease.Release.Version), jobs)
+
+		if job == nil {
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// once job is running, wait for status to be completed, or failed
+		// if failed, exit with non-zero exit code
+		if job.Status.Failed > 0 {
+			return fmt.Errorf("job failed")
+		}
+
+		if job.Status.Succeeded > 0 {
+			return nil
+		}
+
+		// otherwise, return no error
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf("timed out waiting for job")
+}
+
+func getJobMatchingRevision(revision uint, jobs []v1.Job) *v1.Job {
+	for _, job := range jobs {
+		revisionLabel, revisionLabelExists := job.Labels["helm.sh/revision"]
+
+		if !revisionLabelExists {
+			continue
+		}
+
+		jobRevision, err := strconv.ParseUint(revisionLabel, 10, 64)
+
+		if err != nil {
+			continue
+		}
+
+		if uint(jobRevision) == revision {
+			return &job
+		}
+	}
+
+	return nil
+}
+
+func getJobTimeoutValue(values map[string]interface{}) time.Duration {
+	defaultTimeout := time.Minute * 60
+	sidecarInter, ok := values["sidecar"]
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	sidecarVal, ok := sidecarInter.(map[string]interface{})
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	timeoutInter, ok := sidecarVal["timeout"]
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	timeoutVal, ok := timeoutInter.(float64)
+
+	if !ok {
+		return defaultTimeout
+	}
+
+	return time.Second * time.Duration(timeoutVal)
+}

--- a/cli/cmd/job.go
+++ b/cli/cmd/job.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/fatih/color"
 	api "github.com/porter-dev/porter/api/client"
 	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/cli/cmd/deploy/wait"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/batch/v1"
 )
 
 var jobCmd = &cobra.Command{
@@ -147,113 +145,10 @@ func batchImageUpdate(_ *types.GetAuthenticatedUserResponse, client *api.Client,
 
 // waits for a job with a given name/namespace
 func waitForJob(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
-	// get the job release
-	jobRelease, err := client.GetRelease(context.Background(), cliConf.Project, cliConf.Cluster, namespace, name)
-
-	if err != nil {
-		return err
-	}
-
-	// make sure the job chart has a manual job running
-	pausedVal, ok := jobRelease.Release.Config["paused"]
-	pausedErr := fmt.Errorf("this job template is not currently running a manual job")
-
-	if !ok {
-		return pausedErr
-	}
-
-	if pausedValBool, ok := pausedVal.(bool); ok && pausedValBool {
-		return pausedErr
-	}
-
-	// attempt to parse out the timeout value for the job, given by `sidecar.timeout`
-	// if it does not exist, we set the default to 30 minutes
-	timeoutVal := GetJobTimeoutValue(jobRelease.Release.Config)
-
-	color.New(color.FgYellow).Printf("Waiting for timeout seconds %.1f\n", timeoutVal.Seconds())
-
-	// if no job exists with the given revision, wait for the timeout value
-	timeWait := time.Now().Add(timeoutVal)
-
-	for time.Now().Before(timeWait) {
-		// get the jobs for that job chart
-		jobs, err := client.GetJobs(context.Background(), cliConf.Project, cliConf.Cluster, namespace, name)
-
-		if err != nil {
-			return err
-		}
-
-		job := getJobMatchingRevision(uint(jobRelease.Release.Version), jobs)
-
-		if job == nil {
-			time.Sleep(10 * time.Second)
-			continue
-		}
-
-		// once job is running, wait for status to be completed, or failed
-		// if failed, exit with non-zero exit code
-		if job.Status.Failed > 0 {
-			return fmt.Errorf("job failed")
-		}
-
-		if job.Status.Succeeded > 0 {
-			return nil
-		}
-
-		// otherwise, return no error
-		time.Sleep(10 * time.Second)
-	}
-
-	return fmt.Errorf("timed out waiting for job")
-}
-
-func getJobMatchingRevision(revision uint, jobs []v1.Job) *v1.Job {
-	for _, job := range jobs {
-		revisionLabel, revisionLabelExists := job.Labels["helm.sh/revision"]
-
-		if !revisionLabelExists {
-			continue
-		}
-
-		jobRevision, err := strconv.ParseUint(revisionLabel, 10, 64)
-
-		if err != nil {
-			continue
-		}
-
-		if uint(jobRevision) == revision {
-			return &job
-		}
-	}
-
-	return nil
-}
-
-func GetJobTimeoutValue(values map[string]interface{}) time.Duration {
-	defaultTimeout := time.Minute * 60
-	sidecarInter, ok := values["sidecar"]
-
-	if !ok {
-		return defaultTimeout
-	}
-
-	sidecarVal, ok := sidecarInter.(map[string]interface{})
-
-	if !ok {
-		return defaultTimeout
-	}
-
-	timeoutInter, ok := sidecarVal["timeout"]
-
-	if !ok {
-		return defaultTimeout
-	}
-
-	timeoutVal, ok := timeoutInter.(float64)
-
-	if !ok {
-		return defaultTimeout
-	}
-
-	return time.Second * time.Duration(timeoutVal)
+	return wait.WaitForJob(client, &wait.WaitOpts{
+		ProjectID: cliConf.Project,
+		ClusterID: cliConf.Cluster,
+		Namespace: namespace,
+		Name:      name,
+	})
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): `porter.yaml` driver improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

While there's a `waitForJob` option on the primary `deploy` driver, there is no equivalent option in the `update-config` driver. 

## What is the new behavior?

Add `waitForJob option to primary `deploy` driver. 

## Technical Spec/Implementation Notes
