### PR TITLE
check token for capi clusters before getting assume role credentials

### DIFF
--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -365,6 +365,7 @@ func (conf *OutOfClusterConfig) CreateRawConfigFromCluster() (*api.Config, error
 	}
 
 	if conf.Cluster.ProvisionedBy == "CAPI" {
+
 		decodedCert, err := capiCertAuthData(conf.CAPIManagementClusterClient, int(cluster.ID), int(cluster.ProjectID))
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving capi certificate authority data: %w", err)
@@ -372,37 +373,47 @@ func (conf *OutOfClusterConfig) CreateRawConfigFromCluster() (*api.Config, error
 
 		clusterMap[cluster.Name].CertificateAuthorityData = decodedCert
 
-		req := connect.NewRequest(&porterv1.AssumeRoleCredentialsRequest{
-			ProjectId: int64(cluster.ProjectID),
-		})
-
-		creds, err := conf.CAPIManagementClusterClient.AssumeRoleCredentials(context.Background(), req)
-		if err != nil {
-			return nil, fmt.Errorf("error getting capi credentials for repository: %w", err)
+		// check cache here so that we don't unnecessarily assume role
+		cache, err := conf.getTokenCache()
+		if cache != nil {
+			if tok := cache.Token; err == nil && !cache.IsExpired() && len(tok) > 0 {
+				authInfoMap[authInfoName].Token = string(tok)
+			}
 		}
 
-		awsAuth := &ints.AWSIntegration{
-			AWSAccessKeyID:     []byte(creds.Msg.AwsAccessId),
-			AWSSecretAccessKey: []byte(creds.Msg.AwsSecretKey),
-			AWSSessionToken:    []byte(creds.Msg.AwsSessionToken),
+		// if we didn't get a valid token from cache, generate a new one
+		if authInfoMap[authInfoName].Token == "" {
+
+			req := connect.NewRequest(&porterv1.AssumeRoleCredentialsRequest{
+				ProjectId: int64(cluster.ProjectID),
+			})
+
+			creds, err := conf.CAPIManagementClusterClient.AssumeRoleCredentials(context.Background(), req)
+			if err != nil {
+				return nil, fmt.Errorf("error getting capi credentials for repository: %w", err)
+			}
+
+			awsAuth := &ints.AWSIntegration{
+				AWSAccessKeyID:     []byte(creds.Msg.AwsAccessId),
+				AWSSecretAccessKey: []byte(creds.Msg.AwsSecretKey),
+				AWSSessionToken:    []byte(creds.Msg.AwsSessionToken),
+			}
+
+			awsClusterID := cluster.Name
+			shouldOverride := false
+
+			if cluster.AWSClusterID != "" {
+				awsClusterID = cluster.AWSClusterID
+				shouldOverride = true
+			}
+
+			tok, err := awsAuth.GetBearerToken(conf.getTokenCache, conf.setTokenCache, awsClusterID, shouldOverride)
+			if err != nil {
+				return nil, fmt.Errorf("error getting bearer token for repository: %w", err)
+			}
+
+			authInfoMap[authInfoName].Token = tok
 		}
-
-		awsClusterID := cluster.Name
-		shouldOverride := false
-
-		if cluster.AWSClusterID != "" {
-			awsClusterID = cluster.AWSClusterID
-			shouldOverride = true
-		}
-
-		tok, err := awsAuth.GetBearerToken(conf.getTokenCache, conf.setTokenCache, awsClusterID, shouldOverride)
-		if err != nil {
-			return nil, fmt.Errorf("error getting bearer token for repository: %w", err)
-		}
-
-		authInfoMap[authInfoName].Token = tok
-
-		fmt.Printf("I successfully ran!")
 
 	} else {
 		switch cluster.AuthMechanism {


### PR DESCRIPTION
Checking if a token exists for a CAPI cluster before getting the assume role credentials to cut down on time.  This means that the getToken check in the EKSBearerToken is always a no-op in the CAPI case, which is fine fore now.

No need to make any changes for expiration time; looks like the tokens returned by the EKSBearerToken method include their own expiration time (I checked the db, and the CAPI tokens are 15 mins).

I want to come back to this function and refactor code to make things cleaner, but first wanted to make the smallest change possible to get latency down.