### PR TITLE
Change provisioned EKS default to `1.22`

### DIFF
--- a/api/server/handlers/infra/forms.go
+++ b/api/server/handlers/infra/forms.go
@@ -436,7 +436,7 @@ tabs:
       label: EKS control plane version
       variable: cluster_version
       settings:
-        default: "1.20"
+        default: "1.22"
         options:
         - label: "1.20"
           value: "1.20"


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): version bump

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Default EKS version is 1.22. 

## What is the new behavior?

Default EKS version should be 1.20. 

## Technical Spec/Implementation Notes
