### PR TITLE
[POR-517] Redirect with chosen namespace after creating release

### DIFF
--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -189,6 +189,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
     setTimeout(() => {
       pushFiltered(props, dst, ["project_id"], {
         cluster: currentCluster.name,
+        namespace: selectedNamespace,
       });
     }, 500);
   };
@@ -355,6 +356,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
         props.currentTemplate.name === "job" ? "/jobs" : "/applications";
       pushFiltered(props, dst, ["project_id"], {
         cluster: currentCluster.name,
+        namespace: selectedNamespace,
       });
     }, 1000);
   };


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

After launch, users are redirected always with the default namespace

## What is the new behavior?

When a user launches an application, the redirect after deploy, will be made with the selected namespace.

- User creates a release on namespace "test"
- Dashboard finishes the api requests
- Dashboard redirects to chart list with the query param "namespace=test"
- Chart list shows the list with the correct namespace

## Technical Spec/Implementation Notes
