### PR TITLE
[POR-695] Add `porter stack env-group` commands

### DIFF
--- a/api/client/v1_stack.go
+++ b/api/client/v1_stack.go
@@ -44,3 +44,20 @@ func (c *Client) AddEnvGroupToStack(
 
 	return err
 }
+
+func (c *Client) RemoveEnvGroupFromStack(
+	ctx context.Context,
+	projectID, clusterID uint,
+	namespace, stackID, envGroupName string,
+) error {
+	err := c.deleteRequest(
+		fmt.Sprintf(
+			"/v1/projects/%d/clusters/%d/namespaces/%s/stacks/%s/remove_env_group/%s",
+			projectID, clusterID, namespace, stackID, envGroupName,
+		),
+		nil,
+		nil,
+	)
+
+	return err
+}

--- a/api/client/v1_stack.go
+++ b/api/client/v1_stack.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/porter-dev/porter/api/types"
+)
+
+// ListStacks retrieves the list of stacks
+func (c *Client) ListStacks(
+	ctx context.Context,
+	projectID, clusterID uint,
+	namespace string,
+) (*types.StackListResponse, error) {
+	resp := &types.StackListResponse{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/v1/projects/%d/clusters/%d/namespaces/%s/stacks",
+			projectID, clusterID, namespace,
+		),
+		nil,
+		resp,
+	)
+
+	return resp, err
+}
+
+func (c *Client) AddEnvGroupToStack(
+	ctx context.Context,
+	projectID, clusterID uint,
+	namespace, stackID string,
+	req *types.CreateStackEnvGroupRequest,
+) error {
+	err := c.patchRequest(
+		fmt.Sprintf(
+			"/v1/projects/%d/clusters/%d/namespaces/%s/stacks/%s/add_env_group",
+			projectID, clusterID, namespace, stackID,
+		),
+		req,
+		nil,
+	)
+
+	return err
+}

--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -21,21 +21,34 @@ var stackCmd = &cobra.Command{
 	Short:   "Commands that control Porter Stacks",
 }
 
-var stackAddCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Commands to add resources to a stack",
+var stackEnvGroupCmd = &cobra.Command{
+	Use:     "env-group",
+	Aliases: []string{"eg", "envgroup", "env-groups", "envgroups"},
+	Short:   "Commands to add or remove an env group in a stack",
 	Run: func(cmd *cobra.Command, args []string) {
 		color.New(color.FgRed).Println("need to specify an operation to continue")
 	},
 }
 
-var stackAddEnvGroupCmd = &cobra.Command{
-	Use:     "env-group [name]",
-	Args:    cobra.ExactArgs(1),
-	Aliases: []string{"eg", "envgroup", "env-groups", "envgroups"},
-	Short:   "Add an env group to a stack",
+var stackEnvGroupAddCmd = &cobra.Command{
+	Use:   "add [name]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Add an env group to a stack",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := checkLoginAndRun(args, stackAddEnvGroup)
+
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+var stackEnvGroupRemoveCmd = &cobra.Command{
+	Use:   "remove [name]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Remove an existing env group from a stack",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := checkLoginAndRun(args, stackRemoveEnvGroup)
 
 		if err != nil {
 			os.Exit(1)
@@ -46,23 +59,23 @@ var stackAddEnvGroupCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(stackCmd)
 
-	stackCmd.AddCommand(stackAddCmd)
+	stackCmd.AddCommand(stackEnvGroupCmd)
 
-	stackAddCmd.PersistentFlags().StringVar(
+	stackCmd.PersistentFlags().StringVar(
 		&name,
 		"name",
 		"",
 		"the name of the stack",
 	)
 
-	stackAddCmd.PersistentFlags().StringVar(
+	stackCmd.PersistentFlags().StringVar(
 		&namespace,
 		"namespace",
 		"default",
 		"the namespace of the stack",
 	)
 
-	stackAddEnvGroupCmd.PersistentFlags().StringArrayVarP(
+	stackEnvGroupAddCmd.PersistentFlags().StringArrayVarP(
 		&normalEnvGroupVars,
 		"normal",
 		"n",
@@ -70,7 +83,7 @@ func init() {
 		"list of variables to set, in the form VAR=VALUE",
 	)
 
-	stackAddEnvGroupCmd.PersistentFlags().StringArrayVarP(
+	stackEnvGroupAddCmd.PersistentFlags().StringArrayVarP(
 		&secretEnvGroupVars,
 		"secret",
 		"s",
@@ -78,14 +91,15 @@ func init() {
 		"list of secret variables to set, in the form VAR=VALUE",
 	)
 
-	stackAddEnvGroupCmd.PersistentFlags().StringArrayVar(
+	stackEnvGroupAddCmd.PersistentFlags().StringArrayVar(
 		&linkedApps,
 		"linked-apps",
 		[]string{},
 		"list of stack apps to link this env group with",
 	)
 
-	stackAddCmd.AddCommand(stackAddEnvGroupCmd)
+	stackEnvGroupCmd.AddCommand(stackEnvGroupAddCmd)
+	stackEnvGroupCmd.AddCommand(stackEnvGroupRemoveCmd)
 }
 
 func stackAddEnvGroup(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
@@ -157,6 +171,47 @@ func stackAddEnvGroup(_ *types.GetAuthenticatedUserResponse, client *api.Client,
 	}
 
 	color.New(color.FgGreen).Println("successfully added env group")
+
+	return nil
+}
+
+func stackRemoveEnvGroup(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+	envGroupName := args[0]
+
+	if len(envGroupName) == 0 {
+		return fmt.Errorf("empty env group name")
+	} else if len(name) == 0 {
+		return fmt.Errorf("empty stack name")
+	}
+
+	listStacks, err := client.ListStacks(context.Background(), cliConf.Project, cliConf.Cluster, namespace)
+
+	if err != nil {
+		return err
+	}
+
+	stacks := *listStacks
+
+	var stackID string
+
+	for _, stk := range stacks {
+		if stk.Name == name {
+			stackID = stk.ID
+		}
+	}
+
+	if len(stackID) == 0 {
+		return fmt.Errorf("stack not found")
+	}
+
+	err = client.RemoveEnvGroupFromStack(context.Background(), cliConf.Project, cliConf.Cluster, namespace, stackID,
+		envGroupName)
+
+	if err != nil {
+		return err
+	}
+
+	color.New(color.FgGreen).Println("successfully removed env group")
 
 	return nil
 }

--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/spf13/cobra"
+)
+
+var linkedApps []string
+
+// stackCmd represents the "porter stack" base command when called
+// without any subcommands
+var stackCmd = &cobra.Command{
+	Use:     "stack",
+	Aliases: []string{"stacks"},
+	Short:   "Commands that control Porter Stacks",
+}
+
+var stackAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Commands to add resources to a stack",
+	Run: func(cmd *cobra.Command, args []string) {
+		color.New(color.FgRed).Println("need to specify an operation to continue")
+	},
+}
+
+var stackAddEnvGroupCmd = &cobra.Command{
+	Use:     "env-group [name]",
+	Args:    cobra.ExactArgs(1),
+	Aliases: []string{"eg", "envgroup", "env-groups", "envgroups"},
+	Short:   "Add an env group to a stack",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := checkLoginAndRun(args, stackAddEnvGroup)
+
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stackCmd)
+
+	stackCmd.AddCommand(stackAddCmd)
+
+	stackAddCmd.PersistentFlags().StringVar(
+		&name,
+		"name",
+		"",
+		"the name of the stack",
+	)
+
+	stackAddCmd.PersistentFlags().StringVar(
+		&namespace,
+		"namespace",
+		"default",
+		"the namespace of the stack",
+	)
+
+	stackAddEnvGroupCmd.PersistentFlags().StringArrayVarP(
+		&normalEnvGroupVars,
+		"normal",
+		"n",
+		[]string{},
+		"list of variables to set, in the form VAR=VALUE",
+	)
+
+	stackAddEnvGroupCmd.PersistentFlags().StringArrayVarP(
+		&secretEnvGroupVars,
+		"secret",
+		"s",
+		[]string{},
+		"list of secret variables to set, in the form VAR=VALUE",
+	)
+
+	stackAddEnvGroupCmd.PersistentFlags().StringArrayVar(
+		&linkedApps,
+		"linked-apps",
+		[]string{},
+		"list of stack apps to link this env group with",
+	)
+
+	stackAddCmd.AddCommand(stackAddEnvGroupCmd)
+}
+
+func stackAddEnvGroup(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
+	envGroupName := args[0]
+
+	if len(envGroupName) == 0 {
+		return fmt.Errorf("empty env group name")
+	} else if len(name) == 0 {
+		return fmt.Errorf("empty stack name")
+	} else if len(normalEnvGroupVars) == 0 && len(secretEnvGroupVars) == 0 {
+		return fmt.Errorf("one or more variables are required to create the env group")
+	}
+
+	listStacks, err := client.ListStacks(context.Background(), cliConf.Project, cliConf.Cluster, namespace)
+
+	if err != nil {
+		return err
+	}
+
+	stacks := *listStacks
+
+	var stackID string
+
+	for _, stk := range stacks {
+		if stk.Name == name {
+			stackID = stk.ID
+		}
+	}
+
+	if len(stackID) == 0 {
+		return fmt.Errorf("stack not found")
+	}
+
+	normalVariables := make(map[string]string)
+	secretVariables := make(map[string]string)
+
+	for _, v := range normalEnvGroupVars {
+		key, val, err := validateVarValue(v)
+
+		if err != nil {
+			return err
+		}
+
+		normalVariables[key] = val
+	}
+
+	for _, v := range secretEnvGroupVars {
+		key, val, err := validateVarValue(v)
+
+		if err != nil {
+			return err
+		}
+
+		secretVariables[key] = val
+	}
+
+	err = client.AddEnvGroupToStack(
+		context.Background(), cliConf.Project, cliConf.Cluster, namespace, stackID,
+		&types.CreateStackEnvGroupRequest{
+			Name:               envGroupName,
+			Variables:          normalVariables,
+			SecretVariables:    secretVariables,
+			LinkedApplications: linkedApps,
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	color.New(color.FgGreen).Println("successfully added env group")
+
+	return nil
+}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR adds the `porter stack env-group` commands to add or remove an env group in a stack.

## Technical Spec/Implementation Notes
