### PR TITLE
Update OPA queries and add more workload checks

### DIFF
--- a/internal/opa/config.yaml
+++ b/internal/opa/config.yaml
@@ -56,7 +56,7 @@ prometheus:
     name: "prometheus.version"
 nginx_pod:
   kind: "pod"
-  overrideSeverity: "critical"
+  override_severity: "critical"
   match:
     namespace: ingress-nginx
     labels:
@@ -68,6 +68,7 @@ nginx_pod:
     name: "pod.running"
 prometheus_server_pod:
   kind: "pod"
+  override_severity: "critical"
   match:
     namespace: monitoring
     labels:
@@ -146,6 +147,7 @@ node:
 descheduler:
   kind: "helm_release"
   match:
+    kubernetes_service: eks
     name: descheduler
     namespace: kube-system
   mustExist: true
@@ -153,7 +155,38 @@ descheduler:
 vpa:
   kind: "helm_release"
   match:
+    kubernetes_service: eks
     name: vpa
     namespace: kube-system
   mustExist: true
   policies: []
+coredns:
+  kind: "pod"
+  match:
+    kubernetes_service: eks
+    namespace: kube-system
+    labels:
+      eks.amazonaws.com/component: "coredns"
+  policies:
+  - path: "./policies/pod/running.rego"
+    name: "pod.running"
+cluster_autoscaler:
+  kind: "pod"
+  match:
+    kubernetes_service: eks
+    namespace: kube-system
+    labels:
+      app.kubernetes.io/name: "aws-cluster-autoscaler"
+  policies:
+  - path: "./policies/pod/running.rego"
+    name: "pod.running"
+load_balancer_controller:
+  kind: "pod"
+  match:
+    kubernetes_service: eks
+    namespace: kube-system
+    labels:
+      app.kubernetes.io/name: "aws-load-balancer-controller"
+  policies:
+  - path: "./policies/pod/running.rego"
+    name: "pod.running"

--- a/internal/opa/loader.go
+++ b/internal/opa/loader.go
@@ -16,7 +16,7 @@ type ConfigFilePolicyCollection struct {
 	Kind             string             `json:"kind"`
 	Match            MatchParameters    `json:"match"`
 	MustExist        bool               `json:"mustExist"`
-	OverrideSeverity string             `json:"overrideSeverity"`
+	OverrideSeverity string             `json:"override_severity"`
 	Policies         []ConfigFilePolicy `json:"policies"`
 }
 

--- a/workers/jobs/recommender.go
+++ b/workers/jobs/recommender.go
@@ -224,7 +224,7 @@ func (n *recommender) Run() error {
 			continue
 		}
 
-		runner := opa.NewRunner(n.policies, k8sAgent, dynamicClient)
+		runner := opa.NewRunner(n.policies, cluster, k8sAgent, dynamicClient)
 
 		queryResults, err := runner.GetRecommendations(n.categories)
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Other (please describe): monitoring enhancement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

- Crashing prometheus instance is only considered `High` severity
- No checks for coredns, LB controller, or cluster-autoscaler

## What is the new behavior?

- Bump severity of crashing prometheus instance to `Critical` 
- Add checks for coredns, LB controller, and cluster-autoscaler
- Add option to select a specific Kubernetes service (EKS, GKE) for certain checks

## Technical Spec/Implementation Notes
