### PR TITLE
Update EKS form to include dynamic CIDR range

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -387,6 +387,13 @@ tabs:
       placeholder: "ex: 10"
       settings:
         default: 10
+- name: advanced
+  label: Advanced
+  sections:
+  - name: spot_instance_should_enable
+    contents:
+    - type: heading
+      label: Spot Instance Settings
     - type: checkbox
       variable: spot_instances_enabled
       label: Enable spot instances for this cluster.
@@ -399,6 +406,16 @@ tabs:
       label: Assign a bid price for the spot instance (optional).
       variable: spot_price
       placeholder: "ex: 0.05"
+  - name: net_settings
+    contents:
+    - type: heading
+      label: Networking Settings
+    - type: string-input
+      label: "Add a different CIDR range prefix (first two octets: for example 10.99 will create a VPC with CIDR range 10.99.0.0/16)."
+      variable: cluster_vpc_cidr_octets
+      placeholder: "ex: 10.99"
+      settings:
+        default: "10.99"
 `
 
 const gcrForm = `name: GCR


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

VPC created for EKS is statically set to have CIDR range `10.99.0.0/16`. 

## What is the new behavior?

Make CIDR range dynamic, and put this in an "Advanced" tab for EKS options. 

## Technical Spec/Implementation Notes
