### PR TITLE
[PORT-896] fix: broken link to pull requests in deployment details

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
@@ -167,7 +167,7 @@ const DeploymentDetail = () => {
               </DeploymentImageContainer>
               <Dot>•</Dot>
               <GHALink
-                to={`https://github.com/${prDeployment.gh_repo_owner}/${prDeployment.gh_repo_name}/pulls/${prDeployment.pull_request_id}`}
+                to={`https://github.com/${prDeployment.gh_repo_owner}/${prDeployment.gh_repo_name}/pull/${prDeployment.pull_request_id}`}
                 target="_blank"
               >
                 <GithubIcon />


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The link to PR in the deployment detail view is currently broken. It links to:

```
https://github.com/:repo_owner/:repo_name/pulls/:pull_request_id}
```

## What is the new behavior?

The link to PR should link correctly to corresponding PR on Github. The actual URL should be

```
https://github.com/:repo_owner/:repo_name/pull/:pull_request_id}
```
