### PR TITLE
Fix alternative GCR hostnames

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -131,7 +131,7 @@ func (r *Registry) listGCRRepositories(
 
 	regURL := r.URL
 
-	if !strings.Contains(regURL, "http") {
+	if !strings.HasPrefix(regURL, "http") {
 		regURL = fmt.Sprintf("https://%s", regURL)
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -129,9 +129,22 @@ func (r *Registry) listGCRRepositories(
 	// for oauth. This also prevents us from making more requests.
 	client := &http.Client{}
 
+	regURL := r.URL
+
+	if !strings.Contains(regURL, "http") {
+		regURL = fmt.Sprintf("https://%s", regURL)
+	}
+
+	regURLParsed, err := url.Parse(regURL)
+	regHostname := "gcr.io"
+
+	if err == nil {
+		regHostname = regURLParsed.Host
+	}
+
 	req, err := http.NewRequest(
 		"GET",
-		"https://gcr.io/v2/_catalog",
+		fmt.Sprintf("https://%s/v2/_catalog", regHostname),
 		nil,
 	)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Alternative GCR hostnames like `eu.gcr.io` don't properly list repositories. 

## What is the new behavior?

Add casing for alternative GCR hostnames. 

## Technical Spec/Implementation Notes
