### PR TITLE
[hotfix] Do not make context copies of DB sessions for cluster operations

### DIFF
--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"errors"
 	"io/ioutil"
+	"time"
 
 	"github.com/porter-dev/porter/internal/kubernetes"
 	"github.com/porter-dev/porter/internal/models"
@@ -26,6 +27,7 @@ type Form struct {
 	Storage                   string `json:"storage" form:"oneof=secret configmap memory" default:"secret"`
 	Namespace                 string `json:"namespace"`
 	AllowInClusterConnections bool
+	Timeout                   time.Duration // optional
 }
 
 // GetAgentOutOfClusterConfig creates a new Agent from outside the cluster using
@@ -38,6 +40,7 @@ func GetAgentOutOfClusterConfig(form *Form, l *logger.Logger) (*Agent, error) {
 		Repo:                      form.Repo,
 		DigitalOceanOAuth:         form.DigitalOceanOAuth,
 		AllowInClusterConnections: form.AllowInClusterConnections,
+		Timeout:                   form.Timeout,
 	}
 
 	k8sAgent, err := kubernetes.GetAgentOutOfClusterConfig(conf)

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -114,6 +114,7 @@ type OutOfClusterConfig struct {
 	Repo                      repository.Repository
 	DefaultNamespace          string // optional
 	AllowInClusterConnections bool
+	Timeout                   time.Duration // optional
 
 	// Only required if using DigitalOcean OAuth as an auth mechanism
 	DigitalOceanOAuth *oauth2.Config
@@ -134,6 +135,8 @@ func (conf *OutOfClusterConfig) ToRESTConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	restConf.Timeout = conf.Timeout
 
 	rest.SetKubernetesDefaults(restConf)
 	return restConf, nil

--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -175,6 +175,7 @@ func (t *helmRevisionsCountTracker) Run() error {
 					Repo:                      t.repo,
 					DigitalOceanOAuth:         t.doConf,
 					AllowInClusterConnections: false,
+					Timeout:                   5 * time.Second,
 				})
 
 				if err != nil {
@@ -198,6 +199,7 @@ func (t *helmRevisionsCountTracker) Run() error {
 						Repo:                      t.repo,
 						DigitalOceanOAuth:         t.doConf,
 						AllowInClusterConnections: false,
+						Timeout:                   5 * time.Second,
 					}, logger.New(true, os.Stdout), 3, time.Second)
 
 					if err != nil {

--- a/workers/jobs/helm_revisions_count_tracker.go
+++ b/workers/jobs/helm_revisions_count_tracker.go
@@ -46,7 +46,7 @@ import (
 	"helm.sh/helm/v3/pkg/releaseutil"
 )
 
-var stepSize int = 100
+var stepSize int = 20
 
 type helmRevisionsCountTracker struct {
 	enqueueTime        time.Time


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

For DB operations related to the cluster table (and its associates), we currently create a new DB session and add to the connection pool.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We no longer create new DB sessions in cluster operations.

## Technical Spec/Implementation Notes
