### PR TITLE
Fix inactive branches not showing on Preview Environments

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentList.tsx
@@ -118,7 +118,7 @@ const DeploymentList = () => {
         }
 
         setDeploymentList(deploymentList.deployments || []);
-        setPullRequests(deploymentList.pull_requrests || []);
+        setPullRequests(deploymentList.pull_requests || []);
 
         setNewCommentsDisabled(environmentList.new_comments_disabled || false);
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When the user clicks on a preview environment and then tries to filter by "inactive" branches, the branches are empty unless the user clicks on reload.

## What is the new behavior?

Fixed a typo that was preventing inactive branches to be populated.

## Technical Spec/Implementation Notes
