### PR TITLE
Disable preflight check if cluster exists

### DIFF
--- a/dashboard/src/components/ProvisionerSettings.tsx
+++ b/dashboard/src/components/ProvisionerSettings.tsx
@@ -177,46 +177,49 @@ const ProvisionerSettings: React.FC<Props> = (props) => {
     try {
       setIsReadOnly(true);
       setErrorMessage(undefined);
-      markStepStarted("pre-provisioning-check-started");
 
-      await api.preflightCheckAWSUsage(
-        "<token>",
-        {
-          target_arn: props.credentialId,
-          region: awsRegion,
-        },
-        {
-          id: currentProject.id,
-        }
-      );
+      if (!props.clusterId) {
+        markStepStarted("pre-provisioning-check-started");
 
-      markStepStarted("provisioning-started");
+        await api.preflightCheckAWSUsage(
+          "<token>",
+          {
+            target_arn: props.credentialId,
+            region: awsRegion,
+          },
+          {
+            id: currentProject.id,
+          }
+        );
+
+        markStepStarted("provisioning-started");
+      }
 
       const res = await api.createContract("<token>", data, {
         project_id: currentProject.id,
       });
 
       // Only refresh and set clusters on initial create
-      if (!props.clusterId) {
-        setShouldRefreshClusters(true);
-        api
-          .getClusters("<token>", {}, { id: currentProject.id })
-          .then(({ data }) => {
-            data.forEach((cluster: ClusterType) => {
-              if (cluster.id === res.data.contract_revision?.cluster_id) {
-                // setHasFinishedOnboarding(true);
-                setCurrentCluster(cluster);
-                OFState.actions.goTo("clean_up");
-                pushFiltered(props, "/cluster-dashboard", ["project_id"], {
-                  cluster: cluster.name,
-                });
-              }
-            });
-          })
-          .catch((err) => {
-            console.error(err);
+      // if (!props.clusterId) {
+      setShouldRefreshClusters(true);
+      api
+        .getClusters("<token>", {}, { id: currentProject.id })
+        .then(({ data }) => {
+          data.forEach((cluster: ClusterType) => {
+            if (cluster.id === res.data.contract_revision?.cluster_id) {
+              // setHasFinishedOnboarding(true);
+              setCurrentCluster(cluster);
+              OFState.actions.goTo("clean_up");
+              pushFiltered(props, "/cluster-dashboard", ["project_id"], {
+                cluster: cluster.name,
+              });
+            }
           });
-      }
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+      // }
       setErrorMessage(undefined);
     } catch (err) {
       const errMessage = err.response.data.error.replace("unknown: ", "");
@@ -244,8 +247,8 @@ const ProvisionerSettings: React.FC<Props> = (props) => {
   useEffect(() => {
     setIsReadOnly(
       props.clusterId &&
-        (currentCluster.status === "UPDATING" ||
-          currentCluster.status === "UPDATING_UNAVAILABLE")
+      (currentCluster.status === "UPDATING" ||
+        currentCluster.status === "UPDATING_UNAVAILABLE")
     );
     setClusterName(
       `${currentProject.name}-cluster-${Math.random()
@@ -393,7 +396,7 @@ const ExpandHeader = styled.div<{ isExpanded: boolean }>`
     margin-right: 7px;
     margin-left: -7px;
     transform: ${(props) =>
-      props.isExpanded ? "rotate(0deg)" : "rotate(-90deg)"};
+    props.isExpanded ? "rotate(0deg)" : "rotate(-90deg)"};
   }
 `;
 

--- a/dashboard/src/main/home/onboarding/state/index.ts
+++ b/dashboard/src/main/home/onboarding/state/index.ts
@@ -35,16 +35,19 @@ export const OFState = proxy({
     saveState: () => {
       const state = compressState(OFState);
 
-      api
-        .saveOnboardingState(
-          "<token>",
-          {
-            ...state,
-          },
-          { project_id: OFState.StateHandler?.project?.id }
-        )
-        .then((res) => console.log(res))
-        .catch((err) => console.log(err));
+      if (OFState.StateHandler?.project?.id) {
+        api
+          .saveOnboardingState(
+            "<token>",
+            {
+              ...state,
+            },
+            { project_id: OFState.StateHandler?.project?.id }
+          )
+          .then((res) => console.log(res))
+          .catch((err) => console.log(err));
+      }
+
     },
     restoreState: (state: any) => {
       const prevState = decompressState(state);


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Users were running into an issue where they couldn't re-provision a cluster because the quota checks thought that the previously allocated resources on initial provision counted towards the quota.

## What is the new behavior?

Disable quota checks if the cluster already exists. Eventually we'll need to change the quota check to filter out porter resources but this is a quick fix for now. 

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
