### PR TITLE
[POR-602] [hotfix] Case on new `gcr.io` API change for image not found

### DIFF
--- a/cli/cmd/docker/agent.go
+++ b/cli/cmd/docker/agent.go
@@ -291,7 +291,8 @@ func (a *Agent) PullImage(image string) error {
 	out, err := a.ImagePull(a.ctx, image, opts)
 
 	if err != nil {
-		if client.IsErrNotFound(err) {
+		if client.IsErrNotFound(err) ||
+			(strings.Contains(image, "gcr.io") && strings.Contains(err.Error(), "or it may not exist")) {
 			return PullImageErrNotFound
 		} else if client.IsErrUnauthorized(err) {
 			return PullImageErrUnauthorized


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Previously, GCR used to return an image not found error which we cased on.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

It seems that the GCR API has now changed and instead returns a combination of unauthorized + image may not exist error in case of an image not existing in the registry.

## Technical Spec/Implementation Notes
