### PR TITLE
Add timeout and discovery check for recommender system

### DIFF
--- a/workers/jobs/recommender.go
+++ b/workers/jobs/recommender.go
@@ -204,6 +204,7 @@ func (n *recommender) Run() error {
 			Repo:                      n.repo,
 			DigitalOceanOAuth:         n.doConf,
 			AllowInClusterConnections: false,
+			Timeout:                   5 * time.Second,
 		})
 
 		if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Recommender system is slowed down significantly by 32 second client timeout and lack of a discovery check for queries.

## What is the new behavior?

Add an initial discovery check to limit disconnected cluster failures to 5 seconds. 

## Technical Spec/Implementation Notes
