### PR TITLE
Fix deployment hook by querying `values.ingress` for custom domains

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -786,7 +786,7 @@ func (t *DeploymentHook) DataQueries() map[string]interface{} {
 			// determine if we should query for porter_hosts or just hosts
 			isCustomDomain := false
 
-			ingressMap, err := deploy.GetNestedMap(resource.Config, "ingress")
+			ingressMap, err := deploy.GetNestedMap(resource.Config, "values", "ingress")
 
 			if err == nil {
 				enabledVal, enabledExists := ingressMap["enabled"]


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Deployment hook queries `ingress` rather than `values.ingress` which prevents custom domain from being read. 

## What is the new behavior?

Query `values.ingress`. 

## Technical Spec/Implementation Notes
