### PR TITLE
fix(docker): fix docker dev environments

### DIFF
--- a/dashboard/docker/dev.Dockerfile
+++ b/dashboard/docker/dev.Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 
 ENV NODE_ENV=development
 
-RUN npm install
+RUN npm ci --legacy-peer-deps
 RUN npm i -g http-parser-js
 
 COPY . ./

--- a/docker-compose.dev-secure.yaml
+++ b/docker-compose.dev-secure.yaml
@@ -18,7 +18,7 @@ services:
       - postgres
     env_file:
       - ./docker/.env
-    command: /bin/sh -c '/porter/bin/migrate; air -c .air.toml;'
+    command:  air -c .air.toml
     restart: on-failure
     volumes:
       - ./cmd:/porter/cmd

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -18,7 +18,7 @@ services:
       - postgres
     env_file:
       - ./docker/.env
-    command: /bin/sh -c '/porter/bin/migrate; air -c .air.toml;'
+    command: air -c .air.toml
     restart: on-failure
     volumes:
       - ./cmd:/porter/cmd

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -5,14 +5,14 @@ WORKDIR /porter
 
 RUN apk update && apk add --no-cache gcc musl-dev git
 
+# for live reloading of go container
+RUN go install github.com/cosmtrek/air@latest
+
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
 
 RUN chmod +x /porter/docker/bin/*
-
-# for live reloading of go container
-RUN go get github.com/cosmtrek/air
 
 CMD air -c .air.toml


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [x] Docs have been reviewed and added / updated if needed

## What is the current behaviour?

The docker dev environments do not build or start.

## What is the new behaviour?

The docker dev  environments are now usable again.

## Technical Spec/Implementation Notes

- Fix `npm install` command in dashboard dev image to work with resolving issues currently bundled in `package-lock.json` with Node 16+.
- Drop running missing `migrate` command before air as it's done automatically when the porter API starts.
- Fix `air` not being installed when building docker image for API.
