### PR TITLE
Get rid of all `process.env` repo urls and replace with URL from metadata

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/stacks/ExpandedStack/NewAppResource/_TemplateSelector.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/stacks/ExpandedStack/NewAppResource/_TemplateSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import api from "shared/api";
 import { PorterTemplate } from "shared/types";
 import semver from "semver";
@@ -8,8 +8,11 @@ import { BackButton, Card } from "../../launch/components/styles";
 import DynamicLink from "components/DynamicLink";
 import { VersionSelector } from "../../launch/components/VersionSelector";
 import TitleSection from "components/TitleSection";
+import { Context } from "shared/Context";
 
 const TemplateSelector = () => {
+  const { capabilities } = useContext(Context);
+
   const [templates, setTemplates] = useState<PorterTemplate[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<{
     [template_name: string]: string;
@@ -23,7 +26,7 @@ const TemplateSelector = () => {
       const res = await api.getTemplates<PorterTemplate[]>(
         "<token>",
         {
-          repo_url: process.env.APPLICATION_CHART_REPO_URL,
+          repo_url: capabilities?.default_app_helm_repo_url,
         },
         {}
       );

--- a/dashboard/src/main/home/cluster-dashboard/stacks/launch/components/AddResourceButton.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/stacks/launch/components/AddResourceButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import api from "shared/api";
 import { PorterTemplate } from "shared/types";
 import semver from "semver";
@@ -8,8 +8,10 @@ import { VersionSelector } from "./VersionSelector";
 import DynamicLink from "components/DynamicLink";
 
 import styled from "styled-components";
+import { Context } from "shared/Context";
 
 export const AddResourceButton = () => {
+  const { capabilities } = useContext(Context);
   const [templates, setTemplates] = useState<PorterTemplate[]>([]);
   const [currentTemplate, setCurrentTemplate] = useState<PorterTemplate>();
   const [currentVersion, setCurrentVersion] = useState("");
@@ -19,7 +21,7 @@ export const AddResourceButton = () => {
       const res = await api.getTemplates<PorterTemplate[]>(
         "<token>",
         {
-          repo_url: process.env.APPLICATION_CHART_REPO_URL,
+          repo_url: capabilities?.default_app_helm_repo_url,
         },
         {}
       );

--- a/dashboard/src/main/home/launch/expanded-template/ExpandedTemplate.tsx
+++ b/dashboard/src/main/home/launch/expanded-template/ExpandedTemplate.tsx
@@ -75,8 +75,10 @@ export default class ExpandedTemplate extends Component<PropsType, StateType> {
     } else {
       let params =
         this.props.currentTab == "porter"
-          ? { repo_url: process.env.APPLICATION_CHART_REPO_URL }
-          : { repo_url: process.env.ADDON_CHART_REPO_URL };
+          ? { repo_url: this.context.capabilities?.default_app_helm_repo_url }
+          : {
+              repo_url: this.context.capabilities?.default_addon_helm_repo_url,
+            };
 
       api
         .getTemplateInfo("<token>", params, {

--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -130,7 +130,8 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
           cluster_id: currentCluster.id,
           namespace: selectedNamespace,
           repo_url:
-            props.currentTemplate?.repo_url || process.env.ADDON_CHART_REPO_URL,
+            props.currentTemplate?.repo_url ||
+            context.capabilities.default_addon_helm_repo_url,
         }
       )
       .then((_) => {
@@ -337,7 +338,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
           id: currentProject.id,
           cluster_id: currentCluster.id,
           namespace: selectedNamespace,
-          repo_url: process.env.APPLICATION_CHART_REPO_URL,
+          repo_url: context.capabilities?.default_app_helm_repo_url,
         }
       );
       // props.setCurrentView('cluster-dashboard');

--- a/dashboard/src/main/home/modals/UpgradeChartModal.tsx
+++ b/dashboard/src/main/home/modals/UpgradeChartModal.tsx
@@ -28,13 +28,13 @@ export default class UpgradeChartModal extends Component<PropsType, StateType> {
 
   componentDidMount() {
     // get the chart update notes from the api
-    let repoURL = process.env.ADDON_CHART_REPO_URL;
+    let repoURL = this.context.capabilities.default_addon_helm_repo_url;
     let chartName = this.props.currentChart.chart.metadata.name
       .toLowerCase()
       .trim();
 
     if (chartName == "web" || chartName == "worker" || chartName === "job") {
-      repoURL = process.env.APPLICATION_CHART_REPO_URL;
+      repoURL = this.context.capabilities?.default_app_helm_repo_url;
     }
 
     api

--- a/dashboard/src/shared/Context.tsx
+++ b/dashboard/src/shared/Context.tsx
@@ -97,6 +97,7 @@ class ContextProvider extends Component<PropsType, StateType> {
       service_account_id: -1,
       infra_id: -1,
       service: "",
+      agent_integration_enabled: false,
     },
     setCurrentCluster: (currentCluster: ClusterType, callback?: any) => {
       localStorage.setItem(


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Helm chart repo URLs are still bundled as part of the static asset builds, which can break some self-hosted instances. 

## What is the new behavior?

Replace all Helm chart repo URLs with the default URLs from metadata. 

## Technical Spec/Implementation Notes
