### PR TITLE
Improve recommender cleanup process

### DIFF
--- a/internal/repository/gorm/monitor.go
+++ b/internal/repository/gorm/monitor.go
@@ -43,16 +43,16 @@ func (m *MonitorTestResultRepository) UpdateMonitorTestResult(monitor *models.Mo
 	return monitor, nil
 }
 
-func (m *MonitorTestResultRepository) ArchiveMonitorTestResults(recommenderID string) error {
-	query := m.db.Debug().Unscoped().Model(&models.MonitorTestResult{}).Where("last_recommender_run_id != ?", recommenderID)
+func (m *MonitorTestResultRepository) ArchiveMonitorTestResults(projectID, clusterID uint, recommenderID string) error {
+	query := m.db.Debug().Unscoped().Model(&models.MonitorTestResult{}).Where("project_id = ? AND cluster_id = ? AND last_recommender_run_id != ?", projectID, clusterID, recommenderID)
 
 	return query.Update("archived", true).Error
 }
 
-func (m *MonitorTestResultRepository) DeleteOldMonitorTestResults(recommenderID string) error {
+func (m *MonitorTestResultRepository) DeleteOldMonitorTestResults(projectID, clusterID uint, recommenderID string) error {
 	monitors := make([]*models.MonitorTestResult, 0)
 
-	query := m.db.Debug().Unscoped().Where("last_recommender_run_id != ?", recommenderID)
+	query := m.db.Debug().Unscoped().Where("project_id = ? AND cluster_id = ? AND last_recommender_run_id != ?", projectID, clusterID, recommenderID)
 
 	// we need to switch on the database type to delete records older than 24 hours
 	switch m.db.Dialector.Name() {

--- a/internal/repository/monitor.go
+++ b/internal/repository/monitor.go
@@ -7,6 +7,6 @@ type MonitorTestResultRepository interface {
 	ReadMonitorTestResult(projectID, clusterID uint, operationID string) (*models.MonitorTestResult, error)
 	UpdateMonitorTestResult(monitor *models.MonitorTestResult) (*models.MonitorTestResult, error)
 
-	ArchiveMonitorTestResults(recommenderID string) error
-	DeleteOldMonitorTestResults(recommenderID string) error
+	ArchiveMonitorTestResults(projectID, clusterID uint, recommenderID string) error
+	DeleteOldMonitorTestResults(projectID, clusterID uint, recommenderID string) error
 }

--- a/internal/repository/test/monitor.go
+++ b/internal/repository/test/monitor.go
@@ -23,10 +23,10 @@ func (n *MonitorTestResultRepository) UpdateMonitorTestResult(monitor *models.Mo
 	panic("not implemented") // TODO: Implement
 }
 
-func (n *MonitorTestResultRepository) ArchiveMonitorTestResults(recommenderID string) error {
+func (n *MonitorTestResultRepository) ArchiveMonitorTestResults(projectID, clusterID uint, recommenderID string) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (n *MonitorTestResultRepository) DeleteOldMonitorTestResults(recommenderID string) error {
+func (n *MonitorTestResultRepository) DeleteOldMonitorTestResults(projectID, clusterID uint, recommenderID string) error {
 	panic("not implemented") // TODO: Implement
 }

--- a/workers/jobs/recommender.go
+++ b/workers/jobs/recommender.go
@@ -251,16 +251,23 @@ func (n *recommender) Run() error {
 				continue
 			}
 		}
+
+		err = n.repo.MonitorTestResult().ArchiveMonitorTestResults(ids.projectID, ids.clusterID, n.runRecommenderID)
+
+		if err != nil {
+			log.Printf("error archiving test results for cluster ID %d: %v", ids.clusterID, err)
+			continue
+		}
+
+		err = n.repo.MonitorTestResult().DeleteOldMonitorTestResults(ids.projectID, ids.clusterID, n.runRecommenderID)
+
+		if err != nil {
+			log.Printf("error deleting old test results for cluster ID %d: %v", ids.clusterID, err)
+			continue
+		}
 	}
 
-	// archive any test results which don't match
-	err := n.repo.MonitorTestResult().ArchiveMonitorTestResults(n.runRecommenderID)
-
-	if err != nil {
-		return err
-	}
-
-	return n.repo.MonitorTestResult().DeleteOldMonitorTestResults(n.runRecommenderID)
+	return nil
 }
 
 func (n *recommender) getMonitorTestResultFromQueryResult(cluster *models.Cluster, queryRes *opa.OPARecommenderQueryResult, recommenderID string) *models.MonitorTestResult {

--- a/workers/main.go
+++ b/workers/main.go
@@ -66,6 +66,8 @@ func main() {
 	log.Printf("setting max worker count to: %d\n", envDecoder.MaxWorkers)
 	log.Printf("setting max job queue count to: %d\n", envDecoder.MaxQueue)
 
+	log.Printf("legacy project ids are: %v", envDecoder.LegacyProjectIDs)
+
 	db, err := adapter.New(&envDecoder.DBConf)
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): cleanup improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Monitor test result cleanup is global, rather than project or cluster scoped. This can lead to issues where the recommender is run for a specific project or cluster. 

## What is the new behavior?

Monitor test result cleanup should be cluster and project scoped. 

## Technical Spec/Implementation Notes
