### PR TITLE
fix: check for agent addon

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/ExpandedChart.tsx
@@ -728,7 +728,11 @@ const ExpandedChart: React.FC<Props> = (props) => {
 
   // Check if porter agent is installed. If not installed hide the `Logs` component
   useEffect(() => {
-    if (!currentCluster.agent_integration_enabled) {
+    if (
+      !currentCluster.agent_integration_enabled ||
+      // If chart is an add on, we don't need to check if agent is installed
+      !["web", "worker", "job"].includes(currentChart?.chart?.metadata?.name)
+    ) {
       return;
     }
 
@@ -757,7 +761,7 @@ const ExpandedChart: React.FC<Props> = (props) => {
           );
         }
       });
-  }, []);
+  }, [currentChart]);
 
   useEffect(() => {
     if (logData.revision) {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

When clicking on an application that is an add-on, currently we try to check if agent has been installed which leads to an error since add-ons currently dont have support for events.

## What is the new behavior?

This PR skips the check for whether agent is installed on a cluster if application is an add-on