### PR TITLE
Add `--legacy-peer-deps` flag to workflow

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           mkdir -p ./release/static
           cd dashboard
-          npm i --production=false
+          npm i --production=false --legacy-peer-deps
           npm run build
           cd ..
           zip --junk-paths ./release/static/static_${{steps.tag_name.outputs.tag}}.zip ./dashboard/build/*


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Workflow runs fail. 

## What is the new behavior?

Add flag so that `package-lock.json` file gets parsed successfully. 

## Technical Spec/Implementation Notes
