### PR TITLE
Make sure valid AWS cluster id is set for kube client

### DIFF
--- a/internal/models/integrations/aws.go
+++ b/internal/models/integrations/aws.go
@@ -133,7 +133,7 @@ func (a *AWSIntegration) GetBearerToken(
 	if shouldClusterIdOverride {
 		validClusterId = clusterID
 	} else {
-		validClusterId := string(a.AWSClusterID)
+		validClusterId = string(a.AWSClusterID)
 
 		if validClusterId == "" {
 			validClusterId = clusterID


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The cluster id isn't getting set on the kube client. 

## What is the new behavior?

The cluster id should be set. 

## Technical Spec/Implementation Notes
