### PR TITLE
[POR-981] Add option to choose registry for `porter.yaml`

### DIFF
--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -100,6 +100,26 @@ func (c *Client) ListRegistries(
 	return resp, err
 }
 
+// GetRegistry returns a registry given a project id and registry id
+func (c *Client) GetRegistry(
+	ctx context.Context,
+	projectID, registryID uint,
+) (*types.Registry, error) {
+	resp := &types.Registry{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/registries/%d",
+			projectID,
+			registryID,
+		),
+		nil,
+		resp,
+	)
+
+	return resp, err
+}
+
 // DeleteProjectRegistry deletes a registry given a project id and registry id
 func (c *Client) DeleteProjectRegistry(
 	ctx context.Context,

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -489,20 +489,7 @@ func (d *DeployDriver) createApplication(resource *switchboardModels.Resource, c
 	// create new release
 	color.New(color.FgGreen).Printf("Creating %s release: %s\n", d.source.Name, resource.Name)
 
-	regList, err := client.ListRegistries(context.Background(), d.target.Project)
-	if err != nil {
-		return nil, fmt.Errorf("for resource %s, error listing registries: %w", resource.Name, err)
-	}
-
-	var registryURL string
-
-	if len(*regList) == 0 {
-		return nil, fmt.Errorf("no registry found")
-	} else {
-		registryURL = (*regList)[0].URL
-	}
-
-	color.New(color.FgBlue).Printf("for resource %s, using registry %s\n", resource.Name, registryURL)
+	color.New(color.FgBlue).Printf("for resource %s, using registry %s\n", resource.Name, d.target.RegistryURL)
 
 	// attempt to get repo suffix from environment variables
 	var repoSuffix string
@@ -534,6 +521,7 @@ func (d *DeployDriver) createApplication(resource *switchboardModels.Resource, c
 	}
 
 	var subdomain string
+	var err error
 
 	if appConf.Build.Method == "registry" {
 		subdomain, err = createAgent.CreateFromRegistry(appConf.Build.Image, appConf.Values)

--- a/internal/integrations/preview/utils.go
+++ b/internal/integrations/preview/utils.go
@@ -11,10 +11,11 @@ type Source struct {
 }
 
 type Target struct {
-	AppName   string `mapstructure:"app_name"`
-	Project   uint
-	Cluster   uint
-	Namespace string
+	AppName     string `mapstructure:"app_name"`
+	Project     uint
+	Cluster     uint
+	Namespace   string
+	RegistryURL string `mapstructure:"registry_url"`
 }
 
 type RandomStringDriverConfig struct {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

`porter.yaml` will always choose the first available registry in a project when creating a new app/addon.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR adds the functionality to choose a registry for an app/addon defined in a `porter.yaml` file in the following manner:
- A `resource`'s `target` can now have a `registry_url` param to define the registry URL 
- If the above does not exist, then we check if `porter config set-registry` was set and use the registry URL from there
- Lastly, we default to the previous behavior of listing the registries in the project and choosing the first one available to us

## Technical Spec/Implementation Notes
