### PR TITLE
[POR-535] [hotfix] Fix for Slack, DigitalOcean integrations

### DIFF
--- a/api/server/handlers/handler.go
+++ b/api/server/handlers/handler.go
@@ -21,7 +21,7 @@ type PorterHandler interface {
 		w http.ResponseWriter,
 		r *http.Request,
 		state string,
-		isUser, isProject bool,
+		isProject, isUser bool,
 		integrationClient types.OAuthIntegrationClient,
 		integrationID uint,
 	) error

--- a/api/server/handlers/project_oauth/digitalocean.go
+++ b/api/server/handlers/project_oauth/digitalocean.go
@@ -29,7 +29,7 @@ func NewProjectOAuthDOHandler(
 func (p *ProjectOAuthDOHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	state := oauth.CreateRandomState()
 
-	if err := p.PopulateOAuthSession(w, r, state, false, true, "", 0); err != nil {
+	if err := p.PopulateOAuthSession(w, r, state, true, false, "", 0); err != nil {
 		p.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}

--- a/api/server/handlers/project_oauth/slack.go
+++ b/api/server/handlers/project_oauth/slack.go
@@ -29,7 +29,7 @@ func NewProjectOAuthSlackHandler(
 func (p *ProjectOAuthSlackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	state := oauth.CreateRandomState()
 
-	if err := p.PopulateOAuthSession(w, r, state, false, true, "", 0); err != nil {
+	if err := p.PopulateOAuthSession(w, r, state, true, false, "", 0); err != nil {
 		p.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Hotfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

The gitlab integration introduced the `isUser` param to `PorterHandler`'s `PopulateOAuthSession` which had a typo and the order being changed in `DefaultPorterHandler`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The order has now been fixed.

## Technical Spec/Implementation Notes
