### PR TITLE
Disable incidents tab on apps that are deployed on system namespaces

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -24,6 +24,7 @@ import TitleSection from "components/TitleSection";
 import DeploymentType from "./DeploymentType";
 import IncidentsTab from "./incidents/IncidentsTab";
 import BuildSettingsTab from "./BuildSettingsTab";
+import { DisabledNamespacesForIncidents } from "./incidents/DisabledNamespaces";
 
 type Props = {
   namespace: string;
@@ -406,6 +407,9 @@ const ExpandedChart: React.FC<Props> = (props) => {
       case "metrics":
         return <MetricsSection currentChart={chart} />;
       case "incidents":
+        if (DisabledNamespacesForIncidents.includes(currentChart.namespace)) {
+          return null;
+        }
         return (
           <IncidentsTab
             releaseName={chart?.name}
@@ -506,7 +510,10 @@ const ExpandedChart: React.FC<Props> = (props) => {
     let rightTabOptions = [] as any[];
     let leftTabOptions = [] as any[];
     leftTabOptions.push({ label: "Status", value: "status" });
-    leftTabOptions.push({ label: "Incidents", value: "incidents" });
+
+    if (!DisabledNamespacesForIncidents.includes(currentChart.namespace)) {
+      leftTabOptions.push({ label: "Incidents", value: "incidents" });
+    }
 
     if (props.isMetricsInstalled) {
       leftTabOptions.push({ label: "Metrics", value: "metrics" });

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/incidents/DisabledNamespaces.ts
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/incidents/DisabledNamespaces.ts
@@ -1,0 +1,9 @@
+export const DisabledNamespacesForIncidents = [
+  "cert-manager",
+  "ingress-nginx",
+  "kube-node-lease",
+  "kube-public",
+  "kube-system",
+  "monitoring",
+  "porter-agent-system",
+];


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

The porter agent does not listen for incidents on specific namespaces, that's why users may get confused on seeing the incidents tab but not being able to see any incident for those apps (such as prometheus)
