### PR TITLE
rfac: hide rename cluster field

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/dashboard/ClusterSettings.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/dashboard/ClusterSettings.tsx
@@ -304,8 +304,9 @@ const ClusterSettings: React.FC = () => {
         <DarkMatter />
         {keyRotationSection}
         <DarkMatter />
-        {renameClusterSection}
-        <DarkMatter />
+        {/* Disabled this field due to https://discord.com/channels/542888846271184896/856554532972134420/1042497537912864788 */}
+        {/* {renameClusterSection}
+        <DarkMatter /> */}
         <Heading>Delete Cluster</Heading>
         {helperText}
         <Button


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Refactor

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

See
https://discord.com/channels/542888846271184896/856554532972134420/1042497537912864788

-->

## What is the new behavior?

This PR disables rename cluster section from the cluster settings editor to prevent users from running into bugs renaming AWS Cluster ID
