### PR TITLE
Hide forked loki chart from addons

### DIFF
--- a/dashboard/src/main/home/launch/Launch.tsx
+++ b/dashboard/src/main/home/launch/Launch.tsx
@@ -28,7 +28,7 @@ type TabOption = {
   value: string;
 };
 
-const HIDDEN_CHARTS = ["porter-agent"];
+const HIDDEN_CHARTS = ["porter-agent", "loki"];
 
 type PropsType = RouteComponentProps & {};
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): hide system component

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

New loki chart will show on community addons. 

## What is the new behavior?

Hide loki chart on community addons. 

## Technical Spec/Implementation Notes
