### PR TITLE
Infrastructure: EKS control plane versions

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -412,14 +412,14 @@ tabs:
       label: EKS control plane version
       variable: cluster_version
       settings:
-        default: 1.20
+        default: "1.20"
         options:
-        - label: 1.20
-          value: 1.20
-        - label: 1.21
-          value: 1.21
-        - label: 1.22
-          value: 1.22
+        - label: "1.20"
+          value: "1.20"
+        - label: "1.21"
+          value: "1.21"
+        - label: "1.22"
+          value: "1.22"
     - type: number-input
       label: Minimum number of EC2 instances to create in the application autoscaling group.
       variable: min_instances

--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -408,6 +408,18 @@ tabs:
       required: true
       placeholder: my-cluster
       variable: cluster_name
+    - type: select
+      label: EKS control plane version
+      variable: cluster_version
+      settings:
+        default: 1.20
+        options:
+        - label: 1.20
+          value: 1.20
+        - label: 1.21
+          value: 1.21
+        - label: 1.22
+          value: 1.22
     - type: number-input
       label: Minimum number of EC2 instances to create in the application autoscaling group.
       variable: min_instances


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A
Right now, the EKS infrastructure provisioner deploys EKS 1.20, with no way to change the version.

-->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR adds a select field to the EKS infrastructure form for selecting control plane versions.

## Technical Spec/Implementation Notes
