### PR TITLE
Add fix for displaying Azure load balancer address

### DIFF
--- a/internal/kubernetes/domain/domain.go
+++ b/internal/kubernetes/domain/domain.go
@@ -37,15 +37,26 @@ func GetNGINXIngressServiceIP(clientset kubernetes.Interface) (string, bool, err
 		if err != nil {
 			return "", false, err
 		}
-	}
 
-	for _, svc := range svcList.Items {
-		// check that helm chart annotation is correct exists
-		if chartAnn, found := svc.ObjectMeta.Labels["helm.sh/chart"]; found {
-			if (strings.Contains(chartAnn, "ingress-nginx") || strings.Contains(chartAnn, "nginx-ingress")) && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-				nginxSvc = &svc
-				exists = true
-				break
+		if len(svcList.Items) > 0 {
+			for _, svc := range svcList.Items {
+				// check that the service is type load balancer
+				if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+					nginxSvc = &svc
+					exists = true
+					break
+				}
+			}
+		}
+	} else {
+		for _, svc := range svcList.Items {
+			// check that helm chart annotation is correct exists
+			if chartAnn, found := svc.ObjectMeta.Labels["helm.sh/chart"]; found {
+				if (strings.Contains(chartAnn, "ingress-nginx") || strings.Contains(chartAnn, "nginx-ingress")) && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+					nginxSvc = &svc
+					exists = true
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Azure ingress controller does not have expected annotations so we ignore it while looking for an LB address. 

## What is the new behavior?

Add separate case to ignore those annotations. 

## Technical Spec/Implementation Notes
