### PR TITLE
Fix namespaces not persisting across sidebar tabs

### DIFF
--- a/dashboard/src/main/home/sidebar/Sidebar.tsx
+++ b/dashboard/src/main/home/sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ class Sidebar extends Component<PropsType, StateType> {
               let search = `?cluster=${currentCluster.name}&project_id=${currentProject.id}`;
 
               if (pathNamespace) {
-                search.concat(`&namespace=${pathNamespace}`);
+                search = search.concat(`&namespace=${pathNamespace}`);
               }
 
               return {
@@ -136,7 +136,7 @@ class Sidebar extends Component<PropsType, StateType> {
               let search = `?cluster=${currentCluster.name}&project_id=${currentProject.id}`;
 
               if (pathNamespace) {
-                search.concat(`&namespace=${pathNamespace}`);
+                search = search.concat(`&namespace=${pathNamespace}`);
               }
 
               return {
@@ -156,7 +156,7 @@ class Sidebar extends Component<PropsType, StateType> {
               let search = `?cluster=${currentCluster.name}&project_id=${currentProject.id}`;
 
               if (pathNamespace) {
-                search.concat(`&namespace=${pathNamespace}`);
+                search = search.concat(`&namespace=${pathNamespace}`);
               }
 
               return {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?
Currently, selected `namespace`s do not persist when navigating across sidebar links. 

## What is the new behavior?
This should fix the issue of `namespace` not persisting across sidebar links. Sadly, I don't have a good way to test this, but please give it a look. Thanks!

## Technical Spec/Implementation Notes
This issue arises because `concat` does not mutate the string in place, but returns a new string (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat). We need to reassign to the variable `search` after concat-ing the `namespace` string.
