### PR TITLE
[POR-580] Workflow runs should be one at a time + we no longer need the delete workflow YAML

### DIFF
--- a/internal/integrations/ci/actions/actions.go
+++ b/internal/integrations/ci/actions/actions.go
@@ -235,8 +235,9 @@ type GithubActionYAMLOnPush struct {
 }
 
 type GithubActionYAMLJob struct {
-	RunsOn string                 `yaml:"runs-on,omitempty"`
-	Steps  []GithubActionYAMLStep `yaml:"steps,omitempty"`
+	RunsOn      string                 `yaml:"runs-on,omitempty"`
+	Steps       []GithubActionYAMLStep `yaml:"steps,omitempty"`
+	Concurrency map[string]string      `yaml:"concurrency,omitempty"`
 }
 
 type GithubActionYAML struct {

--- a/internal/integrations/ci/actions/preview.go
+++ b/internal/integrations/ci/actions/preview.go
@@ -73,12 +73,6 @@ func SetupEnv(opts *EnvOpts) error {
 		return err
 	}
 
-	deleteWorkflowYAML, err := getPreviewDeleteActionYAML(opts)
-
-	if err != nil {
-		return err
-	}
-
 	githubBranch, _, err := opts.Client.Repositories.GetBranch(
 		context.Background(), opts.GitRepoOwner, opts.GitRepoName, defaultBranch, true,
 	)
@@ -95,8 +89,8 @@ func SetupEnv(opts *EnvOpts) error {
 				"Unable to create PR to merge workflow files into protected branch: %s.\n"+
 					"To enable Porter Preview Environment deployments, please create Github workflow "+
 					"files in this branch with the following contents:\n"+
-					"--------\n%s--------\n--------\n%s--------\nERROR: %w",
-				defaultBranch, string(applyWorkflowYAML), string(deleteWorkflowYAML), ErrCreatePRForProtectedBranch,
+					"--------\n%s--------\nERROR: %w",
+				defaultBranch, string(applyWorkflowYAML), ErrCreatePRForProtectedBranch,
 			)
 		}
 
@@ -112,25 +106,8 @@ func SetupEnv(opts *EnvOpts) error {
 				"Unable to create PR to merge workflow files into protected branch: %s.\n"+
 					"To enable Porter Preview Environment deployments, please create Github workflow "+
 					"files in this branch with the following contents:\n"+
-					"--------\n%s--------\n--------\n%s--------\nERROR: %w",
-				defaultBranch, string(applyWorkflowYAML), string(deleteWorkflowYAML), ErrCreatePRForProtectedBranch,
-			)
-		}
-
-		_, err = commitWorkflowFile(
-			opts.Client,
-			fmt.Sprintf("porter_%s_delete_env.yml", strings.ToLower(opts.EnvironmentName)),
-			deleteWorkflowYAML, opts.GitRepoOwner,
-			opts.GitRepoName, "porter-preview", false,
-		)
-
-		if err != nil {
-			return fmt.Errorf(
-				"Unable to create PR to merge workflow files into protected branch: %s.\n"+
-					"To enable Porter Preview Environment deployments, please create a Github workflow "+
-					"file in this branch with the following contents:\n"+
 					"--------\n%s--------\nERROR: %w",
-				defaultBranch, string(deleteWorkflowYAML), ErrCreatePRForProtectedBranch,
+				defaultBranch, string(applyWorkflowYAML), ErrCreatePRForProtectedBranch,
 			)
 		}
 
@@ -159,75 +136,6 @@ func SetupEnv(opts *EnvOpts) error {
 		defaultBranch,
 		false,
 	)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "409 Could not create file") {
-			// possibly a write-protected branch
-			err = createNewBranch(opts.Client, opts.GitRepoOwner, opts.GitRepoName, defaultBranch, "porter-preview")
-
-			if err != nil {
-				return fmt.Errorf("write-protected branch %s. Error creating porter-preview branch: %w", defaultBranch, err)
-			}
-
-			_, err = commitWorkflowFile(
-				opts.Client,
-				fmt.Sprintf("porter_%s_env.yml", strings.ToLower(opts.EnvironmentName)),
-				applyWorkflowYAML,
-				opts.GitRepoOwner,
-				opts.GitRepoName,
-				"porter-preview",
-				false,
-			)
-
-			if err != nil {
-				return fmt.Errorf("write-protected branch %s. Error committing to porter-preview branch: %w", defaultBranch, err)
-			}
-
-			_, err = commitWorkflowFile(
-				opts.Client,
-				fmt.Sprintf("porter_%s_delete_env.yml", strings.ToLower(opts.EnvironmentName)),
-				deleteWorkflowYAML,
-				opts.GitRepoOwner,
-				opts.GitRepoName,
-				"porter-preview",
-				false,
-			)
-
-			if err != nil {
-				return fmt.Errorf("write-protected branch %s. Error committing to porter-preview branch: %w", defaultBranch, err)
-			}
-
-			pr, _, err := opts.Client.PullRequests.Create(
-				context.Background(), opts.GitRepoOwner, opts.GitRepoName, &github.NewPullRequest{
-					Title: github.String("Merge Porter preview environment Github Actions workflow files"),
-					Base:  github.String(defaultBranch),
-					Head:  github.String("porter-preview"),
-				},
-			)
-
-			if err != nil {
-				return err
-			}
-
-			return fmt.Errorf("write-protected branch %s. Please merge %s to enable preview environment for your repository", defaultBranch, pr.GetURL())
-		}
-
-		return err
-	}
-
-	_, err = commitWorkflowFile(
-		opts.Client,
-		fmt.Sprintf("porter_%s_delete_env.yml", strings.ToLower(opts.EnvironmentName)),
-		deleteWorkflowYAML,
-		opts.GitRepoOwner,
-		opts.GitRepoName,
-		defaultBranch,
-		false,
-	)
-
-	if err != nil {
-		return err
-	}
 
 	return err
 }
@@ -349,43 +257,10 @@ func getPreviewApplyActionYAML(opts *EnvOpts) ([]byte, error) {
 		Jobs: map[string]GithubActionYAMLJob{
 			"porter-preview": {
 				RunsOn: "ubuntu-latest",
-				Steps:  gaSteps,
-			},
-		},
-	}
-
-	return yaml.Marshal(actionYAML)
-}
-
-func getPreviewDeleteActionYAML(opts *EnvOpts) ([]byte, error) {
-	gaSteps := []GithubActionYAMLStep{
-		getDeletePreviewEnvStep(
-			opts.ServerURL,
-			getPorterTokenSecretName(opts.ProjectID),
-			opts.ProjectID,
-			opts.ClusterID,
-			opts.GitRepoName,
-			"v0.2.0",
-		),
-	}
-
-	actionYAML := GithubActionYAML{
-		On: map[string]interface{}{
-			"workflow_dispatch": map[string]interface{}{
-				"inputs": map[string]interface{}{
-					"deployment_id": map[string]interface{}{
-						"description": "Deployment ID",
-						"type":        "number",
-						"required":    true,
-					},
+				Concurrency: map[string]string{
+					"group": "${{ github.workflow }}-${{ github.event.inputs.pr_number }}",
 				},
-			},
-		},
-		Name: "Porter Preview Environment",
-		Jobs: map[string]GithubActionYAMLJob{
-			"porter-delete-preview": {
-				RunsOn: "ubuntu-latest",
-				Steps:  gaSteps,
+				Steps: gaSteps,
 			},
 		},
 	}

--- a/internal/integrations/ci/actions/steps.go
+++ b/internal/integrations/ci/actions/steps.go
@@ -7,7 +7,6 @@ import (
 
 const updateAppActionName = "porter-dev/porter-update-action"
 const createPreviewActionName = "porter-dev/porter-preview-action"
-const deletePreviewActionName = "porter-dev/porter-delete-preview-action"
 
 func getCheckoutCodeStep() GithubActionYAMLStep {
 	return GithubActionYAMLStep{
@@ -64,21 +63,6 @@ func getCreatePreviewEnvStep(
 			"action_id":       "${{ github.run_id }}",
 			"repo_owner":      repoOwner,
 			"repo_name":       repoName,
-		},
-		Timeout: 30,
-	}
-}
-
-func getDeletePreviewEnvStep(serverURL, porterTokenSecretName string, projectID, clusterID uint, repoName, actionVersion string) GithubActionYAMLStep {
-	return GithubActionYAMLStep{
-		Name: "Delete Porter preview env",
-		Uses: fmt.Sprintf("%s@%s", deletePreviewActionName, actionVersion),
-		With: map[string]string{
-			"cluster":       fmt.Sprintf("%d", clusterID),
-			"host":          serverURL,
-			"project":       fmt.Sprintf("%d", projectID),
-			"token":         fmt.Sprintf("${{ secrets.%s }}", porterTokenSecretName),
-			"deployment_id": "${{ github.event.inputs.deployment_id }}",
 		},
 		Timeout: 30,
 	}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

- Currently we are allowing concurrenct workflow runs for preview env deployments
- We create the delete env workflow YAML

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- We now only allow one job to run for one pull request at a time
- We no longer create the delete env workflow YAML

## Technical Spec/Implementation Notes
