### PR TITLE
[FIX] Remove waiting for api response to close overlay on job deletion

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -113,11 +113,8 @@ export const ExpandedJobChartFC: React.FC<{
   };
 
   const handleDeleteChart = async () => {
-    try {
-      await deleteChart();
-    } finally {
-      setCurrentOverlay(null);
-    }
+    deleteChart();
+    setCurrentOverlay(null);
   };
 
   const renderTabContents = (currentTab: string) => {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Overlay closes after DELETE api call finishes

## What is the new behavior?

Remove the dependency between api call waiting and closing the overlay and just close the overlay as soon as the API call is being made


## Technical Spec/Implementation Notes
