### PR TITLE
[POR-496] Add ability to locally set path to a kubeconfig

### DIFF
--- a/api/client/k8s.go
+++ b/api/client/k8s.go
@@ -59,15 +59,15 @@ func (c *Client) GetKubeconfig(
 	ctx context.Context,
 	projectID uint,
 	clusterID uint,
-	localKubeconfig string,
+	localKubeconfigPath string,
 ) (*types.GetTemporaryKubeconfigResponse, error) {
 	resp := &types.GetTemporaryKubeconfigResponse{}
 
-	if localKubeconfig != "" {
-		color.New(color.FgBlue).Printf("using local kubeconfig: %s\n", localKubeconfig)
+	if localKubeconfigPath != "" {
+		color.New(color.FgBlue).Printf("using local kubeconfig: %s\n", localKubeconfigPath)
 
-		if _, err := os.Stat(localKubeconfig); !os.IsNotExist(err) {
-			file, err := os.Open(localKubeconfig)
+		if _, err := os.Stat(localKubeconfigPath); !os.IsNotExist(err) {
+			file, err := os.Open(localKubeconfigPath)
 
 			if err != nil {
 				return nil, err

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -155,7 +155,7 @@ var configSetHostCmd = &cobra.Command{
 }
 
 var configSetKubeconfigCmd = &cobra.Command{
-	Use:   "set-kubeconfig [host]",
+	Use:   "set-kubeconfig [kubeconfig-path]",
 	Args:  cobra.ExactArgs(1),
 	Short: "Saves the path to kubeconfig in the default configuration",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -154,6 +154,20 @@ var configSetHostCmd = &cobra.Command{
 	},
 }
 
+var configSetKubeconfigCmd = &cobra.Command{
+	Use:   "set-kubeconfig [host]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Saves the path to kubeconfig in the default configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := cliConf.SetKubeconfig(args[0])
+
+		if err != nil {
+			color.New(color.FgRed).Printf("An error occurred: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(configCmd)
 
@@ -162,6 +176,7 @@ func init() {
 	configCmd.AddCommand(configSetHostCmd)
 	configCmd.AddCommand(configSetRegistryCmd)
 	configCmd.AddCommand(configSetHelmRepoCmd)
+	configCmd.AddCommand(configSetKubeconfigCmd)
 }
 
 func printConfig() error {

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -212,6 +212,12 @@ func (c *CLIConfig) SetHost(host string) error {
 }
 
 func (c *CLIConfig) SetProject(projectID uint) error {
+	if config.Kubeconfig != "" || viper.IsSet("kubeconfig") {
+		viper.Set("kubeconfig", "")
+		color.New(color.FgBlue).Println("Removing local kubeconfig")
+		config.Kubeconfig = ""
+	}
+
 	viper.Set("project", projectID)
 	color.New(color.FgGreen).Printf("Set the current project as %d\n", projectID)
 	err := viper.WriteConfig()
@@ -226,6 +232,12 @@ func (c *CLIConfig) SetProject(projectID uint) error {
 }
 
 func (c *CLIConfig) SetCluster(clusterID uint) error {
+	if config.Kubeconfig != "" || viper.IsSet("kubeconfig") {
+		viper.Set("kubeconfig", "")
+		color.New(color.FgBlue).Println("Removing local kubeconfig")
+		config.Kubeconfig = ""
+	}
+
 	viper.Set("cluster", clusterID)
 	color.New(color.FgGreen).Printf("Set the current cluster as %d\n", clusterID)
 	err := viper.WriteConfig()

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -32,8 +34,9 @@ type CLIConfig struct {
 
 	Token string `yaml:"token"`
 
-	Registry uint `yaml:"registry"`
-	HelmRepo uint `yaml:"helm_repo"`
+	Registry   uint   `yaml:"registry"`
+	HelmRepo   uint   `yaml:"helm_repo"`
+	Kubeconfig string `yaml:"kubeconfig"`
 }
 
 // InitAndLoadConfig populates the config object with the following precedence rules:
@@ -273,6 +276,30 @@ func (c *CLIConfig) SetHelmRepo(helmRepoID uint) error {
 	}
 
 	config.HelmRepo = helmRepoID
+
+	return nil
+}
+
+func (c *CLIConfig) SetKubeconfig(kubeconfig string) error {
+	path, err := filepath.Abs(kubeconfig)
+
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s does not exist", path)
+	}
+
+	viper.Set("kubeconfig", kubeconfig)
+	color.New(color.FgGreen).Printf("Set the path to kubeconfig as %s\n", kubeconfig)
+	err = viper.WriteConfig()
+
+	if err != nil {
+		return err
+	}
+
+	config.Kubeconfig = kubeconfig
 
 	return nil
 }

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -146,29 +145,13 @@ func portForward(user *types.GetAuthenticatedUserResponse, client *api.Client, a
 		pod = pods[0]
 	}
 
-	var kubeBytes []byte
+	kubeResp, err := client.GetKubeconfig(context.TODO(), cliConf.Project, cliConf.Cluster, cliConf.Kubeconfig)
 
-	if cliConf.Kubeconfig == "" {
-		kubeResp, err := client.GetKubeconfig(context.TODO(), cliConf.Project, cliConf.Cluster)
-
-		if err != nil {
-			return err
-		}
-
-		kubeBytes = kubeResp.Kubeconfig
-	} else {
-		file, err := os.Open(cliConf.Kubeconfig)
-
-		if err != nil {
-			return err
-		}
-
-		kubeBytes, err = io.ReadAll(file)
-
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
+
+	kubeBytes := kubeResp.Kubeconfig
 
 	cmdConf, err := clientcmd.NewClientConfigFromBytes(kubeBytes)
 

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -145,7 +145,7 @@ func portForward(user *types.GetAuthenticatedUserResponse, client *api.Client, a
 		pod = pods[0]
 	}
 
-	kubeResp, err := client.GetKubeconfig(context.TODO(), cliConf.Project, cliConf.Cluster, cliConf.Kubeconfig)
+	kubeResp, err := client.GetKubeconfig(context.Background(), cliConf.Project, cliConf.Cluster, cliConf.Kubeconfig)
 
 	if err != nil {
 		return err

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -264,13 +264,29 @@ func (p *PorterRunSharedConfig) setSharedConfig() error {
 	pID := cliConf.Project
 	cID := cliConf.Cluster
 
-	kubeResp, err := p.Client.GetKubeconfig(context.TODO(), pID, cID)
+	var kubeBytes []byte
 
-	if err != nil {
-		return err
+	if cliConf.Kubeconfig == "" {
+		kubeResp, err := p.Client.GetKubeconfig(context.TODO(), pID, cID)
+
+		if err != nil {
+			return err
+		}
+
+		kubeBytes = kubeResp.Kubeconfig
+	} else {
+		file, err := os.Open(cliConf.Kubeconfig)
+
+		if err != nil {
+			return err
+		}
+
+		kubeBytes, err = io.ReadAll(file)
+
+		if err != nil {
+			return err
+		}
 	}
-
-	kubeBytes := kubeResp.Kubeconfig
 
 	cmdConf, err := clientcmd.NewClientConfigFromBytes(kubeBytes)
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -264,29 +264,13 @@ func (p *PorterRunSharedConfig) setSharedConfig() error {
 	pID := cliConf.Project
 	cID := cliConf.Cluster
 
-	var kubeBytes []byte
+	kubeResp, err := p.Client.GetKubeconfig(context.TODO(), pID, cID, cliConf.Kubeconfig)
 
-	if cliConf.Kubeconfig == "" {
-		kubeResp, err := p.Client.GetKubeconfig(context.TODO(), pID, cID)
-
-		if err != nil {
-			return err
-		}
-
-		kubeBytes = kubeResp.Kubeconfig
-	} else {
-		file, err := os.Open(cliConf.Kubeconfig)
-
-		if err != nil {
-			return err
-		}
-
-		kubeBytes, err = io.ReadAll(file)
-
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
+
+	kubeBytes := kubeResp.Kubeconfig
 
 	cmdConf, err := clientcmd.NewClientConfigFromBytes(kubeBytes)
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -264,7 +264,7 @@ func (p *PorterRunSharedConfig) setSharedConfig() error {
 	pID := cliConf.Project
 	cID := cliConf.Cluster
 
-	kubeResp, err := p.Client.GetKubeconfig(context.TODO(), pID, cID, cliConf.Kubeconfig)
+	kubeResp, err := p.Client.GetKubeconfig(context.Background(), pID, cID, cliConf.Kubeconfig)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Commands like `porter run` need to get a temporary kubeconfig from the Porter server to be able to run properly.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The CLI now has the option to set path to a local kubeconfig that can be used for such commands. This will be necessary for in-cluster auth mechanisms and self-hosted users.

## Technical Spec/Implementation Notes
