### PR TITLE
[hotfix] Fix for metrics regex for deployments

### DIFF
--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -301,7 +301,7 @@ func getSelectionRegex(kind, name string) (string, error) {
 
 	switch strings.ToLower(kind) {
 	case "deployment":
-		suffix = "[a-z0-9]+-[a-z0-9]+"
+		suffix = "[a-z0-9]+(-[a-z0-9]+)*"
 	case "statefulset":
 		suffix = "[0-9]+"
 	case "job":

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -301,7 +301,7 @@ func getSelectionRegex(kind, name string) (string, error) {
 
 	switch strings.ToLower(kind) {
 	case "deployment":
-		suffix = "[a-z0-9]+"
+		suffix = "[a-z0-9]+-[a-z0-9]+"
 	case "statefulset":
 		suffix = "[0-9]+"
 	case "job":


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Only checks for pods with regex `[a-z0-9]+`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR fixes the regex handling for deployment pods when fetching metrics.

## Technical Spec/Implementation Notes
