### PR TITLE
[POR-471] Job chart deletion is not triggering delete_application for env groups

### DIFF
--- a/dashboard/src/shared/hooks/useChart.ts
+++ b/dashboard/src/shared/hooks/useChart.ts
@@ -101,6 +101,32 @@ export const useChart = (oldChart: ChartType, closeChart: () => void) => {
    */
   const deleteChart = async () => {
     try {
+      const syncedEnvGroups = chart.config?.container?.env?.synced || [];
+      const removeApplicationToEnvGroupPromises = syncedEnvGroups.map(
+        (envGroup: any) => {
+          return api.removeApplicationFromEnvGroup(
+            "<token>",
+            {
+              name: envGroup?.name,
+              app_name: chart.name,
+            },
+            {
+              project_id: currentProject.id,
+              cluster_id: currentCluster.id,
+              namespace: chart.namespace,
+            }
+          );
+        }
+      );
+      try {
+        await Promise.all(removeApplicationToEnvGroupPromises);
+      } catch (error) {
+        setCurrentError(
+          "We coudln't remove the synced env group from the application, please remove it manually before uninstalling the chart, or try again."
+        );
+        return;
+      }
+
       await api.uninstallTemplate(
         "<token>",
         {},


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When a job is deleted, the user keeps seeing the application inside the env group

## What is the new behavior?

Added the delete_application api call to remove the deleting application from all env groups


