### PR TITLE
[POR 410] Jobs delete modal never closes

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -112,6 +112,14 @@ export const ExpandedJobChartFC: React.FC<{
     return conf;
   };
 
+  const handleDeleteChart = async () => {
+    try {
+      await deleteChart();
+    } finally {
+      setCurrentOverlay(null);
+    }
+  };
+
   const renderTabContents = (currentTab: string) => {
     if (currentTab === "jobs" && hasPorterImageTemplate) {
       return (
@@ -241,7 +249,7 @@ export const ExpandedJobChartFC: React.FC<{
             if (showOverlay) {
               setCurrentOverlay({
                 message: `Are you sure you want to delete ${chart.name}?`,
-                onYes: deleteChart,
+                onYes: handleDeleteChart,
                 onNo: () => setCurrentOverlay(null),
               });
             } else {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the user clicks on delete on any job, an overlay appears to confirm the action. Right now that overlay never closes even if the deletion went through

## What is the new behavior?

Added a new function handleDeleteChart that will wait until the api call finishes and then close the overlay, no matter if the api request failed or not.

## Technical Spec/Implementation Notes
