### PR TITLE
Feat/allow env group opening in new tab

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/ClusterDashboard.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/ClusterDashboard.tsx
@@ -30,6 +30,7 @@ import loadable from "@loadable/component";
 import Loading from "components/Loading";
 import JobRunTable from "./chart/JobRunTable";
 import TagFilter from "./TagFilter";
+import ExpandedEnvGroupDashboard from "./env-groups/ExpandedEnvGroupDashboard";
 
 // @ts-ignore
 const LazyDatabasesRoutes = loadable(() => import("./databases/routes.tsx"), {
@@ -333,6 +334,16 @@ class ClusterDashboard extends Component<PropsType, StateType> {
           />
 
           {this.renderBodyForApps()}
+        </GuardedRoute>
+        <GuardedRoute
+          path={"/env-groups/:name"}
+          scope="env_group"
+          resource=""
+          verb={["get", "list"]}
+        >
+          <ExpandedEnvGroupDashboard
+            currentCluster={this.props.currentCluster}
+          />
         </GuardedRoute>
         <GuardedRoute
           path={"/env-groups"}

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
@@ -5,6 +5,8 @@ import key from "assets/key.svg";
 
 import { Context } from "shared/Context";
 import { readableDate } from "shared/string_utils";
+import { Link } from "react-router-dom";
+import _ from "lodash";
 
 export type EnvGroupData = {
   name: string;
@@ -36,33 +38,44 @@ export default class EnvGroup extends Component<PropsType, StateType> {
     let namespace = envGroup?.namespace;
     let version = envGroup?.version;
 
+    const getExpandedENVGroupLink = () => {
+      const params = new URLSearchParams(window.location.search);
+
+      params.set("selected_env_group", name);
+
+      return `${window.location.pathname}?${params.toString()}`;
+    };
+
     return (
-      <StyledEnvGroup
-        onMouseEnter={() => this.setState({ expand: true })}
-        onMouseLeave={() => this.setState({ expand: false })}
-        expand={this.state.expand}
-        onClick={() => setExpanded()}
-      >
-        <Title>
-          <IconWrapper>
-            <Icon src={key} />
-          </IconWrapper>
-          {name}
-        </Title>
+      <Link to={getExpandedENVGroupLink()} target="_self">
+        <StyledEnvGroup
+          onMouseEnter={() => this.setState({ expand: true })}
+          onMouseLeave={() => this.setState({ expand: false })}
+          onClick={() => setExpanded()}
+        >
+          <Title>
+            <IconWrapper>
+              <Icon src={key} />
+            </IconWrapper>
+            {name}
+          </Title>
 
-        <BottomWrapper>
-          <InfoWrapper>
-            <LastDeployed>Last updated {readableDate(timestamp)}</LastDeployed>
-          </InfoWrapper>
+          <BottomWrapper>
+            <InfoWrapper>
+              <LastDeployed>
+                Last updated {readableDate(timestamp)}
+              </LastDeployed>
+            </InfoWrapper>
 
-          <TagWrapper>
-            Namespace
-            <NamespaceTag>{namespace}</NamespaceTag>
-          </TagWrapper>
-        </BottomWrapper>
+            <TagWrapper>
+              Namespace
+              <NamespaceTag>{namespace}</NamespaceTag>
+            </TagWrapper>
+          </BottomWrapper>
 
-        <Version>v{version}</Version>
-      </StyledEnvGroup>
+          <Version>v{version}</Version>
+        </StyledEnvGroup>
+      </Link>
     );
   }
 }

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroup.tsx
@@ -17,42 +17,27 @@ export type EnvGroupData = {
 
 type PropsType = {
   envGroup: EnvGroupData;
-  setExpanded: () => void;
 };
 
 type StateType = {
-  expand: boolean;
   update: any[];
 };
 
 export default class EnvGroup extends Component<PropsType, StateType> {
   state = {
-    expand: false,
     update: [] as any[],
   };
 
   render() {
-    let { envGroup, setExpanded } = this.props;
+    let { envGroup } = this.props;
     let name = envGroup?.name;
     let timestamp = envGroup?.created_at;
     let namespace = envGroup?.namespace;
     let version = envGroup?.version;
 
-    const getExpandedENVGroupLink = () => {
-      const params = new URLSearchParams(window.location.search);
-
-      params.set("selected_env_group", name);
-
-      return `${window.location.pathname}?${params.toString()}`;
-    };
-
     return (
-      <Link to={getExpandedENVGroupLink()} target="_self">
-        <StyledEnvGroup
-          onMouseEnter={() => this.setState({ expand: true })}
-          onMouseLeave={() => this.setState({ expand: false })}
-          onClick={() => setExpanded()}
-        >
+      <Link to={`/env-groups/${name}${window.location.search}`} target="_self">
+        <StyledEnvGroup>
           <Title>
             <IconWrapper>
               <Icon src={key} />

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupDashboard.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupDashboard.tsx
@@ -35,8 +35,6 @@ type StateType = {
 };
 
 const EnvGroupDashboard = (props: PropsType) => {
-  const { currentProject } = useContext(Context);
-
   const [state, setState] = useState<StateType>({
     expand: false,
     update: [] as any[],
@@ -47,40 +45,6 @@ const EnvGroupDashboard = (props: PropsType) => {
       ? localStorage.getItem("SortType")
       : "Newest",
   });
-
-  const {
-    data: envGroups,
-    isLoading: listEnvGroupsLoading,
-    isError,
-  } = useQuery<any[]>(
-    [
-      "envGroupList",
-      currentProject.id,
-      state.namespace,
-      props.currentCluster.id,
-    ],
-    async () => {
-      try {
-        if (!state.namespace) {
-          return [];
-        }
-
-        const res = await api.listEnvGroups(
-          "<token>",
-          {},
-          {
-            id: currentProject.id,
-            namespace: state.namespace,
-            cluster_id: props.currentCluster.id,
-          }
-        );
-
-        return res.data;
-      } catch (err) {
-        throw err;
-      }
-    }
-  );
 
   const setNamespace = (namespace: string) => {
     setState((state) => ({ ...state, namespace }));
@@ -188,30 +152,6 @@ const EnvGroupDashboard = (props: PropsType) => {
       );
     }
   };
-
-  useEffect(() => {
-    const selectedEnvGroup = getQueryParam(props, "selected_env_group");
-
-    if (!selectedEnvGroup || !envGroups) {
-      return;
-    }
-
-    const envGroup = envGroups.find(
-      (envGroup) => envGroup.name === selectedEnvGroup
-    );
-
-    if (envGroup) {
-      setExpandedEnvGroup(envGroup);
-    }
-  }, [envGroups]);
-
-  if (listEnvGroupsLoading) {
-    return (
-      <Placeholder>
-        <Loading />
-      </Placeholder>
-    );
-  }
 
   return <>{renderContents()}</>;
 };

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupList.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupList.tsx
@@ -98,11 +98,6 @@ const EnvGroupList: React.FunctionComponent<Props> = (props) => {
       });
   }, [currentCluster, namespace, sortType]);
 
-  const handleExpand = (envGroup: any) => {
-    pushQueryParams(props, { selected_env_group: envGroup.name }, []);
-    props.setExpandedEnvGroup(envGroup);
-  };
-
   const renderEnvGroupList = () => {
     if (isLoading || (!namespace && namespace !== "")) {
       return (
@@ -130,7 +125,6 @@ const EnvGroupList: React.FunctionComponent<Props> = (props) => {
         <EnvGroup
           key={i}
           envGroup={envGroup}
-          setExpanded={() => handleExpand(envGroup)}
         />
       );
     });

--- a/dashboard/src/main/home/cluster-dashboard/env-groups/ExpandedEnvGroupDashboard.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/ExpandedEnvGroupDashboard.tsx
@@ -1,0 +1,173 @@
+import React, { Component, useContext, useEffect, useState } from "react";
+import styled from "styled-components";
+
+import sliders from "assets/sliders.svg";
+
+import { Context } from "shared/Context";
+import { ClusterType } from "shared/types";
+
+import ExpandedEnvGroup from "./ExpandedEnvGroup";
+import { RouteComponentProps, useParams, withRouter } from "react-router";
+import { getQueryParam, pushQueryParams } from "shared/routing";
+import { withAuth, WithAuthProps } from "shared/auth/AuthorizationHoc";
+import { useQuery } from "@tanstack/react-query";
+import api from "shared/api";
+import Loading from "components/Loading";
+import Placeholder from "components/Placeholder";
+
+type PropsType = RouteComponentProps &
+  WithAuthProps & {
+    currentCluster: ClusterType;
+  };
+
+const EnvGroupDashboard = (props: PropsType) => {
+  const namespace = getQueryParam(props, "namespace");
+  const params = useParams<{ name: string }>();
+  const { currentProject } = useContext(Context);
+  const [expandedEnvGroup, setExpandedEnvGroup] = useState<any>();
+
+  const {
+    data: envGroups,
+    isLoading: listEnvGroupsLoading,
+    isError,
+  } = useQuery<any[]>(
+    ["envGroupList", currentProject.id, namespace, props.currentCluster.id],
+    async () => {
+      try {
+        if (!namespace) {
+          return [];
+        }
+
+        const res = await api.listEnvGroups(
+          "<token>",
+          {},
+          {
+            id: currentProject.id,
+            namespace: namespace,
+            cluster_id: props.currentCluster.id,
+          }
+        );
+
+        return res.data;
+      } catch (err) {
+        throw err;
+      }
+    }
+  );
+
+  useEffect(() => {
+    const name = params.name;
+
+    if (!envGroups) {
+      return;
+    }
+
+    const envGroup = envGroups.find((envGroup) => envGroup.name === name);
+
+    setExpandedEnvGroup(envGroup);
+  }, [envGroups, params]);
+
+  if (listEnvGroupsLoading) {
+    return (
+      <Placeholder>
+        <Loading />
+      </Placeholder>
+    );
+  }
+
+  const renderContents = () => {
+    if (!expandedEnvGroup) {
+      return null;
+    }
+
+    return (
+      <ExpandedEnvGroup
+        isAuthorized={props.isAuthorized}
+        namespace={expandedEnvGroup?.namespace ?? namespace}
+        currentCluster={props.currentCluster}
+        envGroup={expandedEnvGroup}
+        closeExpanded={() => props.history.push("/env-groups")}
+      />
+    );
+  };
+
+  if (listEnvGroupsLoading) {
+    return (
+      <Placeholder>
+        <Loading />
+      </Placeholder>
+    );
+  }
+
+  return <>{renderContents()}</>;
+};
+
+export default withRouter(withAuth(EnvGroupDashboard));
+
+const Flex = styled.div`
+  display: flex;
+  align-items: center;
+  border-bottom: 30px solid transparent;
+`;
+
+const SortFilterWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 30px solid transparent;
+  > div:not(:first-child) {
+  }
+`;
+
+const ControlRow = styled.div`
+  display: flex;
+  justify-content: ${(props: { hasMultipleChilds: boolean }) => {
+    if (props.hasMultipleChilds) {
+      return "space-between";
+    }
+    return "flex-end";
+  }};
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+const Button = styled.div`
+  display: flex;
+  margin-left: 10px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: "Work Sans", sans-serif;
+  border-radius: 5px;
+  color: white;
+  height: 30px;
+  padding: 0 8px;
+  min-width: 155px;
+  padding-right: 13px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  cursor: ${(props: { disabled?: boolean }) =>
+    props.disabled ? "not-allowed" : "pointer"};
+
+  background: ${(props: { disabled?: boolean }) =>
+    props.disabled ? "#aaaabbee" : "#616FEEcc"};
+  :hover {
+    background: ${(props: { disabled?: boolean }) =>
+      props.disabled ? "" : "#505edddd"};
+  }
+
+  > i {
+    color: white;
+    width: 18px;
+    height: 18px;
+    font-weight: 600;
+    font-size: 12px;
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    margin-right: 5px;
+    justify-content: center;
+  }
+`;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Currently, we do not allow environment groups to be expanded into new tab.

## What is the new behavior?

This PR adds support for expanding environment groups into new tab
