### PR TITLE
Hotfix resource mapping case for Helm upgrades

### DIFF
--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -290,7 +290,7 @@ func (a *Agent) UpgradeReleaseByValues(
 					return nil, fmt.Errorf("another operation (install/upgrade/rollback) is in progress. If this error persists, please wait for 60 seconds to force an upgrade")
 				}
 			}
-		} else if strings.Contains(err.Error(), "current release manifest contains removed kubernetes api(s)") {
+		} else if strings.Contains(err.Error(), "current release manifest contains removed kubernetes api(s)") || strings.Contains(err.Error(), "resource mapping not found for name") {
 			// ref: https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest
 			// in this case, we manually update the secret containing the new manifests
 			secretList, err := a.K8sAgent.Clientset.CoreV1().Secrets(rel.Namespace).List(

--- a/internal/notifier/sendgrid/incident_notifier.go
+++ b/internal/notifier/sendgrid/incident_notifier.go
@@ -2,6 +2,7 @@ package sendgrid
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/porter-dev/porter/api/types"
 	"github.com/porter-dev/porter/internal/models"
@@ -31,10 +32,16 @@ func (s *IncidentNotifier) NotifyNew(incident *types.Incident, url string) error
 
 	personalizations := make([]*mail.Personalization, 0)
 
+	resourceKind := "application"
+
+	if strings.ToLower(string(incident.InvolvedObjectKind)) == "job" {
+		resourceKind = "job"
+	}
+
 	templData := map[string]interface{}{
 		"incident_text": incident.Summary,
 		"app_url":       url,
-		"subject":       fmt.Sprintf("Your application %s crashed on Porter", incident.ReleaseName),
+		"subject":       fmt.Sprintf("Your %s %s crashed on Porter", resourceKind, incident.ReleaseName),
 		"preheader":     incident.Summary,
 		"created_at":    fmt.Sprintf("%s", incident.CreatedAt.Format("Jan 2, 2006 at 3:04pm (MST)")),
 	}

--- a/internal/notifier/slack/incident_notifier.go
+++ b/internal/notifier/slack/incident_notifier.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/porter-dev/porter/api/types"
@@ -24,8 +25,15 @@ func NewIncidentNotifier(slackInts ...*integrations.SlackIntegration) *IncidentN
 func (s *IncidentNotifier) NotifyNew(incident *types.Incident, url string) error {
 	res := []*SlackBlock{}
 
+	resourceKind := "application"
+
+	if strings.ToLower(string(incident.InvolvedObjectKind)) == "job" {
+		resourceKind = "job"
+	}
+
 	topSectionMarkdwn := fmt.Sprintf(
-		":warning: Your application %s crashed on Porter. <%s|View the incident.>",
+		":warning: Your %s %s crashed on Porter. <%s|View the incident.>",
+		resourceKind,
 		"`"+incident.ReleaseName+"`",
 		url,
 	)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Newer helm package can sometimes throw `resource mapping not found for name`, which was previously matched only by `current release manifest contains removed kubernetes api(s)`.  

## What is the new behavior?

Add casing for both so template upgrades are successful. 

## Technical Spec/Implementation Notes
