### PR TITLE
[POR-716] Prepend the CNB launcher when using `porter run` for a buildpacks release

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -111,10 +111,30 @@ func init() {
 }
 
 func run(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []string) error {
-	color.New(color.FgGreen).Println("Running", strings.Join(args[1:], " "), "for release", args[0])
+	execArgs := args[1:]
+
+	color.New(color.FgGreen).Println("Running", strings.Join(execArgs, " "), "for release", args[0])
 
 	if nonInteractive {
 		color.New(color.FgBlue).Println("Using non-interactive mode. The first available pod will be used to run the command.")
+	}
+
+	if len(execArgs) > 0 {
+		release, err := client.GetRelease(
+			context.Background(), cliConf.Project, cliConf.Cluster, namespace, args[0],
+		)
+
+		if err != nil {
+			return fmt.Errorf("error fetching release %s: %w", args[0], err)
+		}
+
+		if release.BuildConfig != nil &&
+			strings.Contains(release.BuildConfig.Builder, "heroku") &&
+			execArgs[0] != "/cnb/lifecycle/launcher" &&
+			execArgs[0] != "launcher" {
+			// this is a buildpacks release using a heroku builder, prepend the launcher
+			execArgs = append([]string{"/cnb/lifecycle/launcher"}, execArgs...)
+		}
 	}
 
 	podsSimple, err := getPods(client, namespace, args[0])
@@ -202,10 +222,10 @@ func run(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []strin
 	}
 
 	if existingPod {
-		return executeRun(config, namespace, selectedPod.Name, selectedContainerName, args[1:])
+		return executeRun(config, namespace, selectedPod.Name, selectedContainerName, execArgs)
 	}
 
-	return executeRunEphemeral(config, namespace, selectedPod.Name, selectedContainerName, args[1:])
+	return executeRunEphemeral(config, namespace, selectedPod.Name, selectedContainerName, execArgs)
 }
 
 func cleanup(_ *types.GetAuthenticatedUserResponse, client *api.Client, _ []string) error {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -129,6 +129,8 @@ func run(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []strin
 		}
 
 		if release.BuildConfig != nil &&
+			(strings.Contains(release.BuildConfig.Builder, "heroku") ||
+				strings.Contains(release.BuildConfig.Builder, "paketo")) &&
 			execArgs[0] != "/cnb/lifecycle/launcher" &&
 			execArgs[0] != "launcher" {
 			// this is a buildpacks release using a heroku builder, prepend the launcher

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -129,7 +129,6 @@ func run(_ *types.GetAuthenticatedUserResponse, client *api.Client, args []strin
 		}
 
 		if release.BuildConfig != nil &&
-			strings.Contains(release.BuildConfig.Builder, "heroku") &&
 			execArgs[0] != "/cnb/lifecycle/launcher" &&
 			execArgs[0] != "launcher" {
 			// this is a buildpacks release using a heroku builder, prepend the launcher


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now users might be unaware of the fact that a buildpacks release needs the CNB launcher prepended to any command in order to initialise the PATH.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR checks if a release is buildpacks and prepends the CNB launcher to a `porter run` command if need be.

## Technical Spec/Implementation Notes
