### PR TITLE
[POR-986] Flush exception to sentry from CLI errors

### DIFF
--- a/cli/cmd/errors/error_handler.go
+++ b/cli/cmd/errors/error_handler.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/getsentry/sentry-go"
@@ -35,9 +36,8 @@ func (h *sentryErrorHandler) HandleError(err error) {
 			})
 		})
 
-		if eventID := localHub.CaptureException(err); eventID == nil {
-			color.New(color.FgRed).Fprintf(os.Stderr, "error in sending exception to sentry\n")
-		}
+		localHub.CaptureException(err)
+		sentry.Flush(2 * time.Second)
 	}
 
 	color.New(color.FgRed).Fprintf(os.Stderr, "error: %s\n", err.Error())


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Improvement

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

The CLI might print an error regarding Sentry when it's unable to send an error to Sentry.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This is fixed by flushing the error in Sentry's buffer and removing the error message from the CLI altogether.

## Technical Spec/Implementation Notes
