### PR TITLE
[POR-899] fix: broken link to pull requests in deployment details

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/deployments/DeploymentDetail.tsx
@@ -167,7 +167,7 @@ const DeploymentDetail = () => {
               </DeploymentImageContainer>
               <Dot>•</Dot>
               <GHALink
-                to={`https://github.com/${prDeployment.gh_repo_owner}/${prDeployment.gh_repo_name}/pulls/${prDeployment.pull_request_id}`}
+                to={`https://github.com/${prDeployment.gh_repo_owner}/${prDeployment.gh_repo_name}/pull/${prDeployment.pull_request_id}`}
                 target="_blank"
               >
                 <GithubIcon />


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Description

On deleting a cluster,  the warning suggests clicking the help link which is not clickable

## What is the new behavior?

This PR fixes z-index on the help link so that it is clickable

## Technical Spec/Implementation Notes
