### PR TITLE
Make revisions count configurable for helm revisions worker job

### DIFF
--- a/workers/main.go
+++ b/workers/main.go
@@ -56,6 +56,8 @@ type EnvConf struct {
 	LegacyProjectIDs []uint `env:"LEGACY_PROJECT_IDS"`
 
 	Port uint `env:"PORT,default=3000"`
+
+	RevisionsCount int `env:"REVISIONS_COUNT,default=20"`
 }
 
 func main() {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

The most recent 20 revisions are always kept using the revisions culler worker job.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We now default to 20 revisions but this can be configured using the `REVISIONS_COUNT` env var.

## Technical Spec/Implementation Notes
