### PR TITLE
[POR-584] Fetch subnets using the VPC ID

### DIFF
--- a/api/server/handlers/cluster_integration/aws/get_cluster_info.go
+++ b/api/server/handlers/cluster_integration/aws/get_cluster_info.go
@@ -89,22 +89,6 @@ func (c *GetClusterInfoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	ec2Svc := ec2.New(awsSession, awsConf)
 
-	subnetsInfo, err := ec2Svc.DescribeSubnets(&ec2.DescribeSubnetsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("vpc-id"),
-				Values: []*string{
-					clusterInfo.Cluster.ResourcesVpcConfig.VpcId,
-				},
-			},
-		},
-	})
-
-	if err != nil || len(subnetsInfo.Subnets) == 0 {
-		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
-		return
-	}
-
 	res := &types.GetAWSClusterInfoResponse{
 		Name:       clusterName,
 		ARN:        *clusterInfo.Cluster.Arn,
@@ -113,12 +97,34 @@ func (c *GetClusterInfoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		EKSVersion: *clusterInfo.Cluster.PlatformVersion,
 	}
 
-	for _, subnet := range subnetsInfo.Subnets {
-		res.Subnets = append(res.Subnets, &types.AWSSubnet{
-			SubnetID:                *subnet.SubnetId,
-			AvailabilityZone:        *subnet.AvailabilityZone,
-			AvailableIPAddressCount: *subnet.AvailableIpAddressCount,
-		})
+	err = ec2Svc.DescribeSubnetsPages(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					clusterInfo.Cluster.ResourcesVpcConfig.VpcId,
+				},
+			},
+		},
+	}, func(page *ec2.DescribeSubnetsOutput, lastPage bool) bool {
+		if page == nil {
+			return false
+		}
+
+		for _, subnet := range page.Subnets {
+			res.Subnets = append(res.Subnets, &types.AWSSubnet{
+				SubnetID:                *subnet.SubnetId,
+				AvailabilityZone:        *subnet.AvailabilityZone,
+				AvailableIPAddressCount: *subnet.AvailableIpAddressCount,
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		return
 	}
 
 	c.WriteResult(w, r, res)

--- a/api/types/cluster_integration.go
+++ b/api/types/cluster_integration.go
@@ -1,13 +1,16 @@
 package types
 
 type AWSSubnet struct {
+	SubnetID                string `json:"subnet_id"`
 	AvailabilityZone        string `json:"availability_zone"`
 	AvailableIPAddressCount int64  `json:"available_ip_address_count"`
 }
 
 type GetAWSClusterInfoResponse struct {
 	Name       string       `json:"name"`
+	ARN        string       `json:"arn"`
 	K8sVersion string       `json:"kubernetes_server_version"`
 	EKSVersion string       `json:"eks_version"`
+	Status     string       `json:"status"`
 	Subnets    []*AWSSubnet `json:"subnets"`
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now we simply fetch the subnet through the subnet IDs we get through the `DescribeCluster` API call.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We should instead fetch the subnets using the VPC ID.

## Technical Spec/Implementation Notes
