### PR TITLE
Fix ambiguous deployment column for re-enabling a preview env deployment

### DIFF
--- a/internal/repository/gorm/environment.go
+++ b/internal/repository/gorm/environment.go
@@ -122,7 +122,7 @@ func (repo *EnvironmentRepository) ReadDeploymentByID(projectID, clusterID, id u
 	if err := repo.db.
 		Order("deployments.updated_at desc").
 		Joins("INNER JOIN environments ON environments.id = deployments.environment_id").
-		Where("environments.project_id = ? AND environments.cluster_id = ? AND id = ?", projectID, clusterID, id).First(&depl).Error; err != nil {
+		Where("environments.project_id = ? AND environments.cluster_id = ? AND deployments.id = ?", projectID, clusterID, id).First(&depl).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Column `id` is ambiguous for re-enabling a preview environment. 

## What is the new behavior?

Hotfix. 

## Technical Spec/Implementation Notes
