### PR TITLE
Add additional subnet option to EKS form

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -557,6 +557,11 @@ tabs:
       placeholder: "ex: 10.99"
       settings:
         default: "10.99"
+    - type: checkbox
+      label: "Add additional private subnets to the cluster in each AZ."
+      variable: additional_private_subnets
+      settings:
+        default: false
   - name: nginx_settings
     contents:
     - type: heading


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

No additional subnets which can exhaust IP addresses on the cluster. 

## What is the new behavior?

Provide the option to increase the number of subnets on the cluster. For now this is just a boolean checkbox but we will support more flexible options in the near future. 

## Technical Spec/Implementation Notes
