### PR TITLE
[hotfix] Set the name of the new env group inside the `env-group` driver

### DIFF
--- a/cli/cmd/preview/env_group_driver.go
+++ b/cli/cmd/preview/env_group_driver.go
@@ -92,6 +92,7 @@ func (d *EnvGroupDriver) Apply(resource *models.Resource) (*models.Resource, err
 
 			envGroupResp = &types.GetEnvGroupResponse{
 				EnvGroup: &types.EnvGroup{
+					Name:      newEnvGroup.Name,
 					Variables: newEnvGroup.Variables,
 				},
 			}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Inside the env group driver, we should set the name of the newly created env group to be used later.

## Technical Spec/Implementation Notes
