### PR TITLE
Add max instances to EKS infra form

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -379,6 +379,12 @@ tabs:
       required: true
       placeholder: my-cluster
       variable: cluster_name
+    - type: number-input
+      label: Maximum number of EC2 instances to create in the application autoscaling group.
+      variable: max_instances
+      placeholder: "ex: 10"
+      settings:
+        default: 10
     - type: checkbox
       variable: spot_instances_enabled
       label: Enable spot instances for this cluster.


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): infra form improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No option to change max instances (set at 10). 

## What is the new behavior?

Option to increase or decrease max instances for custom infra. 

## Technical Spec/Implementation Notes
