### PR TITLE
[POR-674] `--non-interactive` mode needs the name of the container if more than one exists

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -35,6 +35,7 @@ var namespace string
 var verbose bool
 var existingPod bool
 var nonInteractive bool
+var containerName string
 
 // runCmd represents the "porter run" base command when called
 // without any subcommands
@@ -98,6 +99,14 @@ func init() {
 		"whether to run in non-interactive mode",
 	)
 
+	runCmd.PersistentFlags().StringVarP(
+		&containerName,
+		"container",
+		"c",
+		"",
+		"name of the container inside pod to run the command in",
+	)
+
 	runCmd.AddCommand(cleanupCmd)
 }
 
@@ -144,12 +153,35 @@ func run(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []strin
 
 	var selectedContainerName string
 
-	// if the selected pod has multiple container, spawn selector
 	if len(selectedPod.ContainerNames) == 0 {
-		return fmt.Errorf("At least one pod must exist in this deployment.")
+		return fmt.Errorf("At least one container must exist in the selected pod.")
 	} else if len(selectedPod.ContainerNames) == 1 {
+		if containerName != "" && containerName != selectedPod.ContainerNames[0] {
+			return fmt.Errorf("provided container %s does not exist in pod %s", containerName, selectedPod.Name)
+		}
+
 		selectedContainerName = selectedPod.ContainerNames[0]
-	} else {
+	}
+
+	if containerName != "" && selectedContainerName == "" {
+		// check if provided container name exists in the pod
+		for _, name := range selectedPod.ContainerNames {
+			if name == containerName {
+				selectedContainerName = name
+				break
+			}
+		}
+
+		if selectedContainerName == "" {
+			return fmt.Errorf("provided container %s does not exist in pod %s", containerName, selectedPod.Name)
+		}
+	}
+
+	if selectedContainerName == "" {
+		if nonInteractive {
+			return fmt.Errorf("container name must be specified using the --container flag when using non-interactive mode")
+		}
+
 		selectedContainer, err := utils.PromptSelect("Select the container:", selectedPod.ContainerNames)
 
 		if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The `porter run` command now accepts a `-c` or `--container` flag to take the name of the container name in the pod. This container will be used automatically (if valid) when using the command. In non-interactive mode, this is a required flag if the pod has more than one containers.

## Technical Spec/Implementation Notes
