### PR TITLE
Tiltfile name updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ openapi.yaml
 vendor
 **/*.env
 **/node_modules
-migrate-binary
-porter-binary
 zarf/helm/charts
 
 # Local docs directories

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ vendor
 **/*.env
 **/node_modules
 porter
+migrate
 zarf/helm/charts
 
 # Local docs directories

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,7 +15,7 @@ if config.tilt_subcommand == "down":
 ## Build binary locally for faster devexp
 local_resource(
   name='porter-binary',
-  cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./porter-binary ./cmd/app/main.go''',
+  cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./bin/porter ./cmd/app/main.go''',
   deps=[
     "api",
     "build",
@@ -36,12 +36,11 @@ docker_build_with_restart(
     entrypoint='/app/porter',
     build_args={},
     only=[
-        "porter",
-        "migrate"
+        "bin",
     ],
     live_update=[
-        sync('./porter', '/app/'),
-        sync('./migrate', '/app/'),
+        sync('./bin/porter', '/app/'),
+        sync('./bin/migrate', '/app/'),
     ], 
 ) 
 
@@ -63,7 +62,7 @@ local_resource(
 # Migrations
 local_resource(
     name="migrations-binary",
-    cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./migrate-binary ./cmd/migrate/main.go ./cmd/migrate/migrate_ee.go''',
+    cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./bin/migrate ./cmd/migrate/main.go ./cmd/migrate/migrate_ee.go''',
     resource_deps=["postgresql"],
     labels=["porter"],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -14,8 +14,8 @@ if config.tilt_subcommand == "down":
 
 ## Build binary locally for faster devexp
 local_resource(
-  'porter',
-  '''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -o ./porter ./cmd/app/main.go''',
+  name='porter-binary',
+  cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./porter ./cmd/app/main.go''',
   deps=[
     "api",
     "build",
@@ -37,10 +37,12 @@ docker_build_with_restart(
     build_args={},
     only=[
         "porter",
+        "migrate"
     ],
     live_update=[
         sync('./porter', '/app/'),
-    ]
+        sync('./migrate', '/app/'),
+    ], 
 ) 
 
 # Frontend
@@ -57,6 +59,22 @@ local_resource(
     resource_deps=["postgresql"],
     labels=["porter"]
 )
+
+# Migrations
+local_resource(
+    name="migrations-binary",
+    cmd='''GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod vendor -gcflags '-N -l' -tags ee -o ./migrate ./cmd/migrate/main.go ./cmd/migrate/migrate_ee.go''',
+    resource_deps=["postgresql"],
+    labels=["porter"],
+)
+local_resource(
+    name="run-migrations",
+    cmd='''kubectl exec -it deploy/porter-server-web -- /app/migrate''',
+    resource_deps=["migrations-binary", "porter-binary"],
+    labels=["porter"],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
 
 allow_k8s_contexts('kind-porter')
 

--- a/zarf/docker/Dockerfile.server.tilt
+++ b/zarf/docker/Dockerfile.server.tilt
@@ -7,4 +7,4 @@ FROM debian:bullseye-slim as runner
 WORKDIR /app
 COPY --from=installer /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=installer /go/bin/dlv /
-COPY ./porter /app
+COPY ./bin/porter /app


### PR DESCRIPTION
Allow backend migrations to be triggered manually, as opposed to on every restart with Tilt
