### PR TITLE
[POR-682] Fix bug that used canonical name requirement for Dockerhub image names

### DIFF
--- a/cli/cmd/connect/dockerhub.go
+++ b/cli/cmd/connect/dockerhub.go
@@ -22,21 +22,19 @@ func Dockerhub(
 
 	// query for dockerhub name
 
-	repoName, err := utils.PromptPlaintext(fmt.Sprintf(`Provide the Docker Hub image path, in the form of ${org_name}/${repo_name}. For example, porter1/porter.
-Image path: `))
+	repoName, err := utils.PromptPlaintext("Provide the Docker Hub organization name. For example, if your Docker Hub repository is 'myorg/myrepo', enter 'myorg'.\nName: ")
 
 	if err != nil {
 		return 0, err
 	}
 
-	username, err := utils.PromptPlaintext(fmt.Sprintf(`Docker Hub username: `))
+	username, err := utils.PromptPlaintext("Docker Hub username: ")
 
 	if err != nil {
 		return 0, err
 	}
 
-	password, err := utils.PromptPassword(`Provide the Docker Hub personal access token.
-Token:`)
+	password, err := utils.PromptPassword("Provide the Docker Hub personal access token.\nToken: ")
 
 	if err != nil {
 		return 0, err

--- a/cli/cmd/docker/agent.go
+++ b/cli/cmd/docker/agent.go
@@ -401,7 +401,7 @@ func (a *Agent) getPushOptions(image string) (types.ImagePushOptions, error) {
 }
 
 func GetServerURLFromTag(image string) (string, error) {
-	named, err := reference.ParseNamed(image)
+	named, err := reference.ParseNormalizedNamed(image)
 
 	if err != nil {
 		return "", err
@@ -430,6 +430,10 @@ func GetServerURLFromTag(image string) (string, error) {
 
 	if err != nil {
 		return "", err
+	}
+
+	if domain == "docker.io" {
+		domain = "index.docker.io"
 	}
 
 	return fmt.Sprintf("%s/%s", domain, nonImagePath), nil


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Dockerhub images would give an error: `canonical name expected`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We use `index.docker.io` for Dockerhub repositories across our codebase. However, the Docker Go client strips away `index.` and only keeps `docker.io` for canonicalized form of the image URL. This PR fixes the error by using a more relaxed version of the parse function.

## Technical Spec/Implementation Notes
