### PR TITLE
Add hotfix for duplicated default clusters

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -93,6 +93,23 @@ func initData(conf *config.Config) error {
 			return err
 		}
 
+		// determine if there are any clusters in the project already
+		clusters, err := conf.Repo.Cluster().ListClustersByProjectID(1)
+
+		if err != nil {
+			return err
+		}
+
+		// if there are already clusters in the project, determine if any of the clusters are using an
+		// in-cluster auth mechanism
+		if len(clusters) > 0 {
+			for _, cluster := range clusters {
+				if cluster.AuthMechanism == models.InCluster {
+					return nil
+				}
+			}
+		}
+
 		_, err = conf.Repo.Cluster().ReadCluster(1, 1)
 
 		if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If a default cluster is initially deleted, the Porter init script will continue to create and link default clusters every time it starts up. 

## What is the new behavior?

Prevent duplicate clusters from being added which have an in-cluster mechanism. 

## Technical Spec/Implementation Notes
