### PR TITLE
[POR-435] [FIX] Implemented is read only property for CronInput

### DIFF
--- a/dashboard/src/components/porter-form/field-components/CronInput.tsx
+++ b/dashboard/src/components/porter-form/field-components/CronInput.tsx
@@ -10,7 +10,7 @@ import DocsHelper from "components/DocsHelper";
 import DynamicLink from "components/DynamicLink";
 
 const CronInput: React.FC<CronField> = (props) => {
-  const { id, variable, label, placeholder, value } = props;
+  const { id, variable, label, placeholder, value, isReadOnly } = props;
 
   const { state, variables, setVars, setValidation, validation } = useFormField(
     id,
@@ -35,6 +35,7 @@ const CronInput: React.FC<CronField> = (props) => {
         label={label}
         placeholder={placeholder}
         value={variables[variable]}
+        disabled={isReadOnly}
         setValue={(x: string) => {
           setVars((vars) => {
             return {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the form is read-only the user still can change the value

## What is the new behavior?

Implemented missing isReadOnly property inside the CronInput component

## Technical Spec/Implementation Notes
