### PR TITLE
Fix crash on forms.yaml editor

### DIFF
--- a/dashboard/src/components/porter-form/field-components/KeyValueArray.tsx
+++ b/dashboard/src/components/porter-form/field-components/KeyValueArray.tsx
@@ -32,14 +32,17 @@ const KeyValueArray: React.FC<Props> = (props) => {
     props.id,
     {
       initState: () => {
-        let values = props.value[0];
+        let values = {}
+        if (props?.value?.length > 0) {
+          values = props.value[0]
+        }
         const normalValues = Object.entries(values?.normal || {});
         values = omit(values, ["normal", "synced", "build"]);
         return {
           values: hasSetValue(props)
             ? ([...Object.entries(values), ...normalValues]?.map(([k, v]) => {
-                return { key: k, value: v };
-              }) as any[])
+              return { key: k, value: v };
+            }) as any[])
             : [],
           showEnvModal: false,
           showEditorModal: false,
@@ -112,7 +115,6 @@ const KeyValueArray: React.FC<Props> = (props) => {
     }
   }, [
     props.injectedProps,
-    props.value[0],
     variables?.clusterId,
     variables?.namespace,
     currentProject?.id,


### PR DESCRIPTION
Forms.yaml editor would crash when props.value was missing