### PR TITLE
fix: failed pods deletion + include metadata in tooltip for failed pods

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
@@ -28,6 +28,7 @@ export type ControllerTabPodType = {
   restartCount: number | string;
   podAge: string;
   revisionNumber?: number;
+  containerStatus: any;
 };
 
 const formatCreationTimestamp = timeFormat("%H:%M:%S %b %d, '%y");
@@ -125,6 +126,7 @@ const ControllerTabFC: React.FunctionComponent<Props> = ({
             status: pod?.status,
             replicaSetName,
             restartCount,
+            containerStatus,
             podAge: pod?.metadata?.creationTimestamp ? podAge : "N/A",
             revisionNumber:
               (pod?.metadata?.annotations &&
@@ -233,8 +235,8 @@ const ControllerTabFC: React.FunctionComponent<Props> = ({
         {},
         {
           cluster_id: currentCluster.id,
-          name: pod.metadata?.name,
-          namespace: pod.metadata?.namespace,
+          name: pod?.name,
+          namespace: pod?.namespace,
           id: currentProject.id,
         }
       )

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/PodRow.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/PodRow.tsx
@@ -43,6 +43,12 @@ const PodRow: React.FunctionComponent<PodRowProps> = ({
           {pod?.name}
           <Grey>Restart count: {pod.restartCount}</Grey>
           <Grey>Created on: {pod.podAge}</Grey>
+          {podStatus === "failed" ? (
+            <FailedStatusContainer>
+              <Grey>Failure Reason: {pod?.containerStatus?.state?.waiting?.reason}</Grey>
+              <Grey>{pod?.containerStatus?.state?.waiting?.message}</Grey>
+            </FailedStatusContainer>
+          ) : null}
         </Tooltip>
       )}
 
@@ -71,6 +77,13 @@ const InfoIcon = styled.div`
 const Grey = styled.div`
   margin-top: 5px;
   color: #aaaabb;
+`;
+
+const FailedStatusContainer = styled.div`
+  width: 100%;
+  border: 1px solid hsl(0deg, 100%, 30%);
+  padding: 5px;
+  margin-block: 5px;
 `;
 
 const Tooltip = styled.div`


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently, there are two issues with handling failed pods:

1. We indicate that a particular pod is failing but that alone doesnt help to make it clear why a particular pod is failing
2. Deleting a failed pod leads to an error due to api calls being made with `undefined` and `undefined` for pod name and namespace

## What is the new behavior?

This PR:
1. Adds additional metadata to the tooltip for a failing pod to help user get more insight into why a aprticular pod might be failing
<img width="1438" alt="Screenshot 2022-08-26 at 4 19 13 PM" src="https://user-images.githubusercontent.com/80167324/186985355-1b604ed8-2acc-4bc0-96f5-f600d0cf7f24.png">


2. Fixes bug for deleting failed pods
