### PR TITLE
Handle blue-green deployments from `LogSection` and fallback to live pods when `pod_values` fails

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
@@ -143,19 +143,24 @@ const LogsSection: React.FC<Props> = ({
       return;
     }
 
+    var filters = {
+      namespace: currentChart?.namespace,
+      revision: initData.revision ?? currentChart.version.toString(),
+      match_prefix: currentChart.name,
+    };
+
+    // if the current chart is set to a blue-green deployment, we don't set a revision, but instead
+    // we set the match prefix to the current chart and the active image tag.
+    if (currentChart.config.bluegreen?.enabled) {
+      filters.revision = null;
+      filters.match_prefix = `${currentChart.name}-${currentChart.config.bluegreen?.activeImageTag}`;
+    }
+
     api
-      .getLogPodValues(
-        "<TOKEN>",
-        {
-          namespace: currentChart?.namespace,
-          revision: initData.revision ?? currentChart.version.toString(),
-          match_prefix: currentChart.name,
-        },
-        {
-          project_id: currentProject.id,
-          cluster_id: currentCluster.id,
-        }
-      )
+      .getLogPodValues("<TOKEN>", filters, {
+        project_id: currentProject.id,
+        cluster_id: currentCluster.id,
+      })
       .then((res: any) => {
         setPodFilterOpts(_.uniq(res.data ?? []));
 

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -1041,7 +1041,7 @@ const getAllReleasePods = baseApi<
     cluster_id: number;
   }
 >("GET", (pathParams) => {
-  let { id, name, cluster_id, namespace } = pathParams;
+  const { id, name, cluster_id, namespace } = pathParams;
 
   return `/api/projects/${id}/clusters/${cluster_id}/namespaces/${namespace}/releases/${name}/0/pods/all`;
 });

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -1032,6 +1032,20 @@ const getMatchingPods = baseApi<
   return `/api/projects/${pathParams.id}/clusters/${pathParams.cluster_id}/pods`;
 });
 
+const getAllReleasePods = baseApi<
+  {},
+  {
+    id: number;
+    name: string;
+    namespace: string;
+    cluster_id: number;
+  }
+>("GET", (pathParams) => {
+  let { id, name, cluster_id, namespace } = pathParams;
+
+  return `/api/projects/${id}/clusters/${cluster_id}/namespaces/${namespace}/releases/${name}/0/pods/all`;
+});
+
 const getMetrics = baseApi<
   {
     metric: string;
@@ -2337,6 +2351,7 @@ export default {
   getJobPods,
   getPodByName,
   getMatchingPods,
+  getAllReleasePods,
   getMetrics,
   getNamespaces,
   getNGINXIngresses,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

- Blue-green deployments don't return results for `pod_values` endpoints, because they don't have revision annotations 
- When `pod_values` returns `[]`, there are still cases where the live pods have logs in loki (this frequently happens when loki/promtail have been recently installed). 

## What is the new behavior?

- Modify query when deployment is using `bluegreen` to query for the correct pod prefix, as the image tags are part of the deployment names
- Fallback to live pods list when `pod_values` returns `[]`

## Technical Spec/Implementation Notes
