### PR TITLE
[POR-436] Expanded job chart breaking when trying to parse invalid cron expression

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedJobChart.tsx
@@ -152,6 +152,17 @@ export const ExpandedJobChartFC: React.FC<{
       timeStyle: "long",
     });
 
+    let runDescription = "";
+
+    try {
+      runDescription = `Runs ${CronPrettifier.toString(
+        chart?.config?.schedule.value
+      ).toLowerCase()} UTC`;
+    } catch (error) {
+      runDescription =
+        "An unexpected error happened while trying to parse the cron expression.";
+    }
+
     if (currentTab === "jobs") {
       return (
         <TabWrapper>
@@ -186,11 +197,7 @@ export const ExpandedJobChartFC: React.FC<{
           {chart?.config?.schedule?.enabled ? (
             <RunsDescription>
               <i className="material-icons">access_time</i>
-              Runs{" "}
-              {CronPrettifier.toString(
-                chart?.config?.schedule.value
-              ).toLowerCase()}{" "}
-              UTC
+              {runDescription}
               <Dot
                 style={{
                   color: "#ffffff88",


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If a user had created an invalid cron expression before the CronInput component was added, and tries to see that revision on the expanded job chart the app keeps throwing error and the user can't see any details of it

## What is the new behavior?

Catch any parsing errors and show a standard error message to let the user keep searching through the revision.

## Technical Spec/Implementation Notes
