### PR TITLE
[POR-677] Add `porter kubectl` and `porter helm` wrapper subcommands

### DIFF
--- a/api/server/router/cluster.go
+++ b/api/server/router/cluster.go
@@ -697,7 +697,7 @@ func getClusterRoutes(
 	// GET /api/projects/{project_id}/clusters/{cluster_id}/kubeconfig -> cluster.NewGetTemporaryKubeconfigHandler
 	getTemporaryKubeconfigEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
-			Verb:   types.APIVerbGet,
+			Verb:   types.APIVerbUpdate, // we do not want users with no-write access to be able to use this
 			Method: types.HTTPVerbGet,
 			Path: &types.Path{
 				Parent:       basePath,

--- a/cli/cmd/helm.go
+++ b/cli/cmd/helm.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,19 +47,14 @@ func runHelm(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []s
 
 	cmd := exec.Command("helm", args...)
 
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	err = cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("error running helm: %s", stderr.String())
+		return fmt.Errorf("error running helm: %w", err)
 	}
-
-	fmt.Print(out.String())
 
 	return nil
 }

--- a/cli/cmd/helm.go
+++ b/cli/cmd/helm.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/spf13/cobra"
+)
+
+var helmCmd = &cobra.Command{
+	Use:   "helm",
+	Short: "Use helm to interact with a Porter cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := checkLoginAndRun(args, runHelm)
+
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(helmCmd)
+}
+
+func runHelm(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+	_, err := exec.LookPath("helm")
+
+	if err != nil {
+		return fmt.Errorf("error finding helm: %w", err)
+	}
+
+	tmpFile, err := downloadTempKubeconfig(client)
+
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		os.Remove(tmpFile)
+	}()
+
+	os.Setenv("KUBECONFIG", tmpFile)
+
+	cmd := exec.Command("helm", args...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+
+	if err != nil {
+		return fmt.Errorf("error running helm: %s", stderr.String())
+	}
+
+	fmt.Print(out.String())
+
+	return nil
+}

--- a/cli/cmd/kubectl.go
+++ b/cli/cmd/kubectl.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/spf13/cobra"
+)
+
+var kubectlCmd = &cobra.Command{
+	Use:   "kubectl",
+	Short: "Use kubectl to interact with a Porter cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := checkLoginAndRun(args, runKubectl)
+
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(kubectlCmd)
+}
+
+func runKubectl(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+	_, err := exec.LookPath("kubectl")
+
+	if err != nil {
+		return fmt.Errorf("error finding kubectl: %w", err)
+	}
+
+	tmpFile, err := downloadTempKubeconfig(client)
+
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		os.Remove(tmpFile)
+	}()
+
+	os.Setenv("KUBECONFIG", tmpFile)
+
+	cmd := exec.Command("kubectl", args...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+
+	if err != nil {
+		return fmt.Errorf("error running kubectl: %s", stderr.String())
+	}
+
+	fmt.Print(out.String())
+
+	return nil
+}
+
+func downloadTempKubeconfig(client *api.Client) (string, error) {
+	tmpFile, err := os.CreateTemp("", "porter_kubeconfig_*.yaml")
+
+	if err != nil {
+		return "", fmt.Errorf("error creating temp file for kubeconfig: %w", err)
+	}
+
+	defer tmpFile.Close()
+
+	resp, err := client.GetKubeconfig(context.Background(), cliConf.Project, cliConf.Cluster, cliConf.Kubeconfig)
+
+	if err != nil {
+		return "", fmt.Errorf("error fetching kubeconfig for cluster: %w", err)
+	}
+
+	_, err = tmpFile.Write(resp.Kubeconfig)
+
+	if err != nil {
+		return "", fmt.Errorf("error writing kubeconfig to temp file: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}

--- a/cli/cmd/kubectl.go
+++ b/cli/cmd/kubectl.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -49,19 +48,14 @@ func runKubectl(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 
 	cmd := exec.Command("kubectl", args...)
 
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	err = cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("error running kubectl: %s", stderr.String())
+		return fmt.Errorf("error running helm: %w", err)
 	}
-
-	fmt.Print(out.String())
 
 	return nil
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now have `porter kubectl` and `porter helm` commands that simply wrap over `kubectl` and `helm` respectively but do so with the current Porter cluster configured.

## Technical Spec/Implementation Notes
