### PR TITLE
Fix installation id passed wrong to repo

### DIFF
--- a/dashboard/src/components/repo-selector/RepoList.tsx
+++ b/dashboard/src/components/repo-selector/RepoList.tsx
@@ -76,9 +76,9 @@ const RepoList: React.FC<Props> = ({
     try {
       const resolvedRepoList = await Promise.allSettled(repoListPromises);
 
-      const repos: RepoType[][] = resolvedRepoList
-        .map((repo) => (repo.status === "fulfilled" ? repo.value.data : null))
-        .filter(Boolean);
+      const repos: RepoType[][] = resolvedRepoList.map((repo) =>
+        repo.status === "fulfilled" ? repo.value.data : []
+      );
 
       const names = new Set();
       // note: would be better to use .flat() here but you need es2019 for

--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/ConnectNewRepo.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/ConnectNewRepo.tsx
@@ -257,8 +257,8 @@ const HeaderSection = styled.div`
 
   > i {
     cursor: pointer;
-    font-size 20px;
-    color: #969Fbbaa;
+    font-size: 20px;
+    color: #969fbbaa;
     padding: 2px;
     border: 2px solid #969fbbaa;
     border-radius: 100px;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

When an installation id was failing to retrieve repos, the array index was shifted and the final result was a repository list with non corresponding installation ids.