### PR TITLE
[POR-472] Add tooltip for cluster names on sidebar

### DIFF
--- a/dashboard/src/main/home/sidebar/ClusterSection.tsx
+++ b/dashboard/src/main/home/sidebar/ClusterSection.tsx
@@ -10,6 +10,7 @@ import Drawer from "./Drawer";
 import { RouteComponentProps, withRouter } from "react-router";
 import { pushFiltered } from "shared/routing";
 import { NavLink } from "react-router-dom";
+import { Tooltip } from "@material-ui/core";
 
 type PropsType = RouteComponentProps & {
   forceCloseDrawer: boolean;
@@ -177,7 +178,9 @@ class ClusterSection extends Component<PropsType, StateType> {
             <ClusterIcon>
               <i className="material-icons">device_hub</i>
             </ClusterIcon>
-            <ClusterName>{currentCluster && currentCluster.name}</ClusterName>
+            <Tooltip title={currentCluster?.name}>
+              <ClusterName>{currentCluster?.name}</ClusterName>
+            </Tooltip>
           </LinkWrapper>
           <DrawerButton
             onClick={(e) => {

--- a/dashboard/src/main/home/sidebar/Drawer.tsx
+++ b/dashboard/src/main/home/sidebar/Drawer.tsx
@@ -6,6 +6,7 @@ import { Context } from "shared/Context";
 import { ClusterType } from "shared/types";
 import { RouteComponentProps, withRouter } from "react-router";
 import { pushFiltered } from "shared/routing";
+import { Tooltip } from "@material-ui/core";
 
 type PropsType = RouteComponentProps & {
   toggleDrawer: () => void;
@@ -44,7 +45,9 @@ class Drawer extends Component<PropsType, StateType> {
             <ClusterIcon>
               <i className="material-icons">device_hub</i>
             </ClusterIcon>
-            <ClusterName>{cluster.name}</ClusterName>
+            <Tooltip title={cluster?.name}>
+              <ClusterName>{cluster.name}</ClusterName>
+            </Tooltip>
           </ClusterOption>
         );
       });


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users with long named clusters are unable to see the full name from the sidebar, which makes them open each of those until found the one they wanted to inspect

## What is the new behavior?

Added a tooltip so a user can see the clusters full name on hover.

## Technical Spec/Implementation Notes
