### PR TITLE
[POR-822] Store last errors in the DB for preview env deployments

### DIFF
--- a/api/server/handlers/environment/finalize_deployment.go
+++ b/api/server/handlers/environment/finalize_deployment.go
@@ -109,6 +109,7 @@ func (c *FinalizeDeploymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	depl.Subdomain = request.Subdomain
 	depl.Status = types.DeploymentStatusCreated
+	depl.LastErrors = ""
 
 	// update the deployment
 	depl, err = c.Repo().Environment().UpdateDeployment(depl)

--- a/api/server/handlers/environment/finalize_deployment_with_errors.go
+++ b/api/server/handlers/environment/finalize_deployment_with_errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-github/v41/github"
 	"github.com/porter-dev/porter/api/server/handlers"
@@ -120,6 +121,14 @@ func (c *FinalizeDeploymentWithErrorsHandler) ServeHTTP(w http.ResponseWriter, r
 	}
 
 	depl.Status = types.DeploymentStatusFailed
+
+	var lastErrors []string
+
+	for resName, errString := range request.Errors {
+		lastErrors = append(lastErrors, "%s: %s,", resName, errString)
+	}
+
+	depl.LastErrors = strings.Join(lastErrors, ",")
 
 	// we do not care of the error in this case because the list deployments endpoint
 	// talks to the github API to fetch the deployment status correctly

--- a/api/types/environment.go
+++ b/api/types/environment.go
@@ -63,6 +63,7 @@ type Deployment struct {
 	PullRequestID      uint             `json:"pull_request_id"`
 	InstallationID     uint             `json:"gh_installation_id"`
 	LastWorkflowRunURL string           `json:"last_workflow_run_url"`
+	LastErrors         string           `json:"last_errors"`
 }
 
 type CreateGHDeploymentRequest struct {

--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
@@ -29,6 +29,10 @@ const DeploymentDetail = () => {
   const [expandedPorterYAMLErrors, setExpandedPorterYAMLErrors] = useState<
     string[]
   >([]);
+  const [
+    expandedLastDeploymentErrors,
+    setExpandedLastDeploymentErrors,
+  ] = useState<string[]>([]);
 
   const { currentProject, currentCluster } = useContext(Context);
 
@@ -208,6 +212,23 @@ const DeploymentDetail = () => {
           </Message>
         </Modal>
       )}
+      {expandedLastDeploymentErrors.length > 0 && (
+        <Modal
+          onRequestClose={() => setExpandedLastDeploymentErrors([])}
+          height="auto"
+        >
+          <Message>
+            {expandedLastDeploymentErrors.map((el) => {
+              return (
+                <div>
+                  {"- "}
+                  {el}
+                </div>
+              );
+            })}
+          </Message>
+        </Modal>
+      )}
       <BreadcrumbRow>
         <Breadcrumb to={`/preview-environments/deployments/settings`}>
           <ArrowIcon src={PullRequestIcon} />
@@ -284,6 +305,22 @@ const DeploymentDetail = () => {
               <LinkButton
                 onClick={() => {
                   setExpandedPorterYAMLErrors(porterYAMLErrors);
+                }}
+              >
+                View details
+              </LinkButton>
+            </Banner>
+          </ErrorBannerWrapper>
+        ) : null}
+        {prDeployment.last_errors.length > 0 ? (
+          <ErrorBannerWrapper style={{ marginTop: -20 }}>
+            <Banner type="error">
+              The previous deployment had errors.
+              <LinkButton
+                onClick={() => {
+                  setExpandedLastDeploymentErrors(
+                    prDeployment.last_errors.split(",")
+                  );
                 }}
               >
                 View details

--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/types.ts
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/types.ts
@@ -27,6 +27,7 @@ export type PRDeployment = {
   gh_commit_sha: string;
   gh_pr_branch_from?: string;
   gh_pr_branch_into?: string;
+  last_errors: string;
 };
 
 export type EnvironmentDeploymentMode = "manual" | "auto";

--- a/internal/models/environment.go
+++ b/internal/models/environment.go
@@ -116,6 +116,7 @@ type Deployment struct {
 	CommitSHA      string
 	PRBranchFrom   string
 	PRBranchInto   string
+	LastErrors     string
 }
 
 func (d *Deployment) ToDeploymentType() *types.Deployment {
@@ -139,6 +140,7 @@ func (d *Deployment) ToDeploymentType() *types.Deployment {
 		Subdomain:      d.Subdomain,
 		PullRequestID:  d.PullRequestID,
 		GitHubMetadata: ghMetadata,
+		LastErrors:     d.LastErrors,
 	}
 }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

We do not store errors for preview deployments.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now store deployment errors in the DB and also show a banner in the deployment details view.

## Technical Spec/Implementation Notes
