### PR TITLE
close websockets on switching clusters in sidebar

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/ChartList.tsx
@@ -297,7 +297,7 @@ const ChartList: React.FunctionComponent<Props> = ({
       controllers.map((controller) => closeWebsocket(controller));
       closeWebsocket(jobWebsocketID);
     };
-  }, []);
+  }, [context.currentCluster]);
 
   useEffect(() => {
     const websocketID = "helm_releases";
@@ -307,7 +307,7 @@ const ChartList: React.FunctionComponent<Props> = ({
     return () => {
       closeWebsocket(websocketID);
     };
-  }, [namespace]);
+  }, [namespace, context.currentCluster]);
 
   useEffect(() => {
     let isSubscribed = true;


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

web/job list websockets don't close when switching clusters from the sidebar

## What is the new behavior?

web/job list websockets close when switching clusters from the sidebar

## Technical Spec/Implementation Notes
