### PR TITLE
Track down custom subdomain with proper interface conversion

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -803,11 +803,13 @@ func (t *DeploymentHook) DataQueries() map[string]interface{} {
 							hostsArr, hostsExists := ingressMap["hosts"]
 
 							if hostsExists {
-								hostsArrVal, hostsArrOk := hostsArr.([]string)
+								hostsArrVal, hostsArrOk := hostsArr.([]interface{})
 
 								if hostsArrOk && len(hostsArrVal) > 0 {
-									res[resource.Name] = fmt.Sprintf("{ .%s.ingress.hosts[0] }", resource.Name)
-									isCustomDomain = true
+									if _, ok := hostsArrVal[0].(string); ok {
+										res[resource.Name] = fmt.Sprintf("{ .%s.ingress.hosts[0] }", resource.Name)
+										isCustomDomain = true
+									}
 								}
 							}
 						}

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -534,10 +534,14 @@ func (c *CreateAgent) CreateSubdomainIfRequired(mergedValues map[string]interfac
 						hostsArr, hostsExists := ingressMap["hosts"]
 
 						if hostsExists {
-							hostsArrVal, hostsArrOk := hostsArr.([]string)
+							hostsArrVal, hostsArrOk := hostsArr.([]interface{})
 
 							if hostsArrOk && len(hostsArrVal) > 0 {
-								subdomain = hostsArrVal[0]
+								subdomainStr, ok := hostsArrVal[0].(string)
+
+								if ok {
+									subdomain = subdomainStr
+								}
 							}
 						}
 					} else {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The `ingress.hosts` field was being cast as `.([]string)` when the correct type conversion is `.([]interface{})`. 

## What is the new behavior?

Track down custom subdomain correctly. 

## Technical Spec/Implementation Notes
