### PR TITLE
[POR-881] Disable remote kubeconfig using an env flag

### DIFF
--- a/api/client/k8s.go
+++ b/api/client/k8s.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/porter-dev/porter/api/types"
@@ -97,6 +98,10 @@ func (c *Client) GetKubeconfig(
 		nil,
 		resp,
 	)
+
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return nil, fmt.Errorf("temporary kubeconfig generation is disabled, please use a local kubeconfig")
+	}
 
 	return resp, err
 }

--- a/api/server/handlers/cluster/get_kubeconfig.go
+++ b/api/server/handlers/cluster/get_kubeconfig.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/porter-dev/porter/api/server/authz"
@@ -29,6 +30,13 @@ func NewGetTemporaryKubeconfigHandler(
 }
 
 func (c *GetTemporaryKubeconfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if c.Config().ServerConf.DisableTemporaryKubeconfig {
+		c.HandleAPIError(w, r, apierrors.NewErrNotFound(
+			errors.New("temporary kubeconfig generation is disabled on this instance"),
+		))
+		return
+	}
+
 	cluster, _ := r.Context().Value(types.ClusterScope).(*models.Cluster)
 
 	outOfClusterConfig := c.GetOutOfClusterConfig(cluster)

--- a/api/server/router/cluster.go
+++ b/api/server/router/cluster.go
@@ -762,33 +762,35 @@ func getClusterRoutes(
 		Router:   r,
 	})
 
-	// GET /api/projects/{project_id}/clusters/{cluster_id}/kubeconfig -> cluster.NewGetTemporaryKubeconfigHandler
-	getTemporaryKubeconfigEndpoint := factory.NewAPIEndpoint(
-		&types.APIRequestMetadata{
-			Verb:   types.APIVerbUpdate, // we do not want users with no-write access to be able to use this
-			Method: types.HTTPVerbGet,
-			Path: &types.Path{
-				Parent:       basePath,
-				RelativePath: relPath + "/kubeconfig",
+	if !config.ServerConf.DisableTemporaryKubeconfig {
+		// GET /api/projects/{project_id}/clusters/{cluster_id}/kubeconfig -> cluster.NewGetTemporaryKubeconfigHandler
+		getTemporaryKubeconfigEndpoint := factory.NewAPIEndpoint(
+			&types.APIRequestMetadata{
+				Verb:   types.APIVerbUpdate, // we do not want users with no-write access to be able to use this
+				Method: types.HTTPVerbGet,
+				Path: &types.Path{
+					Parent:       basePath,
+					RelativePath: relPath + "/kubeconfig",
+				},
+				Scopes: []types.PermissionScope{
+					types.UserScope,
+					types.ProjectScope,
+					types.ClusterScope,
+				},
 			},
-			Scopes: []types.PermissionScope{
-				types.UserScope,
-				types.ProjectScope,
-				types.ClusterScope,
-			},
-		},
-	)
+		)
 
-	getTemporaryKubeconfigHandler := cluster.NewGetTemporaryKubeconfigHandler(
-		config,
-		factory.GetResultWriter(),
-	)
+		getTemporaryKubeconfigHandler := cluster.NewGetTemporaryKubeconfigHandler(
+			config,
+			factory.GetResultWriter(),
+		)
 
-	routes = append(routes, &router.Route{
-		Endpoint: getTemporaryKubeconfigEndpoint,
-		Handler:  getTemporaryKubeconfigHandler,
-		Router:   r,
-	})
+		routes = append(routes, &router.Route{
+			Endpoint: getTemporaryKubeconfigEndpoint,
+			Handler:  getTemporaryKubeconfigHandler,
+			Router:   r,
+		})
+	}
 
 	// GET /api/projects/{project_id}/clusters/{cluster_id}/prometheus/detect -> cluster.NewDetectPrometheusInstalledHandler
 	detectPrometheusInstalledEndpoint := factory.NewAPIEndpoint(

--- a/api/server/shared/config/env/envconfs.go
+++ b/api/server/shared/config/env/envconfs.go
@@ -110,6 +110,11 @@ type ServerConf struct {
 	// DisableRegistrySecretsInjection is used to denote if Porter should not inject
 	// imagePullSecrets into a kubernetes deployment (Porter application)
 	DisablePullSecretsInjection bool `env:"DISABLE_PULL_SECRETS_INJECTION,default=false"`
+
+	// DisableTemporaryKubeconfig is used to denote if Porter should not
+	// create a temporary kubeconfig file for a cluster. When set to true, the
+	// /api/projects/{project_id}/clusters/{cluster_id}/kubeconfig will be disabled.
+	DisableTemporaryKubeconfig bool `env:"DISABLE_TEMPORARY_KUBECONFIG,default=false"`
 }
 
 // DBConf is the database configuration: if generated from environment variables,

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -212,14 +212,14 @@ func (c *CLIConfig) SetHost(host string) error {
 }
 
 func (c *CLIConfig) SetProject(projectID uint) error {
+	viper.Set("project", projectID)
+
+	color.New(color.FgGreen).Printf("Set the current project as %d\n", projectID)
+
 	if config.Kubeconfig != "" || viper.IsSet("kubeconfig") {
-		viper.Set("kubeconfig", "")
-		color.New(color.FgBlue).Println("Removing local kubeconfig")
-		config.Kubeconfig = ""
+		color.New(color.FgYellow).Println("Please change local kubeconfig if needed")
 	}
 
-	viper.Set("project", projectID)
-	color.New(color.FgGreen).Printf("Set the current project as %d\n", projectID)
 	err := viper.WriteConfig()
 
 	if err != nil {
@@ -232,14 +232,14 @@ func (c *CLIConfig) SetProject(projectID uint) error {
 }
 
 func (c *CLIConfig) SetCluster(clusterID uint) error {
+	viper.Set("cluster", clusterID)
+
+	color.New(color.FgGreen).Printf("Set the current cluster as %d\n", clusterID)
+
 	if config.Kubeconfig != "" || viper.IsSet("kubeconfig") {
-		viper.Set("kubeconfig", "")
-		color.New(color.FgBlue).Println("Removing local kubeconfig")
-		config.Kubeconfig = ""
+		color.New(color.FgYellow).Println("Please change local kubeconfig if needed")
 	}
 
-	viper.Set("cluster", clusterID)
-	color.New(color.FgGreen).Printf("Set the current cluster as %d\n", clusterID)
 	err := viper.WriteConfig()
 
 	if err != nil {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- Disable remote temporary kubeconfig generation by setting `DISABLE_TEMPORARY_KUBECONFIG=true`
- `porter config set-project` and `porter config set-cluster` will not reset the local kubeconfig (if any)

## Technical Spec/Implementation Notes
