### PR TITLE
feat: add instructions to connect project and cluster

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/ConnectToJobInstructionsModal.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/jobs/ConnectToJobInstructionsModal.tsx
@@ -1,5 +1,6 @@
 import Modal from "main/home/modals/Modal";
-import React from "react";
+import React, { useContext } from "react";
+import { Context } from "shared/Context";
 import { ChartType } from "shared/types";
 import styled from "styled-components";
 
@@ -8,6 +9,7 @@ const ConnectToJobInstructionsModal: React.FC<{
   onClose: () => void;
   chartName: string;
 }> = ({ show, chartName, onClose }) => {
+  const { currentCluster, currentProject } = useContext(Context);
   if (!show) {
     return null;
   }
@@ -26,6 +28,13 @@ const ConnectToJobInstructionsModal: React.FC<{
       </a>
       ).
       <br />
+      <br />
+      Run the following commands to set your current project and cluster
+      <Code>
+        porter config set-project {currentProject.id}
+        <br />
+        porter config set-cluster {currentCluster.id}
+      </Code>
       <br />
       Run the following line of code, and make sure to change the command to
       something your container can run:


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

The instructions for shell access do not include steps for connecting porter cluster and project id using CLI.

## What is the new behavior?

Add instructions for setting up current cluster and project in the porter cli by autofilling values from the current context

<img width="857" alt="Screenshot 2023-01-26 at 6 42 37 PM" src="https://user-images.githubusercontent.com/80167324/214844346-dd2212df-0fbc-4e3a-a1a5-00d0a5ea7f19.png">

