### PR TITLE
Memory-optimised instance types for RDS

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -91,6 +91,12 @@ tabs:
           value: db.t3.xlarge
         - label: db.t3.2xlarge
           value: db.t3.2xlarge
+        - label: db.r6g.large
+          value: db.r6g.large
+        - label: db.r6g.xlarge
+          value: db.r6g.xlarge
+        - label: db.r6g.2xlarge
+          value: db.r6g.2xlarge
   - name: family-versions
     contents:
     - type: select


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): Added three new memory-optimised instance types for the RDS provisioner - `db.r6g.large`, `db.r6g.xlarge` and `db.r6g.2xlarge`.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
