### PR TITLE
[POR-809] feat: support opening app details in new tab

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import styled from "styled-components";
 import { useHistory, useLocation, useRouteMatch } from "react-router";
 
@@ -22,6 +28,7 @@ import {
   withStyles,
 } from "@material-ui/core/styles";
 import { Link } from "react-router-dom";
+import _ from "lodash";
 
 type Props = {
   chart: ChartType;
@@ -118,7 +125,7 @@ const Chart: React.FunctionComponent<Props> = ({
     timeStyle: "long",
   });
 
-  const getExpandedChartLinkURL = () => {
+  const getExpandedChartLinkURL = useCallback(() => {
     const params = new Proxy(new URLSearchParams(window.location.search), {
       get: (searchParams, prop: string) => searchParams.get(prop),
     });
@@ -129,14 +136,18 @@ const Chart: React.FunctionComponent<Props> = ({
       chart.namespace
     }/${chart.name}`;
 
-    const newURLSearchParams = new URLSearchParams({
+    const newParams = {
       // @ts-ignore
       project_id: params.project_id,
       closeChartRedirectUrl,
-    });
+    };
+
+    const newURLSearchParams = new URLSearchParams(
+      _.omitBy(newParams, _.isNil)
+    );
 
     return `${route}?${newURLSearchParams.toString()}`;
-  };
+  }, [chart, context.currentCluster, isJob, closeChartRedirectUrl]);
 
   return (
     <Link to={getExpandedChartLinkURL}>

--- a/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/chart/Chart.tsx
@@ -21,6 +21,7 @@ import {
   MuiThemeProvider,
   withStyles,
 } from "@material-ui/core/styles";
+import { Link } from "react-router-dom";
 
 type Props = {
   chart: ChartType;
@@ -117,97 +118,110 @@ const Chart: React.FunctionComponent<Props> = ({
     timeStyle: "long",
   });
 
+  const getExpandedChartLinkURL = () => {
+    const params = new Proxy(new URLSearchParams(window.location.search), {
+      get: (searchParams, prop: string) => searchParams.get(prop),
+    });
+
+    const cluster = context.currentCluster?.name;
+
+    const route = `${isJob ? "/jobs" : "/applications"}/${cluster}/${
+      chart.namespace
+    }/${chart.name}`;
+
+    const newURLSearchParams = new URLSearchParams({
+      // @ts-ignore
+      project_id: params.project_id,
+      closeChartRedirectUrl,
+    });
+
+    return `${route}?${newURLSearchParams.toString()}`;
+  };
+
   return (
-    <StyledChart
-      onClick={() => {
-        const cluster = context.currentCluster?.name;
-        let route = `${isJob ? "/jobs" : "/applications"}/${cluster}/${
-          chart.namespace
-        }/${chart.name}`;
-        pushFiltered({ location, history }, route, ["project_id"], {
-          closeChartRedirectUrl,
-        });
-      }}
-    >
-      <Title>
-        <IconWrapper>{renderIcon()}</IconWrapper>
-        {chart.canonical_name === "" ? chart.name : chart.canonical_name}
-        {chart?.config?.description && (
-          <>
-            <Dot style={{ marginLeft: "9px", color: "#ffffff88" }}>•</Dot>
-            <MuiThemeProvider theme={theme}>
-              <Tooltip
-                TransitionComponent={Zoom}
-                placement={"bottom-start"}
-                title={
-                  <div
-                    style={{
-                      fontFamily: "Work Sans, sans-serif",
-                      fontSize: "12px",
-                      fontWeight: "normal",
-                      padding: "5px 6px",
-                      color: "#ffffffdd",
-                      lineHeight: "16px",
-                    }}
-                  >
-                    {chart.config.description as string}
-                  </div>
-                }
-              >
-                <Description>{chart.config.description}</Description>
-              </Tooltip>
-            </MuiThemeProvider>
-          </>
-        )}
-      </Title>
+    <Link to={getExpandedChartLinkURL}>
+      <StyledChart>
+        <Title>
+          <IconWrapper>{renderIcon()}</IconWrapper>
+          {chart.canonical_name === "" ? chart.name : chart.canonical_name}
+          {chart?.config?.description && (
+            <>
+              <Dot style={{ marginLeft: "9px", color: "#ffffff88" }}>•</Dot>
+              <MuiThemeProvider theme={theme}>
+                <Tooltip
+                  TransitionComponent={Zoom}
+                  placement={"bottom-start"}
+                  title={
+                    <div
+                      style={{
+                        fontFamily: "Work Sans, sans-serif",
+                        fontSize: "12px",
+                        fontWeight: "normal",
+                        padding: "5px 6px",
+                        color: "#ffffffdd",
+                        lineHeight: "16px",
+                      }}
+                    >
+                      {chart.config.description as string}
+                    </div>
+                  }
+                >
+                  <Description>{chart.config.description}</Description>
+                </Tooltip>
+              </MuiThemeProvider>
+            </>
+          )}
+        </Title>
 
-      <BottomWrapper>
-        <InfoWrapper>
-          <StatusIndicator
-            controllers={filteredControllers}
-            status={chart.info.status}
-            margin_left={"17px"}
-          />
-          <LastDeployed>
-            {jobStatus?.status ? (
-              <>
-                <Dot>•</Dot>
-                <JobStatus status={jobStatus.status}>
-                  {jobStatus.status === JobStatusType.Running
-                    ? "Started running"
-                    : `Last run ${jobStatus.status}`}{" "}
-                  at {readableDate(jobStatus.start_time)}
-                </JobStatus>
-              </>
-            ) : (
-              <>
-                <Dot>•</Dot>
-                <JobStatus>
-                  Last deployed {readableDate(chart.info.last_deployed)}
-                </JobStatus>
-              </>
-            )}
-            {chart.config?.schedule?.enabled ? (
-              <>
-                <Dot style={{ marginLeft: "10px" }}>•</Dot>
-                <JobStatus>
-                  Next run {rtf.format(interval?.next().toDate() || new Date())}
-                </JobStatus>
-              </>
-            ) : null}
-          </LastDeployed>
-        </InfoWrapper>
+        <BottomWrapper>
+          <InfoWrapper>
+            <StatusIndicator
+              controllers={filteredControllers}
+              status={chart.info.status}
+              margin_left={"17px"}
+            />
+            <LastDeployed>
+              {jobStatus?.status ? (
+                <>
+                  <Dot>•</Dot>
+                  <JobStatus status={jobStatus.status}>
+                    {jobStatus.status === JobStatusType.Running
+                      ? "Started running"
+                      : `Last run ${jobStatus.status}`}{" "}
+                    at {readableDate(jobStatus.start_time)}
+                  </JobStatus>
+                </>
+              ) : (
+                <>
+                  <Dot>•</Dot>
+                  <JobStatus>
+                    Last deployed {readableDate(chart.info.last_deployed)}
+                  </JobStatus>
+                </>
+              )}
+              {chart.config?.schedule?.enabled ? (
+                <>
+                  <Dot style={{ marginLeft: "10px" }}>•</Dot>
+                  <JobStatus>
+                    Next run{" "}
+                    {rtf.format(interval?.next().toDate() || new Date())}
+                  </JobStatus>
+                </>
+              ) : null}
+            </LastDeployed>
+          </InfoWrapper>
 
-        <TagWrapper>
-          Namespace
-          <NamespaceTag>{chart.namespace}</NamespaceTag>
-        </TagWrapper>
-      </BottomWrapper>
+          <TagWrapper>
+            Namespace
+            <NamespaceTag>{chart.namespace}</NamespaceTag>
+          </TagWrapper>
+        </BottomWrapper>
 
-      <TopRightContainer>
-        <span>v{chart.version}</span>
-      </TopRightContainer>
-    </StyledChart>
+        <TopRightContainer>
+          <span>v{chart.version}</span>
+        </TopRightContainer>
+      </StyledChart>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently the application details tab uses react-router to direct users to application details page. However, because of this, it is not possible to view the application details in a new tab

Issue Number: N/A

## What is the new behavior?

This PR allows users to open application details in new tab using a `CTRL/CMD + Click`. That way, they will be able to navigate to and open multiple tabs together>
