### PR TITLE
Fix ANSI rendering on new logging component

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
@@ -193,17 +193,22 @@ const LogsSection: React.FC<Props> = ({
           <span className="line-timestamp">
             {dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss")}
           </span>
-          {log.line?.map((ansi, j) => {
-            if (ansi.clearLine) {
-              return null;
-            }
+          <LogOuter>
+            {log.line?.map((ansi, j) => {
+              if (ansi.clearLine) {
+                return null;
+              }
 
-            return (
-              <LogSpan key={[log.lineNumber, i, j].join(".")} ansi={ansi}>
-                {ansi.content.replace(/ /g, "\u00a0")}
-              </LogSpan>
-            );
-          })}
+              return (
+                <LogInnerSpan
+                  key={[log.lineNumber, i, j].join(".")}
+                  ansi={ansi}
+                >
+                  {ansi.content.replace(/ /g, "\u00a0")}
+                </LogInnerSpan>
+              );
+            })}
+          </LogOuter>
         </Log>
       );
     });
@@ -591,10 +596,15 @@ const Log = styled.div`
   }
 `;
 
-const LogSpan = styled.span`
+const LogOuter = styled.div`
   display: inline-block;
   word-wrap: anywhere;
   flex-grow: 1;
+  font-family: monospace, sans-serif;
+  font-size: 12px;
+`;
+
+const LogInnerSpan = styled.span`
   font-family: monospace, sans-serif;
   font-size: 12px;
   font-weight: ${(props: { ansi: Anser.AnserJsonEntry }) =>

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
@@ -193,7 +193,7 @@ const LogsSection: React.FC<Props> = ({
           <span className="line-timestamp">
             {dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss")}
           </span>
-          <LogOuter>
+          <LogOuter key={[log.lineNumber, i].join(".")}>
             {log.line?.map((ansi, j) => {
               if (ansi.clearLine) {
                 return null;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

ANSI escape sequences are currently split into separate `inline-block` elements. 

## What is the new behavior?

Place lines on a single line, split ANSI sequences with whitespace rather than newlines. 

## Technical Spec/Implementation Notes
