### PR TITLE
CUS-61 Wait flag race

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -491,6 +491,9 @@ func updateFull(_ *types.GetAuthenticatedUserResponse, client *api.Client, args 
 	}
 
 	if waitForSuccessfulDeploy {
+		// solves timing issue where replicasets were not on the cluster, before our initial check
+		time.Sleep(10 * time.Second)
+
 		err := checkDeploymentStatus(client)
 
 		if err != nil {
@@ -613,6 +616,9 @@ func updateUpgrade(_ *types.GetAuthenticatedUserResponse, client *api.Client, ar
 	}
 
 	if waitForSuccessfulDeploy {
+		// solves timing issue where replicasets were not on the cluster, before our initial check
+		time.Sleep(10 * time.Second)
+
 		err := checkDeploymentStatus(client)
 
 		if err != nil {


### PR DESCRIPTION
**Summary**
Currently when using the `--wait` flag on a deployment, a race can happen where the replicaset is not yet created on the cluster before the initial check for its status. This causes the command to assume that the upgrade has failed.

**Work items**
- Add hardcoded 10 second wait before checking deployment status, to ensure time to create the replicaset