### PR TITLE
AWS c6i instances for EKS system nodes

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -604,8 +604,22 @@ tabs:
           value: t3.xlarge
         - label: t3.2xlarge
           value: t3.2xlarge
+        - label: c6i.large
+          value: c6i.large
+        - label: c6i.xlarge
+          value: c6i.xlarge
         - label: c6i.2xlarge
           value: c6i.2xlarge
+        - label: c6i.4xlarge
+          value: c6i.4xlarge
+        - label: m6i.large
+          value: m6i.large
+        - label: m6i.xlarge
+          value: m6i.xlarge
+        - label: m6i.2xlarge
+          value: m6i.2xlarge
+        - label: m6i.4xlarge
+          value: m6i.4xlarge
   - name: spot_instance_should_enable
     contents:
     - type: heading

--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -612,14 +612,6 @@ tabs:
           value: c6i.2xlarge
         - label: c6i.4xlarge
           value: c6i.4xlarge
-        - label: m6i.large
-          value: m6i.large
-        - label: m6i.xlarge
-          value: m6i.xlarge
-        - label: m6i.2xlarge
-          value: m6i.2xlarge
-        - label: m6i.4xlarge
-          value: m6i.4xlarge
   - name: spot_instance_should_enable
     contents:
     - type: heading


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A


-->
System nodes on EKS only allow for `c6i.2xlarge` instances. An inadvertent oversight in #2510 meant that additional `c6i` instances were not added to the dashboard.
## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
We now support the following instance types in the `c6i` class for system nodes:
1. `c6i.large`
2. `c6i.xlarge`
3. `c6i.2xlarge`
4. `c6i.4xlarge`
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
