### PR TITLE
Update behavior of deploy webhooks to redeploy on missing tag

### DIFF
--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -95,6 +95,7 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// repository is set to current repository by default
 	repository := rel.Config["image"].(map[string]interface{})["repository"]
+	currTag := rel.Config["image"].(map[string]interface{})["tag"]
 
 	gitAction := release.GitActionConfig
 
@@ -106,7 +107,13 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	image := map[string]interface{}{}
 	image["repository"] = repository
+
 	image["tag"] = request.Commit
+
+	if request.Commit == "" {
+		image["tag"] = currTag
+	}
+
 	rel.Config["image"] = image
 
 	if rel.Config["auto_deploy"] == false {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

If a webhook is called without a commit query param, it redeploys with an empty image tag. 

## What is the new behavior?

Patch webhook implementation so that it redeploys with the previous image tag, if the requested tag is empty. 

## Technical Spec/Implementation Notes
