### PR TITLE
R5 instance types for Amazon RDS

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -91,12 +91,12 @@ tabs:
           value: db.t3.xlarge
         - label: db.t3.2xlarge
           value: db.t3.2xlarge
-        - label: db.r6g.large
-          value: db.r6g.large
-        - label: db.r6g.xlarge
-          value: db.r6g.xlarge
-        - label: db.r6g.2xlarge
-          value: db.r6g.2xlarge
+        - label: db.r5.large
+          value: db.r5.large
+        - label: db.r5.xlarge
+          value: db.r5.xlarge
+        - label: db.r5.2xlarge
+          value: db.r5.2xlarge
   - name: family-versions
     contents:
     - type: select


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.
Memory-optimised instances of RDS were using the `R6g` instance type which uses ARM processors.

Issue Number: N/A

-->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Memory-optimised instance types now use the `R5` class which use Intel Xeon chips.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
