### PR TITLE
[POR-791] Use correct GAR image URI during launch flow

### DIFF
--- a/api/server/router/v1/registry.go
+++ b/api/server/router/v1/registry.go
@@ -390,7 +390,7 @@ func getV1RegistryRoutes(
 	//   - name: registry_id
 	//   - name: repository
 	//     in: path
-	//     description: The image repository name
+	//     description: The image repository name. Should be of the form REPOSITORY/IMAGE when using Google Artifact Registry.
 	//     type: string
 	//     required: true
 	//   - name: num

--- a/cli/cmd/connect/gar.go
+++ b/cli/cmd/connect/gar.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/fatih/color"
@@ -23,8 +22,8 @@ func GAR(
 		return 0, fmt.Errorf("no project set, please run porter config set-project")
 	}
 
-	keyFileLocation, err := utils.PromptPlaintext(fmt.Sprintf(`Please provide the full path to a service account key file.
-Key file location: `))
+	keyFileLocation, err := utils.PromptPlaintext(`Please provide the full path to a service account key file.
+Key file location: `)
 
 	if err != nil {
 		return 0, err
@@ -33,7 +32,7 @@ Key file location: `))
 	// attempt to read the key file location
 	if info, err := os.Stat(keyFileLocation); !os.IsNotExist(err) && !info.IsDir() {
 		// read the file
-		bytes, err := ioutil.ReadFile(keyFileLocation)
+		bytes, err := os.ReadFile(keyFileLocation)
 
 		if err != nil {
 			return 0, err
@@ -54,8 +53,8 @@ Key file location: `))
 
 		color.New(color.FgGreen).Printf("created gcp integration with id %d\n", integration.ID)
 
-		region, err := utils.PromptPlaintext(fmt.Sprintf(`Please enter the artifact registry region. For example, us-central-1.
-Artifact registry region: `))
+		region, err := utils.PromptPlaintext(`Please enter the artifact registry region. For example, us-central1.
+Artifact registry region: `)
 
 		if err != nil {
 			return 0, err
@@ -63,7 +62,7 @@ Artifact registry region: `))
 
 		// create the registry
 		// query for registry name
-		regName, err := utils.PromptPlaintext(fmt.Sprintf(`Give this registry a name: `))
+		regName, err := utils.PromptPlaintext("Give this registry a name: ")
 
 		if err != nil {
 			return 0, err

--- a/dashboard/src/components/image-selector/TagList.tsx
+++ b/dashboard/src/components/image-selector/TagList.tsx
@@ -46,7 +46,13 @@ export default class TagList extends Component<PropsType, StateType> {
     const { currentProject } = this.context;
 
     let splits = this.props.selectedImageUrl.split("/");
-    let repoName = splits[splits.length - 1];
+    let repoName: string;
+
+    if (this.props.selectedImageUrl.includes("pkg.dev")) {
+      repoName = splits[splits.length - 2] + "/" + splits[splits.length - 1];
+    } else {
+      repoName = splits[splits.length - 1];
+    }
 
     let matches = this.props.selectedImageUrl.match(ecrRepoRegex);
 

--- a/dashboard/src/main/home/integrations/create-integration/GARForm.tsx
+++ b/dashboard/src/main/home/integrations/create-integration/GARForm.tsx
@@ -59,12 +59,33 @@ const GARForm = (props: { closeForm: () => void }) => {
     }
 
     try {
+      let registryURL: string;
+
+      if (integration.gcp_project_id.includes(":")) {
+        const domainProjectID = integration.gcp_project_id.split(":");
+
+        if (
+          domainProjectID.length !== 2 ||
+          domainProjectID[0].length === 0 ||
+          domainProjectID[1].length === 0
+        ) {
+          setButtonStatus(
+            "Invalid GCP project ID. Please check your credentials."
+          );
+          return;
+        }
+
+        registryURL = `${region}-docker.pkg.dev/${domainProjectID[0]}/${domainProjectID[1]}`;
+      } else {
+        registryURL = `${region}-docker.pkg.dev/${integration.gcp_project_id}`;
+      }
+
       await api.connectGCRRegistry(
         "token",
         {
           gcp_integration_id: integration.id,
           name: credentialsName,
-          url: `${region}-docker.pkg.dev/${integration.gcp_project_id}`,
+          url: registryURL,
         },
         { id: currentProject.id }
       );

--- a/dashboard/src/main/home/integrations/create-integration/GARForm.tsx
+++ b/dashboard/src/main/home/integrations/create-integration/GARForm.tsx
@@ -61,6 +61,10 @@ const GARForm = (props: { closeForm: () => void }) => {
     try {
       let registryURL: string;
 
+      // GCP project IDs can have the ':' character like example.com:my-project
+      // if this is the case then we need to case on this
+      //
+      // see: https://cloud.google.com/artifact-registry/docs/docker/names#domain
       if (integration.gcp_project_id.includes(":")) {
         const domainProjectID = integration.gcp_project_id.split(":");
 

--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -71,16 +71,16 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
   };
 
   const getFullActionConfig = (): FullActionConfigType => {
-    let imageRepoUri = `${selectedRegistry?.url}/${templateName}-${selectedNamespace}`;
+    let imageRepoURI = `${selectedRegistry?.url}/${templateName}-${selectedNamespace}`;
 
     // DockerHub registry integration is per repo
     if (selectedRegistry?.service === "dockerhub") {
-      imageRepoUri = selectedRegistry?.url;
+      imageRepoURI = selectedRegistry?.url;
     }
 
     // Customize image repo URI for GAR
-    if (imageRepoUri.includes("pkg.dev")) {
-      imageRepoUri = `${imageRepoUri}/${templateName}-${selectedNamespace}`;
+    if (imageRepoURI.includes("pkg.dev")) {
+      imageRepoURI = `${imageRepoURI}/${templateName}-${selectedNamespace}`;
     }
 
     if (actionConfig.kind === "github") {
@@ -91,7 +91,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
         registry_id: selectedRegistry?.id,
         dockerfile_path: dockerfilePath,
         folder_path: folderPath,
-        image_repo_uri: imageRepoUri,
+        image_repo_uri: imageRepoURI,
         git_repo_id: actionConfig.git_repo_id,
         should_create_workflow: shouldCreateWorkflow,
       };
@@ -103,7 +103,7 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
         registry_id: selectedRegistry?.id,
         dockerfile_path: dockerfilePath,
         folder_path: folderPath,
-        image_repo_uri: imageRepoUri,
+        image_repo_uri: imageRepoURI,
         gitlab_integration_id: actionConfig.gitlab_integration_id,
         should_create_workflow: shouldCreateWorkflow,
       };

--- a/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
+++ b/dashboard/src/main/home/launch/launch-flow/LaunchFlow.tsx
@@ -78,6 +78,11 @@ const LaunchFlow: React.FC<PropsType> = (props) => {
       imageRepoUri = selectedRegistry?.url;
     }
 
+    // Customize image repo URI for GAR
+    if (imageRepoUri.includes("pkg.dev")) {
+      imageRepoUri = `${imageRepoUri}/${templateName}-${selectedNamespace}`;
+    }
+
     if (actionConfig.kind === "github") {
       return {
         kind: "github",

--- a/dashboard/src/main/home/onboarding/steps/ConnectRegistry/forms/_GCPRegistryForm.tsx
+++ b/dashboard/src/main/home/onboarding/steps/ConnectRegistry/forms/_GCPRegistryForm.tsx
@@ -351,7 +351,7 @@ export const GARegistryConfig: React.FC<{
 
     setButtonStatus("loading");
 
-    let gcpProjectId = NaN;
+    let gcpProjectId: string;
 
     try {
       const gcp_integration = await api
@@ -375,7 +375,26 @@ export const GARegistryConfig: React.FC<{
       return;
     }
 
-    const registryUrl = `${region}-docker.pkg.dev/${gcpProjectId}`;
+    let registryURL: string;
+
+    if (gcpProjectId.includes(":")) {
+      const domainProjectID = gcpProjectId.split(":");
+
+      if (
+        domainProjectID.length !== 2 ||
+        domainProjectID[0].length === 0 ||
+        domainProjectID[1].length === 0
+      ) {
+        setButtonStatus(
+          "Invalid GCP project ID. Please check your credentials."
+        );
+        return;
+      }
+
+      registryURL = `${region}-docker.pkg.dev/${domainProjectID[0]}/${domainProjectID[1]}`;
+    } else {
+      registryURL = `${region}-docker.pkg.dev/${gcpProjectId}`;
+    }
 
     try {
       const data = await api
@@ -385,7 +404,7 @@ export const GARegistryConfig: React.FC<{
             name: registryName,
             gcp_integration_id:
               snap.StateHandler.connected_registry.credentials.id,
-            url: registryUrl,
+            url: registryURL,
           },
           {
             id: project.id,
@@ -395,7 +414,7 @@ export const GARegistryConfig: React.FC<{
       nextFormStep({
         settings: {
           registry_connection_id: data.id,
-          gcr_url: registryUrl,
+          gcr_url: registryURL,
           registry_name: registryName,
         },
       });

--- a/dashboard/src/main/home/onboarding/steps/ConnectRegistry/forms/_GCPRegistryForm.tsx
+++ b/dashboard/src/main/home/onboarding/steps/ConnectRegistry/forms/_GCPRegistryForm.tsx
@@ -377,6 +377,10 @@ export const GARegistryConfig: React.FC<{
 
     let registryURL: string;
 
+    // GCP project IDs can have the ':' character like example.com:my-project
+    // if this is the case then we need to case on this
+    //
+    // see: https://cloud.google.com/artifact-registry/docs/docker/names#domain
     if (gcpProjectId.includes(":")) {
       const domainProjectID = gcpProjectId.split(":");
 

--- a/internal/helm/postrenderer.go
+++ b/internal/helm/postrenderer.go
@@ -815,7 +815,18 @@ func getRegNameFromImageRef(image string) (string, error) {
 	if strings.Contains(domain, "docker.io") {
 		regName = "index.docker.io/" + path
 	} else if strings.Contains(domain, "pkg.dev") {
-		regName = domain + "/" + strings.Split(path, "/")[0]
+		pathSlice := strings.Split(path, "/")
+
+		// a GAR image path can either be PROJECT-ID/REPOSITORY/IMAGE or DOMAIN/PROJECT-ID/REPOSITORY/IMAGE
+		//
+		// see: https://cloud.google.com/artifact-registry/docs/docker/names#domain
+		if len(pathSlice) == 3 {
+			regName = fmt.Sprintf("%s/%s", domain, pathSlice[0])
+		} else if len(pathSlice) == 4 {
+			regName = fmt.Sprintf("%s/%s/%s", domain, pathSlice[0], pathSlice[1])
+		} else {
+			return "", fmt.Errorf("invalid GAR image: %s", image)
+		}
 	} else {
 		regName = domain
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/distribution/reference"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 
@@ -77,9 +78,9 @@ func (r *Registry) ListRepositories(
 	if r.GCPIntegrationID != 0 {
 		if strings.Contains(r.URL, "pkg.dev") {
 			return r.listGARRepositories(repo)
-		} else {
-			return r.listGCRRepositories(repo)
 		}
+
+		return r.listGCRRepositories(repo)
 	}
 
 	if r.DOIntegrationID != 0 {
@@ -241,6 +242,9 @@ func (source *garTokenSource) Token() (*oauth2.Token, error) {
 	return source.reg.GetGARToken(source.repo)
 }
 
+// GAR has the concept of a "repository" which is a collection of images, unlike ECR or others
+// where a repository is a single image. This function returns the list of fully qualified names
+// of GAR images including their repository names.
 func (r *Registry) listGARRepositories(
 	repo repository.Repository,
 ) ([]*ptypes.RegistryRepository, error) {
@@ -262,7 +266,7 @@ func (r *Registry) listGARRepositories(
 		return nil, err
 	}
 
-	var res []*ptypes.RegistryRepository
+	var repoNames []string
 	nextToken := ""
 
 	parsedURL, err := url.Parse("https://" + r.URL)
@@ -292,11 +296,7 @@ func (r *Registry) listGARRepositories(
 			repoSlice := strings.Split(resp.GetName(), "/")
 			repoName := repoSlice[len(repoSlice)-1]
 
-			res = append(res, &ptypes.RegistryRepository{
-				Name:      resp.GetName(),
-				CreatedAt: resp.GetCreateTime().AsTime(),
-				URI:       parsedURL.Host + "/" + gcpInt.GCPProjectID + "/" + repoName,
-			})
+			repoNames = append(repoNames, repoName)
 		}
 
 		if it.PageInfo().Token == "" {
@@ -304,6 +304,58 @@ func (r *Registry) listGARRepositories(
 		}
 
 		nextToken = it.PageInfo().Token
+	}
+
+	svc, err := v1artifactregistry.NewService(context.Background(), option.WithTokenSource(&garTokenSource{
+		reg:  r,
+		repo: repo,
+	}), option.WithScopes("roles/artifactregistry.reader"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	resMap := make(map[string]*ptypes.RegistryRepository)
+	dockerSvc := v1artifactregistry.NewProjectsLocationsRepositoriesDockerImagesService(svc)
+
+	for _, repoName := range repoNames {
+		for {
+			resp, err := dockerSvc.List(fmt.Sprintf("projects/%s/locations/%s/repositories/%s",
+				gcpInt.GCPProjectID, location, repoName)).PageSize(1000).PageToken(nextToken).Do()
+
+			if err != nil {
+				return nil, err
+			}
+
+			for _, image := range resp.DockerImages {
+				named, err := reference.ParseNamed(image.Uri)
+
+				if err != nil {
+					// let us skip this image becaue it has a malformed URI coming from the GCP API
+					continue
+				}
+
+				uploadTime, _ := time.Parse(time.RFC3339, image.UploadTime)
+
+				resMap[named.Name()] = &ptypes.RegistryRepository{
+					Name:      repoName,
+					URI:       named.Name(),
+					CreatedAt: uploadTime,
+				}
+			}
+
+			if resp.NextPageToken == "" {
+				break
+			}
+
+			nextToken = resp.NextPageToken
+		}
+	}
+
+	var res []*ptypes.RegistryRepository
+
+	for _, v := range resMap {
+		res = append(res, v)
 	}
 
 	return res, nil
@@ -1172,6 +1224,14 @@ func (r *Registry) listGCRImages(repoName string, repo repository.Repository) ([
 }
 
 func (r *Registry) listGARImages(repoName string, repo repository.Repository) ([]*ptypes.Image, error) {
+	// FIXME: GAR implemets the repo/image scheme so we should be looking out for that
+
+	// repoImageSlice := strings.Split(repoName, "/")
+
+	// if len(repoImageSlice) != 2 {
+	// 	return nil, fmt.Errorf("invalid GAR repo name: %s", repoName)
+	// }
+
 	gcpInt, err := repo.GCPIntegration().ReadGCPIntegration(
 		r.ProjectID,
 		r.GCPIntegrationID,
@@ -1190,7 +1250,6 @@ func (r *Registry) listGARImages(repoName string, repo repository.Repository) ([
 		return nil, err
 	}
 
-	nextToken := ""
 	var res []*ptypes.Image
 
 	parsedURL, err := url.Parse("https://" + r.URL)
@@ -1200,8 +1259,8 @@ func (r *Registry) listGARImages(repoName string, repo repository.Repository) ([
 	}
 
 	location := strings.TrimSuffix(parsedURL.Host, "-docker.pkg.dev")
-
 	dockerSvc := v1artifactregistry.NewProjectsLocationsRepositoriesDockerImagesService(svc)
+	nextToken := ""
 
 	for {
 		resp, err := dockerSvc.List(fmt.Sprintf("projects/%s/locations/%s/repositories/%s",
@@ -1212,15 +1271,27 @@ func (r *Registry) listGARImages(repoName string, repo repository.Repository) ([
 		}
 
 		for _, image := range resp.DockerImages {
-			uploadTime, _ := time.Parse(time.RFC3339, image.UploadTime)
+			named, err := reference.ParseNamed(image.Uri)
 
-			for _, tag := range image.Tags {
-				res = append(res, &ptypes.Image{
-					RepositoryName: repoName,
-					Tag:            tag,
-					PushedAt:       &uploadTime,
-					Digest:         strings.Split(image.Name, "@")[1],
-				})
+			if err != nil {
+				continue
+			}
+
+			paths := strings.Split(reference.Path(named), "/")
+
+			imageName := paths[len(paths)-1]
+
+			if imageName == repoName {
+				uploadTime, _ := time.Parse(time.RFC3339, image.UploadTime)
+
+				for _, tag := range image.Tags {
+					res = append(res, &ptypes.Image{
+						RepositoryName: repoName,
+						Tag:            tag,
+						PushedAt:       &uploadTime,
+						Digest:         strings.Split(image.Uri, "@")[1],
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

When using a GAR registry, the new release image should be of the form `<region>-docker.pkg.dev/<GCP project ID>/<repo><image>`. The `porter create` command cases for this but the dashboard launch flow does not.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The dashboard launch flow cases on the image repo URI and if it belongs to a GAR registry, then it appends the `<image` part as mentioned above.

## Technical Spec/Implementation Notes
