### PR TITLE
Add fix for expandable resource button crashing when there's no button

### DIFF
--- a/dashboard/src/components/ExpandableResource.tsx
+++ b/dashboard/src/components/ExpandableResource.tsx
@@ -76,14 +76,16 @@ const ExpandableResource: React.FC<Props> = (props) => {
             </Pair>
           );
         })}
-        <StyledSaveButton
-          onClick={onSave}
-          clearPosition={true}
-          text={button.name}
-          helper={button.description}
-          statusPosition={"right"}
-          className="expanded-save-button"
-        />
+        {button && (
+          <StyledSaveButton
+            onClick={onSave}
+            clearPosition={true}
+            text={button.name}
+            helper={button.description}
+            statusPosition={"right"}
+            className="expanded-save-button"
+          />
+        )}
       </ExpandedWrapper>
     </ResourceTab>
   );

--- a/dashboard/src/components/porter-form/field-components/ResourceList.tsx
+++ b/dashboard/src/components/porter-form/field-components/ResourceList.tsx
@@ -97,7 +97,10 @@ const ResourceList: React.FC<ResourceListField> = (props) => {
           return (
             <ExpandableResource
               key={i}
-              button={props?.settings?.options["resource-button"]}
+              button={
+                props?.settings?.options &&
+                props?.settings?.options["resource-button"]
+              }
               resource={resource}
               isLast={i === resourceList.length - 1}
               roundAllCorners={true}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Expandable resource button crashes when there's no expanded button definition. 

## What is the new behavior?

Add casing to prevent crashes. 

## Technical Spec/Implementation Notes
