### PR TITLE
chore: fix logging in details tab

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -63,9 +63,9 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npx webpack-dev-server",
+    "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "build": "NODE_ENV=\"production\" webpack",
-    "build-and-analyze": "ENABLE_ANALYZER=true NODE_ENV=\"production\" webpack"
+    "build-and-analyze": "ENABLE_ANALYZER=true NODE_ENV=\"production\" ./node_modules/webpack/bin/webpack.js"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/events/EventList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/events/EventList.tsx
@@ -26,6 +26,69 @@ type Props = {
   setLogData?: (logData: InitLogData) => void;
 };
 
+interface ExpandedIncidentLogsProps {
+  logs: Log[];
+  onViewMore: () => void;
+}
+
+const ExpandedIncidentLogs = ({
+  logs,
+  onViewMore,
+}: ExpandedIncidentLogsProps) => {
+  if (!logs.length) {
+    return (
+      <LogsLoadWrapper>
+        <Loading />
+      </LogsLoadWrapper>
+    );
+  }
+
+  return (
+    <LogsSectionWrapper>
+      <StyledLogsSection>
+        {logs?.map((log, i) => {
+          return (
+            <LogSpan key={[log.lineNumber, i].join(".")}>
+              <span className="line-number">{log.lineNumber}.</span>
+              <span className="line-timestamp">
+                {dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss")}
+              </span>
+              <LogOuter key={[log.lineNumber, i].join(".")}>
+                {log.line?.map((ansi, j) => {
+                  if (ansi.clearLine) {
+                    return null;
+                  }
+
+                  return (
+                    <LogInnerSpan
+                      key={[log.lineNumber, i, j].join(".")}
+                      ansi={ansi}
+                    >
+                      {ansi.content.replace(/ /g, "\u00a0")}
+                    </LogInnerSpan>
+                  );
+                })}
+              </LogOuter>
+            </LogSpan>
+          );
+        })}
+      </StyledLogsSection>
+      <ViewLogsWrapper>
+        <DocsLink
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onViewMore();
+          }}
+        >
+          View complete log history
+          <i className="material-icons">open_in_new</i>{" "}
+        </DocsLink>
+      </ViewLogsWrapper>
+    </LogsSectionWrapper>
+  );
+};
+
 const EventList: React.FC<Props> = ({ filters, namespace, setLogData }) => {
   const { currentProject, currentCluster } = useContext(Context);
   const [events, setEvents] = useState([]);
@@ -158,54 +221,12 @@ const EventList: React.FC<Props> = ({ filters, namespace, setLogData }) => {
           <img src={document} />
           {expandedIncidentEvents[0].detail}
         </Message>
-        {logs.length ? (
-          <LogsSectionWrapper>
-            <StyledLogsSection>
-              {logs?.map((log, i) => {
-                return (
-                  <LogSpan key={[log.lineNumber, i].join(".")}>
-                    <span className="line-number">{log.lineNumber}.</span>
-                    <span className="line-timestamp">
-                      {dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss")}
-                    </span>
-                    <LogOuter key={[log.lineNumber, i].join(".")}>
-                      {log.line?.map((ansi, j) => {
-                        if (ansi.clearLine) {
-                          return null;
-                        }
-
-                        return (
-                          <LogInnerSpan
-                            key={[log.lineNumber, i, j].join(".")}
-                            ansi={ansi}
-                          >
-                            {ansi.content.replace(/ /g, "\u00a0")}
-                          </LogInnerSpan>
-                        );
-                      })}
-                    </LogOuter>
-                  </LogSpan>
-                );
-              })}
-            </StyledLogsSection>
-            <ViewLogsWrapper>
-              <DocsLink
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  redirectToLogs(expandedEvent);
-                }}
-              >
-                View complete log history
-                <i className="material-icons">open_in_new</i>{" "}
-              </DocsLink>
-            </ViewLogsWrapper>
-          </LogsSectionWrapper>
-        ) : (
-          <LogsLoadWrapper>
-            <Loading />
-          </LogsLoadWrapper>
-        )}
+        {expandedEvent.should_view_logs ? (
+          <ExpandedIncidentLogs
+            logs={logs}
+            onViewMore={() => redirectToLogs(expandedEvent)}
+          />
+        ) : null}
       </>
     );
   };

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/events/EventList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/events/EventList.tsx
@@ -171,6 +171,7 @@ const EventList: React.FC<Props> = ({ filters, namespace, setLogData }) => {
       )
       .then((res) => {
         if (!expandedEvent.should_view_logs) {
+          setExpandedIncidentEvents(res.data.events);
           return null;
         }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently, in the Event incidents tab, the logs component is shown with a loader even when the `should_show_logs` for the event is set to `false`. 

## What is the new behavior?

This PR fixes this behaviour to check on the `should_show_logs` of the event incident and show the logs section only when set to true
