### PR TITLE
[FIX] Porter form breaking on charts with no key-value-array field

### DIFF
--- a/dashboard/src/components/porter-form/PorterFormContextProvider.tsx
+++ b/dashboard/src/components/porter-form/PorterFormContextProvider.tsx
@@ -499,6 +499,13 @@ export const PorterFormContextProvider: React.FC<Props> = (props) => {
           metadata: Object.assign.apply({}, metadataList),
         });
 
+      if (!metadataList.length) {
+        return {
+          values: Object.assign.apply({}, varList),
+          metadata: {},
+        };
+      }
+
       return {
         values: Object.assign.apply({}, varList),
         metadata: Object.assign.apply({}, metadataList),


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Any form.yaml that didn't had a key-value-array was failing to update due to the getMetadata functions not being executed (currently the key-value-array is the only one that has one)

## What is the new behavior?

Added a null safe check to see if we actually have metadata on any field of the form and if not, simply return an object.

## Technical Spec/Implementation Notes
