### PR TITLE
[POR-553] [POR-567] Cancel active workflow runs for a preview env deployment when required

### DIFF
--- a/api/server/handlers/webhook/github_incoming.go
+++ b/api/server/handlers/webhook/github_incoming.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v41/github"
@@ -142,12 +144,75 @@ func (c *GithubIncomingWebhookHandler) processPullRequestEvent(event *github.Pul
 					event.GetPullRequest().GetNumber(), err)
 			}
 		} else {
+			// check for already running workflows we should be cancelling
+			var wg sync.WaitGroup
+			statuses := []string{"in_progress", "queued", "requested", "waiting"}
+
+			wg.Add(len(statuses))
+
+			errChan := make(chan error)
+
+			for _, status := range statuses {
+				go func(status string) {
+					defer wg.Done()
+
+					reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+
+					runs, _, err := client.Actions.ListWorkflowRunsByFileName(
+						reqCtx, owner, repo, fmt.Sprintf("porter_%s_env.yml", env.Name),
+						&github.ListWorkflowRunsOptions{
+							Branch: event.GetPullRequest().GetHead().GetRef(),
+							Status: status,
+						},
+					)
+
+					if err == nil && runs.GetTotalCount() > 0 {
+						wg.Add(runs.GetTotalCount())
+
+						for _, run := range runs.WorkflowRuns {
+							go func(id int64, url string) {
+								defer wg.Done()
+
+								reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+								defer cancel()
+
+								_, err := client.Actions.CancelWorkflowRunByID(reqCtx, owner, repo, id)
+
+								if err != nil {
+									errChan <- fmt.Errorf("error cancelling %s: %w", url, err)
+								}
+							}(run.GetID(), run.GetHTMLURL())
+						}
+					} else if err != nil {
+						errChan <- fmt.Errorf("error listing workflows for status %s: %w", status, err)
+					}
+				}(status)
+			}
+
+			wg.Wait()
+
+			chanErr := fmt.Errorf("")
+
+			for err := range errChan {
+				chanErr = fmt.Errorf("%s: %w", chanErr.Error(), err)
+			}
+
 			err = c.deleteDeployment(r, depl, env, client)
 
 			if err != nil {
+				deleteErr := fmt.Errorf("[webhookID: %s, owner: %s, repo: %s, environmentID: %d, deploymentID: %d, prNumber: %d] "+
+					"error deleting deployment: %w", webhookID, owner, repo, env.ID, depl.ID, event.GetPullRequest().GetNumber(), err)
+
+				if chanErr.Error() != "" {
+					deleteErr = fmt.Errorf("%s. errors found while trying to cancel active workflow runs %w", deleteErr.Error(), chanErr)
+				}
+
+				return deleteErr
+			} else if chanErr.Error() != "" {
 				return fmt.Errorf("[webhookID: %s, owner: %s, repo: %s, environmentID: %d, deploymentID: %d, prNumber: %d] "+
-					"error deleting deployment: %w", webhookID, owner, repo, env.ID, depl.ID,
-					event.GetPullRequest().GetNumber(), err)
+					"deployment deleted but errors found while trying to cancel active workflow runs %w", webhookID, owner, repo, env.ID, depl.ID,
+					event.GetPullRequest().GetNumber(), chanErr)
 			}
 		}
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now, if a PR is merged and the respective github workflow was in an active state, it will go through with the entire run.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This will now cancel all active workflow runs whenever a PR is merged before deleting the deployment from the database.

## Technical Spec/Implementation Notes
