### PR TITLE
hotfix: less strict zod schema validation

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11610,6 +11610,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
     }
   }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -65,7 +65,8 @@
     "stacktrace-js": "^2.0.2",
     "styled-components": "^5.2.0",
     "traverse": "^0.6.7",
-    "valtio": "^1.2.4"
+    "valtio": "^1.2.4",
+    "zod": "^3.20.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
@@ -231,7 +231,7 @@ const LogsSection: React.FC<Props> = ({
         <Log key={[log.lineNumber, i].join(".")}>
           <span className="line-number">{log.lineNumber}.</span>
           <span className="line-timestamp">
-            {dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss")}
+            {log.timestamp ? dayjs(log.timestamp).format("MMM D, YYYY HH:mm:ss") : "-"}
           </span>
           <LogOuter key={[log.lineNumber, i].join(".")}>
             {log.line?.map((ansi, j) => {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Logs are currently not rendering for some users due to conflicts in schema agreements between gRPC and the logging component causing the invalid logs to not be parsed. 

## What is the new behavior?

Makes the schema requirement less strict so that non-confirming logs are also renderered. As a long term fix, we should investigate what broke the schema contract which might need deeper investigation

