### PR TITLE
add k8s namespace override for capi provisioned cluster

### DIFF
--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -287,7 +287,22 @@ func (conf *OutOfClusterConfig) GetClientConfigFromCluster() (clientcmd.ClientCo
 		if err != nil {
 			return nil, err
 		}
-		return clientcmd.NewClientConfigFromBytes([]byte(rc))
+		clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(rc))
+		if err != nil {
+			return nil, err
+		}
+		rawConfig, err := clientConfig.RawConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		overrides := &clientcmd.ConfigOverrides{}
+
+		overrides.Context = api.Context{
+			Namespace: conf.DefaultNamespace,
+		}
+
+		return clientcmd.NewDefaultClientConfig(rawConfig, overrides), nil
 	}
 
 	if conf.Cluster.AuthMechanism == models.Local {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## What is the current behavior?

When we deploy a stack, the helm chart is installed in the correct namespace, but the kubernetes resources themselves are installed to default.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Namespace overrides are now passed into the client config used by the helm agent (through its k8s agent) for CAPI provisioned clusters.
