### PR TITLE
[POR-682] [hotfix] Fix dockerhub registry repo path

### DIFF
--- a/cli/cmd/connect/dockerhub.go
+++ b/cli/cmd/connect/dockerhub.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/porter-dev/porter/api/types"
 
@@ -22,10 +23,16 @@ func Dockerhub(
 
 	// query for dockerhub name
 
-	repoName, err := utils.PromptPlaintext("Provide the Docker Hub organization name. For example, if your Docker Hub repository is 'myorg/myrepo', enter 'myorg'.\nName: ")
-
+	repoName, err := utils.PromptPlaintext(`Provide the Docker Hub repository, in the form of ${org_name}/${repo_name}. For example, porter1/porter.
+Repository: `)
 	if err != nil {
 		return 0, err
+	}
+
+	orgRepo := strings.Split(repoName, "/")
+
+	if len(orgRepo) != 2 || orgRepo[0] == "" || orgRepo[1] == "" {
+		return 0, fmt.Errorf("invalid Docker Hub image path: %s", repoName)
 	}
 
 	username, err := utils.PromptPlaintext("Docker Hub username: ")

--- a/cli/cmd/connect/dockerhub.go
+++ b/cli/cmd/connect/dockerhub.go
@@ -23,8 +23,7 @@ func Dockerhub(
 
 	// query for dockerhub name
 
-	repoName, err := utils.PromptPlaintext(`Provide the Docker Hub repository, in the form of ${org_name}/${repo_name}. For example, porter1/porter.
-Repository: `)
+	repoName, err := utils.PromptPlaintext("Provide the Docker Hub repository, in the form of ${org_name}/${repo_name}. For example, porter1/porter.\nRepository: ")
 	if err != nil {
 		return 0, err
 	}
@@ -32,7 +31,7 @@ Repository: `)
 	orgRepo := strings.Split(repoName, "/")
 
 	if len(orgRepo) != 2 || orgRepo[0] == "" || orgRepo[1] == "" {
-		return 0, fmt.Errorf("invalid Docker Hub image path: %s", repoName)
+		return 0, fmt.Errorf("invalid Docker Hub repository: %s", repoName)
 	}
 
 	username, err := utils.PromptPlaintext("Docker Hub username: ")

--- a/cli/cmd/deploy/create.go
+++ b/cli/cmd/deploy/create.go
@@ -438,6 +438,9 @@ func (c *CreateAgent) GetImageRepoURL(name, namespace string) (uint, string, err
 	if strings.Contains(imageURI, "pkg.dev") {
 		repoSlice := strings.Split(imageURI, "/")
 		imageURI = fmt.Sprintf("%s/%s", imageURI, repoSlice[len(repoSlice)-1])
+	} else if strings.Contains(imageURI, "index.docker.io") {
+		repoSlice := strings.Split(imageURI, "/")
+		imageURI = strings.Join(repoSlice[:len(repoSlice)-1], "/")
 	}
 
 	return regID, imageURI, nil


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

There is no validation of the path to the DockerHub repo. Also, image URI is set wrong when creating a new release for a DockerHub repo.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- Add simple validation for DockerHub repo of the form `org/repo`
- When creating a new release, if using a DockerHub repo to deploy the image, the repo name should be intact without appending any release name information to it

## Technical Spec/Implementation Notes
