### PR TITLE
Fix create addon requests using `repo_url` in body

### DIFF
--- a/api/types/release.go
+++ b/api/types/release.go
@@ -36,7 +36,7 @@ type UpdateNotificationConfigRequest struct {
 }
 
 type CreateReleaseBaseRequest struct {
-	RepoURL         string                 `json:"-" schema:"repo_url"`
+	RepoURL         string                 `json:"repo_url,omitempty" schema:"repo_url"`
 	TemplateName    string                 `json:"template_name" form:"required"`
 	TemplateVersion string                 `json:"template_version" form:"required"`
 	Values          map[string]interface{} `json:"values"`


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Addon requests that use `repo_url` in body request are throwing errors since adding `json:"-"`. 

## What is the new behavior?

Allow `repo_url` in body. 

## Technical Spec/Implementation Notes
