### PR TITLE
[POR-478] User can't load env group variables from build settings

### DIFF
--- a/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
+++ b/dashboard/src/main/home/modals/LoadEnvGroupModal.tsx
@@ -20,7 +20,7 @@ import {
 } from "components/porter-form/types";
 import Helper from "components/form-components/Helper";
 import DocsHelper from "components/DocsHelper";
-import { isObject } from "lodash";
+import { isEmpty, isObject } from "lodash";
 
 type PropsType = {
   namespace: string;
@@ -161,6 +161,14 @@ export default class LoadEnvGroupModal extends Component<PropsType, StateType> {
     if (!incoming) {
       return [];
     }
+
+    if (
+      !isObject(this.props.existingValues) ||
+      isEmpty(this.props.existingValues)
+    ) {
+      return [];
+    }
+
     // console.log(incoming, this.props.existingValues);
     return Object.entries(incoming)
       .filter(([key]) => this.props.existingValues[key])


### PR DESCRIPTION

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Technical Spec/Implementation Notes

When checking if there's overriden keys, the load env group modal fails if there's no previous keys, this changes add null safe checking for previous keys.
