### PR TITLE
Add updates to the EKS form for Prometheus improvements and subnet multiplicity

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -599,6 +599,14 @@ tabs:
       variable: additional_private_subnets
       settings:
         default: false
+  - name: subnet_multiplicity
+    show_if: additional_private_subnets
+    contents:
+    - type: number-input
+      label: "Multiplicity of the subnet within each AZ."
+      variable: additional_private_subnets_multiplicity
+      settings:
+        default: 3
   - name: nginx_settings
     contents:
     - type: heading
@@ -606,6 +614,15 @@ tabs:
     - type: checkbox
       variable: disable_nginx_load_balancer
       label: Disable NGINX load balancer and expose NGINX only on a cluster IP address.
+      settings:
+        default: false
+  - name: prometheus_settings
+    contents:
+    - type: heading
+      label: Prometheus Settings
+    - type: checkbox
+      variable: additional_prometheus_node_group
+      label: Add an additional prometheus node group to ensure monitoring stability.
       settings:
         default: false
 `

--- a/provisioner/server/handlers/state/create_resource.go
+++ b/provisioner/server/handlers/state/create_resource.go
@@ -277,7 +277,12 @@ func createCluster(config *config.Config, infra *models.Infra, operation *models
 		}
 	}
 
-	cluster.Name = output["cluster_name"].(string)
+	// only update the cluster name if this is during creation - we don't want to overwrite the cluster name
+	// which may have been manually set
+	if isNotFound {
+		cluster.Name = output["cluster_name"].(string)
+	}
+
 	cluster.Server = output["cluster_endpoint"].(string)
 	cluster.CertificateAuthorityData = caData
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

- Prometheus can be unstable when sharing a node with other system workloads
- EKS has a fairly limited subnet range by default 

## What is the new behavior?

- Add the concept of subnet multiplicity to add up to 100 additional subnets, so about 25,100 more addresses
- Add option to place prometheus in a separate node group which also contains a vertical pod autoscaler

## Technical Spec/Implementation Notes
