### PR TITLE
[hotfix] RetryHelmAgent should case on all kinds of error to refresh the underlying Helm agent

### DIFF
--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -226,8 +226,6 @@ func (t *helmRevisionsCountTracker) Run() error {
 
 					log.Printf("fetched %d releases for namespace %s in cluster ID %d", len(releases), ns.Name, cluster.ID)
 
-					time.Sleep(time.Minute * 15)
-
 					for _, rel := range releases {
 						revisions, err := agent.GetReleaseHistory(rel.Name)
 
@@ -248,6 +246,8 @@ func (t *helmRevisionsCountTracker) Run() error {
 
 						// sort revisions from newest to oldest
 						releaseutil.Reverse(revisions, releaseutil.SortByRevision)
+
+						time.Sleep(time.Minute * 15)
 
 						for i := 100; i < len(revisions); i += 1 {
 							rev := revisions[i]

--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -247,8 +247,6 @@ func (t *helmRevisionsCountTracker) Run() error {
 						// sort revisions from newest to oldest
 						releaseutil.Reverse(revisions, releaseutil.SortByRevision)
 
-						time.Sleep(time.Minute * 15)
-
 						for i := 100; i < len(revisions); i += 1 {
 							rev := revisions[i]
 

--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -226,6 +226,8 @@ func (t *helmRevisionsCountTracker) Run() error {
 
 					log.Printf("fetched %d releases for namespace %s in cluster ID %d", len(releases), ns.Name, cluster.ID)
 
+					time.Sleep(time.Minute * 15)
+
 					for _, rel := range releases {
 						revisions, err := agent.GetReleaseHistory(rel.Name)
 

--- a/workers/utils/retry_helm_agent.go
+++ b/workers/utils/retry_helm_agent.go
@@ -4,8 +4,8 @@ package utils
 
 import (
 	"fmt"
+	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/porter-dev/porter/api/types"
@@ -52,14 +52,14 @@ func (a *RetryHelmAgent) ListReleases(
 
 		if err == nil {
 			return releases, nil
-		} else if strings.Contains(err.Error(), "Unauthorized") {
+		} else {
+			log.Printf("recreating helm agent for retrying ListReleases. Error: %v", err)
+
 			a.agent, err = helm.GetAgentOutOfClusterConfig(a.form, a.l)
 
 			if err != nil {
 				return nil, fmt.Errorf("error recreating helm agent for retrying ListReleases: %w", err)
 			}
-		} else {
-			return nil, err
 		}
 
 		time.Sleep(a.retryInterval)
@@ -76,14 +76,14 @@ func (a *RetryHelmAgent) GetReleaseHistory(
 
 		if err == nil {
 			return releases, nil
-		} else if strings.Contains(err.Error(), "Unauthorized") {
+		} else {
+			log.Printf("recreating helm agent for retrying GetReleaseHistory. Error: %v", err)
+
 			a.agent, err = helm.GetAgentOutOfClusterConfig(a.form, a.l)
 
 			if err != nil {
 				return nil, fmt.Errorf("error recreating helm agent for retrying GetReleaseHistory: %w", err)
 			}
-		} else {
-			return nil, err
 		}
 
 		time.Sleep(a.retryInterval)
@@ -101,14 +101,14 @@ func (a *RetryHelmAgent) DeleteReleaseRevision(
 
 		if err == nil {
 			return nil
-		} else if strings.Contains(err.Error(), "Unauthorized") {
+		} else {
+			log.Printf("recreating helm agent for retrying DeleteReleaseRevision. Error: %v", err)
+
 			a.agent, err = helm.GetAgentOutOfClusterConfig(a.form, a.l)
 
 			if err != nil {
 				return fmt.Errorf("error recreating helm agent for retrying DeleteReleaseRevision: %w", err)
 			}
-		} else {
-			return err
 		}
 
 		time.Sleep(a.retryInterval)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now the RetryHelmAgent only refreshes its underlying Helm agent if there is an Unauthorized error.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR now enables the RetryHelmAgent to refresh its underlying Helm agent in case of any error. Also added log statements.

## Technical Spec/Implementation Notes
