### PR TITLE
fix(api): handle when welcome hook is not configured

### DIFF
--- a/api/server/handlers/user/welcome_webhook.go
+++ b/api/server/handlers/user/welcome_webhook.go
@@ -27,14 +27,19 @@ func NewUserWelcomeHandler(
 }
 
 func (u *UserWelcomeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Skip if no welcome hook is configured.
+	welcomeFormWebhook := u.Config().ServerConf.WelcomeFormWebhook
+	if welcomeFormWebhook == "" {
+		return
+	}
+
 	reqVals := &types.WelcomeWebhookRequest{}
 
 	if ok := u.DecodeAndValidate(w, r, reqVals); !ok {
 		return
 	}
 
-	req, err := http.NewRequest("GET", u.Config().ServerConf.WelcomeFormWebhook, nil)
-
+	req, err := http.NewRequest("GET", welcomeFormWebhook, nil)
 	if err != nil {
 		return
 	}

--- a/api/server/handlers/user/welcome_webhook_test.go
+++ b/api/server/handlers/user/welcome_webhook_test.go
@@ -1,0 +1,79 @@
+package user_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/porter-dev/porter/api/server/handlers/user"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apitest"
+	"github.com/porter-dev/porter/api/types"
+)
+
+func TestWelcomeWebhookWithoutURL(t *testing.T) {
+	req, rr := apitest.GetRequestAndRecorder(
+		t,
+		string(types.HTTPVerbPost),
+		"/api/welcome",
+		&types.WelcomeWebhookRequest{
+			Email:     "test@test.it",
+			IsCompany: true,
+			Company:   "Awesome Company",
+			Role:      "Founder",
+			Name:      "John Doe",
+		},
+	)
+
+	config := apitest.LoadConfig(t)
+	config.ServerConf.WelcomeFormWebhook = ""
+
+	handler := user.NewUserWelcomeHandler(
+		config,
+		shared.NewDefaultRequestDecoderValidator(config.Logger, config.Alerter),
+		shared.NewDefaultResultWriter(config.Logger, config.Alerter),
+	)
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, rr.Result().StatusCode, 200, "incorrect status code")
+}
+
+func helloWebhook(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "Hello!\n")
+}
+
+func TestWelcomeWebhookWithURL(t *testing.T) {
+	req, rr := apitest.GetRequestAndRecorder(
+		t,
+		string(types.HTTPVerbPost),
+		"/api/welcome",
+		&types.WelcomeWebhookRequest{
+			Email:     "test@test.it",
+			IsCompany: true,
+			Company:   "Awesome Company",
+			Role:      "Founder",
+			Name:      "John Doe",
+		},
+	)
+
+	go func() {
+		http.HandleFunc("/hello", helloWebhook)
+		http.ListenAndServe(":10044", nil)
+	}()
+
+	config := apitest.LoadConfig(t)
+	config.ServerConf.WelcomeFormWebhook = "http://localhost:10044/hello"
+
+	handler := user.NewUserWelcomeHandler(
+		config,
+		shared.NewDefaultRequestDecoderValidator(config.Logger, config.Alerter),
+		shared.NewDefaultResultWriter(config.Logger, config.Alerter),
+	)
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, rr.Result().StatusCode, 200, "incorrect status code")
+}


### PR DESCRIPTION
## Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Issue Number: Fixes https://github.com/porter-dev/porter/issues/2346

If `WELCOME_FORM_WEBHOOK` is not configured, first time signup will fail.

## What is the new behavior?

The welcome hook endpoint verifies if `WELCOME_FORM_WEBHOOK` is set before attempting to call it, making the parameter optional. 
