### PR TITLE
Fix Docker build errors not getting caught

### DIFF
--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -310,7 +310,9 @@ func (c *CreateAgent) CreateFromDocker(
 	}
 
 	if opts.Method == DeployBuildTypeDocker {
-		basePath, err := filepath.Abs(".")
+		var basePath string
+
+		basePath, err = filepath.Abs(".")
 
 		if err != nil {
 			return "", err

--- a/cli/cmd/preview/build_image_driver.go
+++ b/cli/cmd/preview/build_image_driver.go
@@ -280,7 +280,9 @@ func (d *BuildDriver) Apply(resource *models.Resource) (*models.Resource, error)
 	}
 
 	if d.config.Build.Method == string(deploy.DeployBuildTypeDocker) {
-		basePath, err := filepath.Abs(".")
+		var basePath string
+
+		basePath, err = filepath.Abs(".")
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Docker build errors are sometimes not caught on creation (for both preview envs and from `porter create`. This is a result of `err` being initialized inside an `if` block scope. 

## What is the new behavior?

Set `err` to outer scope, so that docker build errors are always caught. 

## Technical Spec/Implementation Notes
