### PR TITLE
[hotfix] Cover all cases to check the number of workflow runs 

### DIFF
--- a/api/server/shared/commonutils/git_utils.go
+++ b/api/server/shared/commonutils/git_utils.go
@@ -39,7 +39,7 @@ func GetLatestWorkflowRun(client *github.Client, owner, repo, filename, branch s
 		return nil, err
 	}
 
-	if workflowRuns == nil || workflowRuns.GetTotalCount() == 0 {
+	if workflowRuns == nil || workflowRuns.GetTotalCount() == 0 || len(workflowRuns.WorkflowRuns) == 0 {
 		return nil, ErrNoWorkflowRuns
 	}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now we case on the github API's `total_count` parameter to check for the number of workflow runs.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

It seems that in some cases the `total_count` can be non-zero and yet the workflow runs slice can be of zero length.

## Technical Spec/Implementation Notes
