### PR TITLE
Prevent hello-porter images from being written to the database

### DIFF
--- a/api/server/handlers/release/update_rollback.go
+++ b/api/server/handlers/release/update_rollback.go
@@ -118,7 +118,9 @@ func updateReleaseRepo(config *config.Config, release *models.Release, helmRelea
 		return fmt.Errorf("Could not find field repository in config")
 	}
 
-	if repoStr != release.ImageRepoURI {
+	if repoStr != release.ImageRepoURI &&
+		repoStr != "public.ecr.aws/o1j4x7p4/hello-porter" &&
+		repoStr != "public.ecr.aws/o1j4x7p4/hello-porter-job" {
 		release.ImageRepoURI = repoStr
 		_, err := config.Repo.Release().UpdateRelease(release)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

In certain cases hello-porter images can be written to the database. 

## What is the new behavior?

Prevent upgrades to the chart from writing hello-porter images to the database. 

## Technical Spec/Implementation Notes
