### PR TITLE
Set target cluster when clicking between existing clusters

### DIFF
--- a/dashboard/src/main/home/sidebar/ClusterSection.tsx
+++ b/dashboard/src/main/home/sidebar/ClusterSection.tsx
@@ -44,6 +44,7 @@ export const ClusterSection: React.FC<Props> = ({
           <SideLine />
           <NavButton
             path="/applications"
+            targetClusterName={cluster?.name}
             active={
               currentCluster.id === clusterId &&
               window.location.pathname === "/applications"
@@ -54,6 +55,7 @@ export const ClusterSection: React.FC<Props> = ({
           </NavButton>
           <NavButton
             path="/jobs"
+            targetClusterName={cluster?.name}
             active={
               currentCluster.id === clusterId &&
               window.location.pathname === "/jobs"
@@ -64,6 +66,7 @@ export const ClusterSection: React.FC<Props> = ({
           </NavButton>
           <NavButton
             path="/env-groups"
+            targetClusterName={cluster?.name}
             active={
               currentCluster.id === clusterId &&
               window.location.pathname === "/env-groups"
@@ -77,6 +80,7 @@ export const ClusterSection: React.FC<Props> = ({
             currentProject.enable_rds_databases && (
               <NavButton
                 path="/databases"
+                targetClusterName={cluster?.name}
                 active={
                   currentCluster.id === clusterId &&
                   window.location.pathname === "/databases"
@@ -89,6 +93,7 @@ export const ClusterSection: React.FC<Props> = ({
           {currentProject?.stacks_enabled ? (
             <NavButton
               path="/stacks"
+              targetClusterName={cluster?.name}
               active={
                 currentCluster.id === clusterId &&
                 window.location.pathname === "/stacks"
@@ -99,8 +104,9 @@ export const ClusterSection: React.FC<Props> = ({
             </NavButton>
           ) : null}
           {currentProject?.preview_envs_enabled && (
-            <NavButton 
+            <NavButton
               path="/preview-environments"
+              targetClusterName={cluster?.name}
               active={
                 currentCluster.id === clusterId &&
                 window.location.pathname === "/preview-environments"
@@ -119,6 +125,7 @@ export const ClusterSection: React.FC<Props> = ({
           )}
           <NavButton
             path={"/cluster-dashboard"}
+            targetClusterName={cluster?.name}
             active={
               currentCluster.id === clusterId &&
               window.location.pathname === "/cluster-dashboard"
@@ -134,17 +141,19 @@ export const ClusterSection: React.FC<Props> = ({
 
   return (
     <>
-      <ClusterSelector 
+      <ClusterSelector
         onClick={() => setIsExpanded(!isExpanded)}
         active={
-          !isExpanded && cluster.id === currentCluster.id && [
+          !isExpanded &&
+          cluster.id === currentCluster.id &&
+          [
             "/cluster-dashboard",
             "/preview-environments",
             "/stacks",
             "/databases",
             "/env-groups",
             "/jobs",
-            "/applications"
+            "/applications",
           ].includes(window.location.pathname)
         }
       >

--- a/dashboard/src/main/home/sidebar/SidebarLink.tsx
+++ b/dashboard/src/main/home/sidebar/SidebarLink.tsx
@@ -25,14 +25,11 @@ const SidebarLink: React.FC<
       search.append("project_id", String(currentProject.id));
     }
 
-    console.log("GOT NAMESPACE", getQueryParam("namespace"));
-
     if (!pathNamespace) {
       pathNamespace = getQueryParam("namespace");
     }
 
     if (pathNamespace) {
-      console.log("APPENDING NAMESPACE", pathNamespace);
       search.append("namespace", pathNamespace);
     }
 

--- a/dashboard/src/main/home/sidebar/SidebarLink.tsx
+++ b/dashboard/src/main/home/sidebar/SidebarLink.tsx
@@ -3,11 +3,9 @@ import { NavLink, NavLinkProps, useParams } from "react-router-dom";
 import { Context } from "shared/Context";
 import { useRouting } from "shared/routing";
 
-const SidebarLink: React.FC<{ path: string } & Omit<NavLinkProps, "to">> = ({
-  children,
-  path,
-  ...props
-}) => {
+const SidebarLink: React.FC<
+  { path: string; targetClusterName?: string } & Omit<NavLinkProps, "to">
+> = ({ children, path, ...props }) => {
   const params = useParams<{ namespace: string }>();
   const { getQueryParam } = useRouting();
   const { currentCluster, currentProject } = useContext(Context);
@@ -20,18 +18,21 @@ const SidebarLink: React.FC<{ path: string } & Omit<NavLinkProps, "to">> = ({
     let pathNamespace = params.namespace;
     const search = new URLSearchParams();
     if (currentCluster?.name) {
-      search.append("cluster", currentCluster.name);
+      search.append("cluster", props.targetClusterName || currentCluster.name);
     }
 
     if (currentProject?.id) {
       search.append("project_id", String(currentProject.id));
     }
 
+    console.log("GOT NAMESPACE", getQueryParam("namespace"));
+
     if (!pathNamespace) {
       pathNamespace = getQueryParam("namespace");
     }
 
     if (pathNamespace) {
+      console.log("APPENDING NAMESPACE", pathNamespace);
       search.append("namespace", pathNamespace);
     }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Cluster URL param isn't set when clicking between clusters on the sidebar. 

## What is the new behavior?

Set cluster name URL param when clicking between clusters.

## Technical Spec/Implementation Notes
