### PR TITLE
[POR-653] Revision delete is removing chart from chart list

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -140,7 +140,10 @@ const ChartList: React.FunctionComponent<Props> = ({
                 return chart;
               });
             case "DELETE":
-              return tmpCharts.filter((chart) => !isSameChart(chart));
+              const chartToDelete = tmpCharts.find(isSameChart);
+              if (chartToDelete.version === newChart.version) {
+                return tmpCharts.filter((chart) => !isSameChart(chart));
+              }
             default:
               return tmpCharts;
           }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Description

With latest updates to the revision deleter job, the chart list is receiving a lot of DELETE messages over the websocket, the issue here is that the chart is being removed from the chart list although the DELETE corresponds to an older version.

Expected behavior:
- Delete event only removes chart from chart list if the revision removed is equal to the latest revision of the chart