### PR TITLE
add support for registry-only and repo-only source selector on launch

### DIFF
--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -367,6 +367,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
       return (
         <SourcePage
           sourceType={sourceType}
+          hasSource={form.hasSource}
           setSourceType={setSourceType}
           templateName={templateName}
           setPage={setCurrentPage}

--- a/dashboard/src/main/home/launch/launch-flow/SourcePage.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/SourcePage.tsx
@@ -27,6 +27,8 @@ type PropsType = RouteComponentProps & {
   imageTag: string;
   setImageTag: (x: string) => void;
 
+  hasSource?: string;
+
   actionConfig: ActionConfigType;
   setActionConfig: (
     x: ActionConfigType | ((prevState: ActionConfigType) => ActionConfigType)
@@ -55,17 +57,18 @@ const defaultActionConfig: ActionConfigType = {
   image_repo_uri: "",
   git_branch: "",
   git_repo_id: 0,
+  kind: "github",
 };
 
 class SourcePage extends Component<PropsType, StateType> {
   renderSourceSelector = () => {
     let { capabilities, setCurrentModal } = this.context;
-    let { sourceType, setSourceType } = this.props;
+    let { sourceType, setSourceType, hasSource } = this.props;
 
     if (sourceType === "") {
       return (
         <BlockList>
-          {capabilities.github || capabilities.gitlab ? (
+          {(capabilities.github || capabilities.gitlab) && hasSource !== "registry-only" && (
             <Block onClick={() => setSourceType("repo")}>
               <BlockIcon src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png" />
               <BlockTitle>Git repository</BlockTitle>
@@ -73,14 +76,16 @@ class SourcePage extends Component<PropsType, StateType> {
                 Deploy using source from a Git repo.
               </BlockDescription>
             </Block>
-          ) : null}
-          <Block onClick={() => setSourceType("registry")}>
-            <BlockIcon src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/97_Docker_logo_logos-512.png" />
-            <BlockTitle>Docker registry</BlockTitle>
-            <BlockDescription>
-              Deploy a container from an image registry.
-            </BlockDescription>
-          </Block>
+          )}
+          {hasSource !== "repo-only" && (
+            <Block onClick={() => setSourceType("registry")}>
+              <BlockIcon src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/97_Docker_logo_logos-512.png" />
+              <BlockTitle>Docker registry</BlockTitle>
+              <BlockDescription>
+                Deploy a container from an image registry.
+              </BlockDescription>
+            </Block>
+          )}
         </BlockList>
       );
     }

--- a/dashboard/src/main/home/launch/launch-flow/SourcePage.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/SourcePage.tsx
@@ -68,15 +68,16 @@ class SourcePage extends Component<PropsType, StateType> {
     if (sourceType === "") {
       return (
         <BlockList>
-          {(capabilities.github || capabilities.gitlab) && hasSource !== "registry-only" && (
-            <Block onClick={() => setSourceType("repo")}>
-              <BlockIcon src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png" />
-              <BlockTitle>Git repository</BlockTitle>
-              <BlockDescription>
-                Deploy using source from a Git repo.
-              </BlockDescription>
-            </Block>
-          )}
+          {(capabilities.github || capabilities.gitlab) &&
+            hasSource !== "registry-only" && (
+              <Block onClick={() => setSourceType("repo")}>
+                <BlockIcon src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png" />
+                <BlockTitle>Git repository</BlockTitle>
+                <BlockDescription>
+                  Deploy using source from a Git repo.
+                </BlockDescription>
+              </Block>
+            )}
           {hasSource !== "repo-only" && (
             <Block onClick={() => setSourceType("registry")}>
               <BlockIcon src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/97_Docker_logo_logos-512.png" />

--- a/dashboard/src/main/home/new-project/NewProject.tsx
+++ b/dashboard/src/main/home/new-project/NewProject.tsx
@@ -24,9 +24,14 @@ type ValidationError = {
 };
 
 export const NewProjectFC = () => {
-  const { user, setProjects, setCurrentProject, canCreateProject, projects, capabilities } = useContext(
-    Context
-  );
+  const {
+    user,
+    setProjects,
+    setCurrentProject,
+    canCreateProject,
+    projects,
+    capabilities,
+  } = useContext(Context);
   const { pushFiltered } = useRouting();
   const [buttonStatus, setButtonStatus] = useState("");
   const [name, setName] = useState("");
@@ -105,7 +110,7 @@ export const NewProjectFC = () => {
 
   const renderContents = () => {
     let version = capabilities?.version;
-    alert(user.email)
+    alert(user.email);
     if (version !== "production" || user.email === "support@porter.run") {
       return (
         <>
@@ -134,7 +139,9 @@ export const NewProjectFC = () => {
             <InputWrapper>
               <ProjectIcon>
                 <ProjectImage src={gradient} />
-                <Letter>{name ? name.toUpperCase().substring(0, 1) : "-"}</Letter>
+                <Letter>
+                  {name ? name.toUpperCase().substring(0, 1) : "-"}
+                </Letter>
               </ProjectIcon>
               <InputRow
                 type="string"
@@ -161,13 +168,11 @@ export const NewProjectFC = () => {
             />
           </SlideWrapper>
         </>
-      )
+      );
     } else {
-      return (
-        <WelcomeForm />
-      )
+      return <WelcomeForm />;
     }
-  }
+  };
 
   return (
     <Wrapper>

--- a/dashboard/src/main/home/new-project/WelcomeForm.tsx
+++ b/dashboard/src/main/home/new-project/WelcomeForm.tsx
@@ -14,30 +14,37 @@ const WelcomeForm = (props: any) => {
 
   const encode = (data: any) => {
     return Object.keys(data)
-        .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
-        .join("&");
-  }
+      .map(
+        (key) => encodeURIComponent(key) + "=" + encodeURIComponent(data[key])
+      )
+      .join("&");
+  };
 
   const submitForm = (e: any) => {
     fetch("/", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: encode({ "form-name": "demo", email, company, "website": companySite})
+      body: encode({
+        "form-name": "demo",
+        email,
+        company,
+        website: companySite,
+      }),
     })
       .then(() => {
-        setIsDone(true)
+        setIsDone(true);
         axios.post(
           process.env.DISCORD_WEBHOOK_URL,
           {
             username: "Demo Request",
-            content: `**${email}** from **${company}** (website: ${companySite})`
+            content: `**${email}** from **${company}** (website: ${companySite})`,
           },
           {
             headers: {
-              'Content-Type': 'application/json'
-            }
+              "Content-Type": "application/json",
+            },
           }
-        )
+        );
 
         axios.get(process.env.ZAPIER_WEBHOOK_URL, {
           params: {
@@ -45,10 +52,10 @@ const WelcomeForm = (props: any) => {
             isCompany: true,
             company: `${company} - ${companySite}`,
             role: "**Requesting Demo**",
-          }
-        })
+          },
+        });
       })
-      .catch(error => alert(error));
+      .catch((error) => alert(error));
 
     e.preventDefault();
   };
@@ -63,52 +70,50 @@ const WelcomeForm = (props: any) => {
       onExited={() => setActive(false)}
     >
       <StyledWelcomeForm>
-        {
-          isDone ? (
-            <div>
-              <Title>Your response has been recorded.</Title>
-              <Subtitle>We'll be in touch shortly!</Subtitle>
-            </div>
-          ) : (
-            <form name="demo" onSubmit={submitForm}>
-              <Title>Book a Demo</Title>
-              <Subtitle>Just two things and we'll be in touch.</Subtitle>
-              <SubtitleAlt>
-                <Num>1</Num> What is your work email? *
-              </SubtitleAlt>
-              <Input
-                type="email"
-                placeholder="ex: sophon@acme.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
-              <SubtitleAlt>
-                <Num>2</Num> What is your company name? *
-              </SubtitleAlt>
-              <Input
-                type="text"
-                placeholder="ex: Acme"
-                value={company}
-                onChange={(e) => setCompany(e.target.value)}
-              />
-              <SubtitleAlt>
-                <Num>3</Num> What is your company website? *
-              </SubtitleAlt>
-              <Input
-                type="text"
-                name="website"
-                placeholder="ex: https://acme.com"
-                value={companySite}
-                onChange={(e) => setCompanySite(e.target.value)}
-              />
-              <Submit
-                type="submit"
-                value="Done"
-                disabled={!company || !email || !companySite}
-              />
-            </form>
-          )
-        }
+        {isDone ? (
+          <div>
+            <Title>Your response has been recorded.</Title>
+            <Subtitle>We'll be in touch shortly!</Subtitle>
+          </div>
+        ) : (
+          <form name="demo" onSubmit={submitForm}>
+            <Title>Book a Demo</Title>
+            <Subtitle>Just two things and we'll be in touch.</Subtitle>
+            <SubtitleAlt>
+              <Num>1</Num> What is your work email? *
+            </SubtitleAlt>
+            <Input
+              type="email"
+              placeholder="ex: sophon@acme.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <SubtitleAlt>
+              <Num>2</Num> What is your company name? *
+            </SubtitleAlt>
+            <Input
+              type="text"
+              placeholder="ex: Acme"
+              value={company}
+              onChange={(e) => setCompany(e.target.value)}
+            />
+            <SubtitleAlt>
+              <Num>3</Num> What is your company website? *
+            </SubtitleAlt>
+            <Input
+              type="text"
+              name="website"
+              placeholder="ex: https://acme.com"
+              value={companySite}
+              onChange={(e) => setCompanySite(e.target.value)}
+            />
+            <Submit
+              type="submit"
+              value="Done"
+              disabled={!company || !email || !companySite}
+            />
+          </form>
+        )}
       </StyledWelcomeForm>
     </CSSTransition>
   );

--- a/dashboard/src/main/home/project-settings/InviteList.tsx
+++ b/dashboard/src/main/home/project-settings/InviteList.tsx
@@ -72,7 +72,9 @@ const InvitePage: React.FunctionComponent<Props> = ({}) => {
           id: currentProject?.id,
         }
       );
-      invites = response.data.filter((i: InviteType) => !i.accepted && i.email !== "support@porter.run");
+      invites = response.data.filter(
+        (i: InviteType) => !i.accepted && i.email !== "support@porter.run"
+      );
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently source selector always renders repo and registry options.

## What is the new behavior?

Allow user to specify repo or registry source only based on helm chart

## Technical Spec/Implementation Notes
