### PR TITLE
Fix sidebar link failing when no project available

### DIFF
--- a/dashboard/src/main/home/sidebar/SidebarLink.tsx
+++ b/dashboard/src/main/home/sidebar/SidebarLink.tsx
@@ -18,20 +18,27 @@ const SidebarLink: React.FC<{ path: string } & Omit<NavLinkProps, "to">> = ({
    */
   const withQueryParams = (path: string) => (location: any) => {
     let pathNamespace = params.namespace;
-    let search = `?cluster=${currentCluster.name}&project_id=${currentProject.id}`;
+    const search = new URLSearchParams();
+    if (currentCluster?.name) {
+      search.append("cluster", currentCluster.name);
+    }
+
+    if (currentProject?.id) {
+      search.append("project_id", String(currentProject.id));
+    }
 
     if (!pathNamespace) {
       pathNamespace = getQueryParam("namespace");
     }
 
     if (pathNamespace) {
-      search = search.concat(`&namespace=${pathNamespace}`);
+      search.append("namespace", pathNamespace);
     }
 
     return {
       ...location,
       pathname: path,
-      search,
+      search: search.toString(),
     };
   };
 


### PR DESCRIPTION
Added null casing to the SidebarLink to check if the properties that are going
to be added to the search params actually exists and we're not trying to access
empty objects.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When a user has no clusters, the SidebarLink component throws error and blocks the user in the unknown error screen.

## What is the new behavior?

Apply null casing to check if the properties that the SidebarLink check are available or not.

## Technical Spec/Implementation Notes
