### PR TITLE
Fix OPA loading and add checks for node version and labels/taints

### DIFF
--- a/internal/opa/config.yaml
+++ b/internal/opa/config.yaml
@@ -120,3 +120,16 @@ certificates:
     name: "certificates.expiry_two_weeks"
   - path: "./policies/certificates/expired.rego"
     name: "certificates.expired"
+node:
+  kind: "crd_list"
+  match:
+    group: core
+    version: v1
+    resource: nodes
+  policies:
+  - path: "./policies/node/k8s_version.rego"
+    name: "node.k8s_version"
+  - path: "./policies/node/porter_run_taints.rego"
+    name: "node.porter_run_taints"
+  - path: "./policies/node/porter_run_labels.rego"
+    name: "node.porter_run_labels"

--- a/internal/opa/config.yaml
+++ b/internal/opa/config.yaml
@@ -56,7 +56,7 @@ prometheus:
     name: "prometheus.version"
 nginx_pod:
   kind: "pod"
-  override_severity: "critical"
+  overrideSeverity: "critical"
   match:
     namespace: ingress-nginx
     labels:

--- a/internal/opa/loader.go
+++ b/internal/opa/loader.go
@@ -13,11 +13,11 @@ import (
 type ConfigFile map[string]ConfigFilePolicyCollection
 
 type ConfigFilePolicyCollection struct {
-	Kind             string             `yaml:"kind"`
-	Match            MatchParameters    `yaml:"match"`
-	MustExist        bool               `yaml:"mustExist"`
-	OverrideSeverity string             `yaml:"override_severity"`
-	Policies         []ConfigFilePolicy `yaml:"policies"`
+	Kind             string             `json:"kind"`
+	Match            MatchParameters    `json:"match"`
+	MustExist        bool               `json:"mustExist"`
+	OverrideSeverity string             `json:"overrideSeverity"`
+	Policies         []ConfigFilePolicy `json:"policies"`
 }
 
 type ConfigFilePolicy struct {
@@ -74,6 +74,8 @@ func LoadPolicies(configFilePathDir string) (*KubernetesPolicies, error) {
 			OverrideSeverity: cfPolicyCollection.OverrideSeverity,
 			MustExist:        cfPolicyCollection.MustExist,
 		}
+
+		fmt.Println("ADDED POLICY WITH SEVERITY", cfPolicyCollection.OverrideSeverity)
 	}
 
 	return &KubernetesPolicies{

--- a/internal/opa/loader.go
+++ b/internal/opa/loader.go
@@ -74,8 +74,6 @@ func LoadPolicies(configFilePathDir string) (*KubernetesPolicies, error) {
 			OverrideSeverity: cfPolicyCollection.OverrideSeverity,
 			MustExist:        cfPolicyCollection.MustExist,
 		}
-
-		fmt.Println("ADDED POLICY WITH SEVERITY", cfPolicyCollection.OverrideSeverity)
 	}
 
 	return &KubernetesPolicies{

--- a/internal/opa/opa.go
+++ b/internal/opa/opa.go
@@ -315,6 +315,11 @@ func (runner *KubernetesOPARunner) runCRDListQueries(name string, collection Kub
 		Resource: collection.Match.Resource,
 	}
 
+	// just case on the "core" group and unset it
+	if collection.Match.Group == "core" {
+		objRes.Group = ""
+	}
+
 	crdList, err := runner.dynamicClient.Resource(objRes).Namespace(collection.Match.Namespace).List(context.Background(), v1.ListOptions{})
 
 	if err != nil {

--- a/internal/opa/policies/node/k8s_version.rego
+++ b/internal/opa/policies/node/k8s_version.rego
@@ -1,0 +1,25 @@
+package node.k8s_version
+
+import future.keywords
+
+POLICY_ID := "k8s_version"
+
+POLICY_VERSION := "v0.0.1"
+
+POLICY_SEVERITY := "high"
+
+latest_stable_version := "1.21.0"
+
+POLICY_TITLE := sprintf("The Kubernetes version for node %s should be at least v%s", [input.metadata.name, latest_stable_version])
+
+POLICY_SUCCESS_MESSAGE := sprintf("Success: Kubernetes version is up-to-date", [])
+
+trimmedVersion := trim_left(input.status.nodeInfo.kubeletVersion, "v")
+
+# semver.compare returns -1 if latest_stable_version < trimmedVersion
+allow if semver.compare(latest_stable_version, trimmedVersion) <= 0
+
+FAILURE_MESSAGE contains msg if {
+	not allow
+	msg := sprintf("Failed: latest stable version is %s, but node %s is on %s", [latest_stable_version, input.metadata.name, trimmedVersion])
+}

--- a/internal/opa/policies/node/porter_run_labels.rego
+++ b/internal/opa/policies/node/porter_run_labels.rego
@@ -1,0 +1,23 @@
+package node.porter_run_labels
+
+import future.keywords
+
+POLICY_ID := "porter_run_labels"
+
+POLICY_VERSION := "v0.0.1"
+
+POLICY_SEVERITY := "high"
+
+POLICY_TITLE := sprintf("The node %s should have the label porter.run/workload-kind", [input.metadata.name])
+
+POLICY_SUCCESS_MESSAGE := sprintf("Success: this node has the label porter.run/workload-kind", [])
+
+# determine if the label porter.run/workload-kind exists
+allow if {
+	input.metadata.labels["porter.run/workload-kind"]
+}
+
+FAILURE_MESSAGE contains msg if {
+	not allow
+	msg := sprintf("Failed: the node %s does not have the label porter.run/workload-kind", [input.metadata.name])
+}

--- a/internal/opa/policies/node/porter_run_taints.rego
+++ b/internal/opa/policies/node/porter_run_taints.rego
@@ -1,0 +1,41 @@
+package node.porter_run_taints
+
+import future.keywords
+
+POLICY_ID := "porter_run_taints"
+
+POLICY_VERSION := "v0.0.1"
+
+POLICY_SEVERITY := "high"
+
+POLICY_TITLE := sprintf("The only taints on node %s should be porter.run/workload-kind=system", [input.metadata.name])
+
+POLICY_SUCCESS_MESSAGE := sprintf("Success: this node either has no taints, or has a taint with key porter.run/workload-kind", [])
+
+# if there are no taints, allow the condition
+allow if {
+	not input.spec.taints[0]
+}
+
+# if there is a taint with the key porter.run/workload-kind, allow the condition
+allow if {
+	input.spec.taints[0].key == "porter.run/workload-kind"
+	input.spec.taints[0].effect == "NoSchedule"
+}
+
+FAILURE_MESSAGE contains msg1 if {
+	not allow
+	msg1 := sprintf("Failed: the only permitted taints must contain the key porter.run/workload-kind", [])
+}
+
+FAILURE_MESSAGE contains msg2 if {
+	not allow
+	not input.spec.taints[0].key == "porter.run/workload-kind"
+	msg2 := sprintf("Taint has key %s", [input.spec.taints[0].key])
+}
+
+FAILURE_MESSAGE contains msg3 if {
+	not allow
+	not input.spec.taints[0].effect == "NoSchedule"
+	msg3 := sprintf("Taint has effect %s", [input.spec.taints[0].effect])
+}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Loader does not work for `override_severity`, and node requirements are missing from OPA rules. 

## What is the new behavior?

Modify loader to use `json` tags and camelCase, and add node requirements as part of checks. 

## Technical Spec/Implementation Notes
