### PR TITLE
Revert "fix: failed pods deletion + include metadata in tooltip for failed pods"

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/ControllerTab.tsx
@@ -28,7 +28,6 @@ export type ControllerTabPodType = {
   restartCount: number | string;
   podAge: string;
   revisionNumber?: number;
-  containerStatus: any;
 };
 
 const formatCreationTimestamp = timeFormat("%H:%M:%S %b %d, '%y");
@@ -126,7 +125,6 @@ const ControllerTabFC: React.FunctionComponent<Props> = ({
             status: pod?.status,
             replicaSetName,
             restartCount,
-            containerStatus,
             podAge: pod?.metadata?.creationTimestamp ? podAge : "N/A",
             revisionNumber:
               (pod?.metadata?.annotations &&
@@ -235,8 +233,8 @@ const ControllerTabFC: React.FunctionComponent<Props> = ({
         {},
         {
           cluster_id: currentCluster.id,
-          name: pod?.name,
-          namespace: pod?.namespace,
+          name: pod.metadata?.name,
+          namespace: pod.metadata?.namespace,
           id: currentProject.id,
         }
       )

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/PodRow.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/status/PodRow.tsx
@@ -43,12 +43,6 @@ const PodRow: React.FunctionComponent<PodRowProps> = ({
           {pod?.name}
           <Grey>Restart count: {pod.restartCount}</Grey>
           <Grey>Created on: {pod.podAge}</Grey>
-          {podStatus === "failed" ? (
-            <FailedStatusContainer>
-              <Grey>Failure Reason: {pod?.containerStatus?.state?.waiting?.reason}</Grey>
-              <Grey>{pod?.containerStatus?.state?.waiting?.message}</Grey>
-            </FailedStatusContainer>
-          ) : null}
         </Tooltip>
       )}
 
@@ -77,13 +71,6 @@ const InfoIcon = styled.div`
 const Grey = styled.div`
   margin-top: 5px;
   color: #aaaabb;
-`;
-
-const FailedStatusContainer = styled.div`
-  width: 100%;
-  border: 1px solid hsl(0deg, 100%, 30%);
-  padding: 5px;
-  margin-block: 5px;
 `;
 
 const Tooltip = styled.div`


### PR DESCRIPTION
Reverts porter-dev/porter#2340 due to some applications not being able to see the logs properly.