### PR TITLE
[POR-603] [hotfix] Case on possible nil pointer value of `ImageTag` from ECR API response

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -707,11 +707,9 @@ func (r *Registry) GetECRPaginatedImages(
 	imageIDMap := make(map[string]bool)
 
 	for _, id := range resp.ImageIds {
-		if id == nil {
-			continue
+		if id != nil && id.ImageTag != nil {
+			imageIDMap[*id.ImageTag] = true
 		}
-
-		imageIDMap[*id.ImageTag] = true
 	}
 
 	var wg sync.WaitGroup
@@ -750,10 +748,6 @@ func (r *Registry) GetECRPaginatedImages(
 	imageInfoMap := make(map[string]*ptypes.Image)
 
 	for _, img := range imageDetails {
-		if img == nil {
-			continue
-		}
-
 		for _, tag := range img.ImageTags {
 			newImage := &ptypes.Image{
 				Digest:         *img.ImageDigest,

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -707,6 +707,10 @@ func (r *Registry) GetECRPaginatedImages(
 	imageIDMap := make(map[string]bool)
 
 	for _, id := range resp.ImageIds {
+		if id == nil {
+			continue
+		}
+
 		imageIDMap[*id.ImageTag] = true
 	}
 
@@ -746,6 +750,10 @@ func (r *Registry) GetECRPaginatedImages(
 	imageInfoMap := make(map[string]*ptypes.Image)
 
 	for _, img := range imageDetails {
+		if img == nil {
+			continue
+		}
+
 		for _, tag := range img.ImageTags {
 			newImage := &ptypes.Image{
 				Digest:         *img.ImageDigest,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

We do not case on the pointer validity right now.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

It seems that the ECR API might return responses with nil pointer `ImageTag` values. We need to case on this.

## Technical Spec/Implementation Notes
