### PR TITLE
Use production tag instead of branch

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,7 +1,7 @@
 name: Deploy to production
 on:
   push:
-    branches:
+    tags:
       - production
 jobs:
   deploy:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,20 @@
+version: '3'
+
+tasks:
+  move-to-production:
+    desc: Move the current branch to production
+    cmds:
+    - cmd: git tag -d production
+      ignore_error: false
+      silent: true
+    - cmd: git push origin :production
+      ignore_error: false
+      silent: true
+    - cmd: git tag production
+      ignore_error: false
+      silent: true
+    - cmd: git push origin production
+      ignore_error: false
+      silent: true
+ 
+


### PR DESCRIPTION
Switch to use production tag instead of branch, ahead of versioned production releases. Only people with `maintain` access to the repo can add the `production` tag.

Running `task move-to-production` will move the current branch to production. This will **not** update the branch you are on