### PR TITLE
[hotfix] Emit kubeconfig information from CLI to stderr

### DIFF
--- a/api/client/k8s.go
+++ b/api/client/k8s.go
@@ -64,7 +64,7 @@ func (c *Client) GetKubeconfig(
 	resp := &types.GetTemporaryKubeconfigResponse{}
 
 	if localKubeconfigPath != "" {
-		color.New(color.FgBlue).Printf("using local kubeconfig: %s\n", localKubeconfigPath)
+		color.New(color.FgBlue).Fprintf(os.Stderr, "using local kubeconfig: %s\n", localKubeconfigPath)
 
 		if _, err := os.Stat(localKubeconfigPath); !os.IsNotExist(err) {
 			file, err := os.Open(localKubeconfigPath)
@@ -85,7 +85,7 @@ func (c *Client) GetKubeconfig(
 		}
 	}
 
-	color.New(color.FgBlue).Println("using remote kubeconfig")
+	color.New(color.FgBlue).Fprintln(os.Stderr, "using remote kubeconfig")
 
 	err := c.getRequest(
 		fmt.Sprintf(

--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -26,7 +26,7 @@ var stackEnvGroupCmd = &cobra.Command{
 	Aliases: []string{"eg", "envgroup", "env-groups", "envgroups"},
 	Short:   "Commands to add or remove an env group in a stack",
 	Run: func(cmd *cobra.Command, args []string) {
-		color.New(color.FgRed).Println("need to specify an operation to continue")
+		color.New(color.FgRed).Fprintln(os.Stderr, "need to specify an operation to continue")
 	},
 }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

Right now the kubeconfig information is printed to stdout which leads to `porter kubectl` and `porter helm` when using the `-o json` parameter may break json parsing with a tool like `jq`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Emit the kubeconfig information to stderr to fix this.

## Technical Spec/Implementation Notes

Resolves https://github.com/porter-dev/porter/issues/2532