### PR TITLE
Add option to make Porter cookie insecure

### DIFF
--- a/api/server/shared/config/env/envconfs.go
+++ b/api/server/shared/config/env/envconfs.go
@@ -20,6 +20,7 @@ type ServerConf struct {
 	StaticFilePath       string        `env:"STATIC_FILE_PATH,default=/porter/static"`
 	CookieName           string        `env:"COOKIE_NAME,default=porter"`
 	CookieSecrets        []string      `env:"COOKIE_SECRETS,default=random_hash_key_;random_block_key"`
+	CookieInsecure       bool          `env:"COOKIE_INSECURE,default=false"`
 	TokenGeneratorSecret string        `env:"TOKEN_GENERATOR_SECRET,default=secret"`
 	TimeoutRead          time.Duration `env:"SERVER_TIMEOUT_READ,default=5s"`
 	TimeoutWrite         time.Duration `env:"SERVER_TIMEOUT_WRITE,default=10s"`

--- a/api/server/shared/config/loader/loader.go
+++ b/api/server/shared/config/loader/loader.go
@@ -91,6 +91,7 @@ func (e *EnvConfigLoader) LoadConfig() (res *config.Config, err error) {
 		&sessionstore.NewStoreOpts{
 			SessionRepository: res.Repo.Session(),
 			CookieSecrets:     envConf.ServerConf.CookieSecrets,
+			Insecure:          envConf.ServerConf.CookieInsecure,
 		},
 	)
 

--- a/internal/auth/sessionstore/sessionstore.go
+++ b/internal/auth/sessionstore/sessionstore.go
@@ -111,6 +111,8 @@ func (store *PGStore) save(session *sessions.Session) error {
 type NewStoreOpts struct {
 	SessionRepository repository.SessionRepository
 	CookieSecrets     []string
+
+	Insecure bool
 }
 
 // NewStore takes an initialized db and session key pairs to create a session-store in postgres db.
@@ -126,7 +128,7 @@ func NewStore(opts *NewStoreOpts) (*PGStore, error) {
 		Options: &sessions.Options{
 			Path:     "/",
 			MaxAge:   86400 * 30,
-			Secure:   true,
+			Secure:   !opts.Insecure,
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		},


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): self-hosted improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When Porter is hosted on a non-localhost URL on port 80, authentication doesn't work as the cookie is set to `Secure` by default. 

## What is the new behavior?

Continue to set cookies to `Secure` by default, but give the user the option to turn this off via the env var `COOKIE_INSECURE=true`.

## Technical Spec/Implementation Notes
