### PR TITLE
[POR-818] Fallback to server metadata default helm chart repos for preview env

### DIFF
--- a/api/client/base.go
+++ b/api/client/base.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"context"
+
+	sharedConfig "github.com/porter-dev/porter/api/server/shared/config"
+)
+
+func (c *Client) GetPorterInstanceMetadata(ctx context.Context) (*sharedConfig.Metadata, error) {
+	resp := &sharedConfig.Metadata{}
+
+	err := c.getRequest(
+		"/metadata",
+		nil,
+		resp,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/api/server/handlers/environment/delete.go
+++ b/api/server/handlers/environment/delete.go
@@ -79,6 +79,11 @@ func (c *DeleteEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		if !isSystemNamespace(depl.Namespace) {
 			agent.DeleteNamespace(depl.Namespace)
 		}
+
+		if _, err := c.Repo().Environment().DeleteDeployment(depl); err != nil {
+			c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+			return
+		}
 	}
 
 	ghWebhookID := env.GithubWebhookID

--- a/api/server/handlers/webhook/github_incoming.go
+++ b/api/server/handlers/webhook/github_incoming.go
@@ -370,21 +370,25 @@ func (c *GithubIncomingWebhookHandler) processPushEvent(event *github.PushEvent,
 
 	envType := env.ToEnvironmentType()
 
+	if len(envType.GitDeployBranches) == 0 {
+		return nil
+	}
+
 	branch := strings.TrimPrefix(event.GetRef(), "refs/heads/")
 
-	if len(envType.GitDeployBranches) > 0 {
-		found := false
+	fmt.Println(envType.GitDeployBranches)
 
-		for _, br := range envType.GitDeployBranches {
-			if br == branch {
-				found = true
-				break
-			}
-		}
+	found := false
 
-		if !found {
-			return nil
+	for _, br := range envType.GitDeployBranches {
+		if br == branch {
+			found = true
+			break
 		}
+	}
+
+	if !found {
+		return nil
 	}
 
 	client, err := getGithubClientFromEnvironment(c.Config(), env)

--- a/api/server/router/base.go
+++ b/api/server/router/base.go
@@ -81,7 +81,7 @@ func GetBaseRoutes(
 		Router:   r,
 	})
 
-	// GET /api/capabilities -> user.NewUserCreateHandler
+	// GET /api/metadata -> metadata.NewMetadataGetHandler
 	getMetadataEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
 			Verb:   types.APIVerbGet,

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -368,7 +368,7 @@ func (d *DeployDriver) applyApplication(resource *switchboardModels.Resource, cl
 
 	if tag == "" {
 		color.New(color.FgYellow).Printf("for resource %s, since PORTER_TAG is not set, the Docker image tag will default to"+
-			" the git repo SHA", resourceName)
+			" the git repo SHA\n", resourceName)
 
 		commit, err := git.LastCommit()
 

--- a/docker/cli.Dockerfile
+++ b/docker/cli.Dockerfile
@@ -13,6 +13,7 @@ COPY /cli ./cli
 COPY /internal ./internal
 COPY /api ./api
 COPY /pkg ./pkg
+COPY /provisioner ./provisioner
 
 RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     go mod download

--- a/docker/cli.Dockerfile
+++ b/docker/cli.Dockerfile
@@ -13,7 +13,6 @@ COPY /cli ./cli
 COPY /internal ./internal
 COPY /api ./api
 COPY /pkg ./pkg
-COPY /provisioner ./provisioner
 
 RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     go mod download

--- a/services/porter_cli_container/dev.Dockerfile
+++ b/services/porter_cli_container/dev.Dockerfile
@@ -13,6 +13,7 @@ COPY /internal ./internal
 COPY /api ./api
 COPY /ee ./ee
 COPY /pkg ./pkg
+COPY /provisioner ./provisioner
 
 RUN --mount=type=cache,target=$GOPATH/pkg/mod \
     go mod download


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

We currently only default to `https://charts.getporter.dev` and `https://chart-addons.getporter.dev` to check for source Helm chart information when the `repo` does not exist.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We should default to the server configured default helm repos as well.

## Technical Spec/Implementation Notes
