### PR TITLE
[POR-673] Fix repo list dropdown z-index

### DIFF
--- a/dashboard/src/components/repo-selector/RepoList.tsx
+++ b/dashboard/src/components/repo-selector/RepoList.tsx
@@ -442,6 +442,7 @@ const ProviderSelectorStyles = {
     overflow-y: auto;
     width: calc(100% - 4px);
     box-shadow: 0 8px 20px 0px #00000088;
+    z-index: 999;
   `,
   Option: styled.div`
     display: flex;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## Motivation

Repo list dropdown was always behind other items such as the docs helper.
Added a new z-index to the dropdown of 999 so it's always at the front when open.

