### PR TITLE
Add option to set AWS cluster id on cluster rename

### DIFF
--- a/api/server/handlers/cluster/update.go
+++ b/api/server/handlers/cluster/update.go
@@ -37,8 +37,9 @@ func (c *ClusterUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// if the cluster has an AWS integration, make sure that the old cluster name is set
-	if cluster.AWSIntegrationID != 0 {
+	// if the cluster has an AWS integration, and the request does not have a cluster name attached, make
+	// sure that the old cluster name is set
+	if cluster.AWSIntegrationID != 0 && request.AWSClusterID == "" {
 		awsInt, err := c.Repo().AWSIntegration().ReadAWSIntegration(cluster.ProjectID, cluster.AWSIntegrationID)
 
 		if err != nil {
@@ -56,6 +57,8 @@ func (c *ClusterUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				return
 			}
 		}
+	} else if request.AWSClusterID != "" {
+		cluster.AWSClusterID = request.AWSClusterID
 	}
 
 	cluster.Name = request.Name

--- a/api/types/cluster.go
+++ b/api/types/cluster.go
@@ -264,7 +264,7 @@ type CreateClusterCandidateRequest struct {
 type UpdateClusterRequest struct {
 	Name string `json:"name" form:"required"`
 
-	AWSClusterID string `json:"aws_cluster_name"`
+	AWSClusterID string `json:"aws_cluster_id"`
 }
 
 type ListClusterResponse []*Cluster

--- a/api/types/cluster.go
+++ b/api/types/cluster.go
@@ -29,6 +29,9 @@ type Cluster struct {
 
 	// (optional) The aws integration id, if available
 	AWSIntegrationID uint `json:"aws_integration_id"`
+
+	// (optional) The aws cluster id, if available
+	AWSClusterID string `json:"aws_cluster_id,omitempty"`
 }
 
 type ClusterCandidate struct {
@@ -260,6 +263,8 @@ type CreateClusterCandidateRequest struct {
 
 type UpdateClusterRequest struct {
 	Name string `json:"name" form:"required"`
+
+	AWSClusterID string `json:"aws_cluster_name"`
 }
 
 type ListClusterResponse []*Cluster

--- a/dashboard/src/main/home/cluster-dashboard/dashboard/ClusterSettings.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/ClusterSettings.tsx
@@ -11,6 +11,9 @@ const ClusterSettings: React.FC = () => {
   const [newClusterName, setNewClusterName] = useState<string>(
     context.currentCluster.name
   );
+  const [newAWSClusterID, setNewAWSClusterID] = useState<string>(
+    context.currentCluster.aws_cluster_id
+  );
   const [successfulRename, setSuccessfulRename] = useState<boolean>(false);
 
   const [accessKeyId, setAccessKeyId] = useState<string>("");
@@ -46,6 +49,7 @@ const ClusterSettings: React.FC = () => {
         "<token>",
         {
           name: newClusterName,
+          aws_cluster_id: newAWSClusterID,
         },
         {
           project_id: context.currentProject.id,
@@ -143,6 +147,20 @@ const ClusterSettings: React.FC = () => {
     }
   }
 
+  let overrideAWSClusterNameSection =
+    context.currentCluster?.aws_integration_id &&
+    context.currentCluster?.aws_integration_id != 0 ? (
+      <InputRow
+        type="text"
+        value={newAWSClusterID}
+        setValue={(x: string) => setNewAWSClusterID(x)}
+        label="AWS Cluster ID"
+        placeholder="ex: my-awesome-cluster"
+        width="100%"
+        isRequired={false}
+      />
+    ) : null;
+
   let renameClusterSection = (
     <div>
       <Heading>Rename Cluster</Heading>
@@ -155,6 +173,7 @@ const ClusterSettings: React.FC = () => {
         width="100%"
         isRequired={true}
       />
+      {overrideAWSClusterNameSection}
       <Button color="#616FEEcc" onClick={updateClusterName}>
         Submit
       </Button>

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -99,6 +99,7 @@ const overwriteAWSIntegration = baseApi<
 const updateClusterName = baseApi<
   {
     name: string;
+    aws_cluster_id?: string;
   },
   {
     project_id: number;

--- a/dashboard/src/shared/types.tsx
+++ b/dashboard/src/shared/types.tsx
@@ -8,6 +8,7 @@ export interface ClusterType {
   infra_id?: number;
   service?: string;
   aws_integration_id?: number;
+  aws_cluster_id?: string;
 }
 
 export interface DetailedClusterType extends ClusterType {

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -341,7 +341,15 @@ func (conf *OutOfClusterConfig) CreateRawConfigFromCluster() (*api.Config, error
 			return nil, err
 		}
 
-		tok, err := awsAuth.GetBearerToken(conf.getTokenCache, conf.setTokenCache, cluster.Name)
+		awsClusterID := cluster.Name
+		shouldOverride := false
+
+		if cluster.AWSClusterID != "" {
+			awsClusterID = cluster.AWSClusterID
+			shouldOverride = true
+		}
+
+		tok, err := awsAuth.GetBearerToken(conf.getTokenCache, conf.setTokenCache, awsClusterID, shouldOverride)
 
 		if err != nil {
 			return nil, err

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -55,6 +55,8 @@ type Cluster struct {
 
 	NotificationsDisabled bool `json:"notifications_disabled"`
 
+	AWSClusterID string
+
 	// ------------------------------------------------------------------
 	// All fields below this line are encrypted before storage
 	// ------------------------------------------------------------------
@@ -97,6 +99,7 @@ func (c *Cluster) ToClusterType() *types.Cluster {
 		Service:          serv,
 		InfraID:          c.InfraID,
 		AWSIntegrationID: c.AWSIntegrationID,
+		AWSClusterID:     c.AWSClusterID,
 	}
 }
 

--- a/internal/models/integrations/aws.go
+++ b/internal/models/integrations/aws.go
@@ -105,6 +105,7 @@ func (a *AWSIntegration) GetBearerToken(
 	getTokenCache GetTokenCacheFunc,
 	setTokenCache SetTokenCacheFunc,
 	clusterID string,
+	shouldClusterIdOverride bool,
 ) (string, error) {
 	cache, err := getTokenCache()
 
@@ -127,15 +128,21 @@ func (a *AWSIntegration) GetBearerToken(
 		return "", err
 	}
 
-	clusterIDGuess := string(a.AWSClusterID)
+	var validClusterId string
 
-	if clusterIDGuess == "" {
-		clusterIDGuess = clusterID
+	if shouldClusterIdOverride {
+		validClusterId = clusterID
+	} else {
+		validClusterId := string(a.AWSClusterID)
+
+		if validClusterId == "" {
+			validClusterId = clusterID
+		}
 	}
 
 	tok, err := generator.GetWithOptions(&token.GetTokenOptions{
 		Session:   sess,
-		ClusterID: clusterIDGuess,
+		ClusterID: validClusterId,
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the same AWS credential is used between clusters, only one cluster will have the correct `AWSClusterID` set at a given time. 

## What is the new behavior?

Store a field called `AWSClusterID` as part of the cluster model as well, which can optionally be set when the user changes the cluster name. 

## Technical Spec/Implementation Notes
