### PR TITLE
[POR-641] New CLI commands to update env groups

### DIFF
--- a/api/client/k8s.go
+++ b/api/client/k8s.go
@@ -104,8 +104,8 @@ func (c *Client) GetEnvGroup(
 	projectID, clusterID uint,
 	namespace string,
 	req *types.GetEnvGroupRequest,
-) (*types.EnvGroup, error) {
-	resp := &types.EnvGroup{}
+) (*types.GetEnvGroupResponse, error) {
+	resp := &types.GetEnvGroupResponse{}
 
 	err := c.getRequest(
 		fmt.Sprintf(

--- a/api/server/handlers/namespace/get_env_group.go
+++ b/api/server/handlers/namespace/get_env_group.go
@@ -68,7 +68,6 @@ func (c *GetEnvGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stackId, err := stacks.GetStackForEnvGroup(c.Config(), cluster.ProjectID, cluster.ID, envGroup)
 
 	if err != nil {
-
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.WriteResult(w, r, &types.GetEnvGroupResponse{EnvGroup: envGroup})
 			return

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -32,7 +32,7 @@ deleting a configuration:
 		color.New(color.FgGreen, color.Bold).Sprintf("porter delete"),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		err := checkLoginAndRun(args, delete)
+		err := checkLoginAndRun(args, deleteDeployment)
 
 		if err != nil {
 			os.Exit(1)
@@ -100,7 +100,7 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 }
 
-func delete(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+func deleteDeployment(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
 	projectID := cliConf.Project
 
 	if projectID == 0 {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -617,6 +617,8 @@ func updateUnsetEnvGroup(_ *types.GetAuthenticatedUserResponse, client *api.Clie
 		return err
 	}
 
+	color.New(color.FgGreen).Println("env group successfully updated")
+
 	return nil
 }
 

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -206,7 +206,7 @@ the image that the application uses if no --values file is specified:
 
 var updateEnvGroupCmd = &cobra.Command{
 	Use:     "env-group",
-	Aliases: []string{"eg", "envgroup"},
+	Aliases: []string{"eg", "envgroup", "env-groups", "envgroups"},
 	Short:   "Updates an environment group's variables, specified by the --name flag.",
 	Run: func(cmd *cobra.Command, args []string) {
 		color.New(color.FgRed).Println("need to specify an operation to continue")

--- a/cli/cmd/preview/env_group_driver.go
+++ b/cli/cmd/preview/env_group_driver.go
@@ -67,7 +67,7 @@ func (d *EnvGroupDriver) Apply(resource *models.Resource) (*models.Resource, err
 			group.Namespace = d.target.Namespace
 		}
 
-		envGroup, err := client.GetEnvGroup(
+		envGroupResp, err := client.GetEnvGroup(
 			context.Background(),
 			d.target.Project,
 			d.target.Cluster,
@@ -78,7 +78,7 @@ func (d *EnvGroupDriver) Apply(resource *models.Resource) (*models.Resource, err
 		)
 
 		if err != nil && err.Error() == "env group not found" {
-			envGroup, err = client.CreateEnvGroup(
+			newEnvGroup, err := client.CreateEnvGroup(
 				context.Background(), d.target.Project, d.target.Cluster, group.Namespace,
 				&types.CreateEnvGroupRequest{
 					Name:      group.Name,
@@ -89,12 +89,18 @@ func (d *EnvGroupDriver) Apply(resource *models.Resource) (*models.Resource, err
 			if err != nil {
 				return nil, err
 			}
+
+			envGroupResp = &types.GetEnvGroupResponse{
+				EnvGroup: &types.EnvGroup{
+					Variables: newEnvGroup.Variables,
+				},
+			}
 		} else if err != nil {
 			return nil, err
 		}
 
-		d.output[envGroup.Name] = map[string]interface{}{
-			"variables": envGroup.Variables,
+		d.output[envGroupResp.Name] = map[string]interface{}{
+			"variables": envGroupResp.Variables,
 		}
 	}
 

--- a/internal/kubernetes/envgroup/create.go
+++ b/internal/kubernetes/envgroup/create.go
@@ -85,6 +85,10 @@ func CreateEnvGroup(agent *kubernetes.Agent, input types.ConfigMapInput) (*v1.Co
 
 	oldSecret, _, err := agent.GetLatestVersionedSecret(input.Name, input.Namespace)
 
+	if input.SecretVariables == nil {
+		input.SecretVariables = make(map[string]string)
+	}
+
 	if err != nil && !errors.Is(err, kubernetes.IsNotFoundError) {
 		return nil, err
 	} else if err == nil && oldSecret != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Introduce new commands to update env groups from the CLI
- `porter update env-group set <VAR>=<VALUE> --name <env-group-name> --type (secret|normal)`
- `porter update env-group unset <VAR> --name <env-group-name>`

## Technical Spec/Implementation Notes
