### PR TITLE
[hotfix] Keep a global DB connection in-line with Go's `sql.DB` connection recommendations

### DIFF
--- a/internal/adapter/gorm.go
+++ b/internal/adapter/gorm.go
@@ -34,11 +34,19 @@ func New(conf *env.DBConf) (*gorm.DB, error) {
 	if conf.SQLLite {
 		// we add DisableForeignKeyConstraintWhenMigrating since our sqlite does
 		// not support foreign key constraints
-		return gorm.Open(sqlite.Open(conf.SQLLitePath), &gorm.Config{
+		res, err := gorm.Open(sqlite.Open(conf.SQLLitePath), &gorm.Config{
 			DisableForeignKeyConstraintWhenMigrating: true,
 			FullSaveAssociations:                     true,
 			Logger:                                   logger,
 		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		globalDBConn = res
+
+		return res, nil
 	}
 
 	// connect to default postgres instance first

--- a/internal/adapter/gorm.go
+++ b/internal/adapter/gorm.go
@@ -14,8 +14,14 @@ import (
 	"gorm.io/gorm"
 )
 
+var globalDBConn *gorm.DB
+
 // New returns a new gorm database instance
 func New(conf *env.DBConf) (*gorm.DB, error) {
+	if globalDBConn != nil {
+		return globalDBConn, nil
+	}
+
 	logger := logger.New(
 		log.New(os.Stdout, "\r\n", log.LstdFlags),
 		logger.Config{
@@ -86,12 +92,16 @@ func New(conf *env.DBConf) (*gorm.DB, error) {
 			}
 
 			if err == nil {
+				globalDBConn = res
+
 				return res, nil
 			}
 
 			retryCount++
 		}
 	}
+
+	globalDBConn = res
 
 	return res, err
 }

--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -33,7 +33,6 @@ import (
 	"github.com/porter-dev/porter/provisioner/integrations/storage/s3"
 
 	"github.com/porter-dev/porter/ee/integrations/vault"
-	"github.com/porter-dev/porter/internal/adapter"
 	"github.com/porter-dev/porter/internal/helm"
 	"github.com/porter-dev/porter/internal/kubernetes"
 	"github.com/porter-dev/porter/internal/models"
@@ -77,15 +76,10 @@ type HelmRevisionsCountTrackerOpts struct {
 }
 
 func NewHelmRevisionsCountTracker(
+	db *gorm.DB,
 	enqueueTime time.Time,
 	opts *HelmRevisionsCountTrackerOpts,
 ) (*helmRevisionsCountTracker, error) {
-	db, err := adapter.New(opts.DBConf)
-
-	if err != nil {
-		return nil, err
-	}
-
 	var credBackend rcreds.CredentialStorage
 
 	if opts.DBConf.VaultAPIKey != "" && opts.DBConf.VaultServerURL != "" && opts.DBConf.VaultPrefix != "" {

--- a/workers/main.go
+++ b/workers/main.go
@@ -126,6 +126,8 @@ func httpService() http.Handler {
 	r.Use(middleware.Heartbeat("/ping"))
 	r.Use(middleware.AllowContentType("application/json"))
 
+	r.Mount("/debug", middleware.Profiler())
+
 	log.Println("setting up HTTP POST endpoint to enqueue jobs")
 
 	r.Post("/enqueue/{id}", func(w http.ResponseWriter, r *http.Request) {

--- a/workers/main.go
+++ b/workers/main.go
@@ -16,13 +16,16 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/joeshaw/envdecode"
 	"github.com/porter-dev/porter/api/server/shared/config/env"
+	"github.com/porter-dev/porter/internal/adapter"
 	"github.com/porter-dev/porter/internal/worker"
 	"github.com/porter-dev/porter/workers/jobs"
+	"gorm.io/gorm"
 )
 
 var (
 	jobQueue   chan worker.Job
 	envDecoder = EnvConf{}
+	dbConn     *gorm.DB
 )
 
 // EnvConf holds the environment variables for this binary
@@ -50,12 +53,20 @@ func main() {
 	log.Printf("setting max worker count to: %d\n", envDecoder.MaxWorkers)
 	log.Printf("setting max job queue count to: %d\n", envDecoder.MaxQueue)
 
+	db, err := adapter.New(&envDecoder.DBConf)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	dbConn = db
+
 	jobQueue = make(chan worker.Job, envDecoder.MaxQueue)
 	d := worker.NewDispatcher(int(envDecoder.MaxWorkers))
 
 	log.Println("starting worker dispatcher")
 
-	err := d.Run(jobQueue)
+	err = d.Run(jobQueue)
 
 	if err != nil {
 		log.Fatalln(err)
@@ -134,7 +145,7 @@ func httpService() http.Handler {
 
 func getJob(id string) worker.Job {
 	if id == "helm-revisions-count-tracker" {
-		newJob, err := jobs.NewHelmRevisionsCountTracker(time.Now().UTC(), &jobs.HelmRevisionsCountTrackerOpts{
+		newJob, err := jobs.NewHelmRevisionsCountTracker(dbConn, time.Now().UTC(), &jobs.HelmRevisionsCountTrackerOpts{
 			DBConf:             &envDecoder.DBConf,
 			DOClientID:         envDecoder.DOClientID,
 			DOClientSecret:     envDecoder.DOClientSecret,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

We call `gorm.Open` every time we create a new SQL adapter. This goes against the guidelines to maintain a global DB connection and not recreate everytime.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now keep a global DB connection object in memory and reuse it like a singleton.

## Technical Spec/Implementation Notes
