### PR TITLE
add telemetry to all helm agent.go methods

### DIFF
--- a/api/server/authz/release.go
+++ b/api/server/authz/release.go
@@ -50,7 +50,7 @@ func (p *ReleaseScopedMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	// get the version for the application
 	version, _ := requestutils.GetURLParamUint(r, types.URLParamReleaseVersion)
 
-	release, err := helmAgent.GetRelease(name, int(version), false)
+	release, err := helmAgent.GetRelease(context.Background(), name, int(version), false)
 	if err != nil {
 		// ugly casing since at the time of this commit Helm doesn't have an errors package.
 		// so we rely on the Helm error containing "not found"

--- a/api/server/handlers/cluster/install_agent.go
+++ b/api/server/handlers/cluster/install_agent.go
@@ -65,7 +65,7 @@ func (c *InstallAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	chart, err := loader.LoadChartPublic(c.Config().ServerConf.DefaultAddonHelmRepoURL, "porter-agent", "")
+	chart, err := loader.LoadChartPublic(context.Background(), c.Config().ServerConf.DefaultAddonHelmRepoURL, "porter-agent", "")
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
@@ -139,7 +139,7 @@ func (c *InstallAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Values:    porterAgentValues,
 	}
 
-	_, err = helmAgent.InstallChart(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
+	_, err = helmAgent.InstallChart(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
@@ -172,13 +172,13 @@ func checkAndDeleteOlderAgent(k8sAgent *kubernetes.Agent, helmAgent *helm.Agent)
 	}
 
 	// detect if the `porter-agent` release is installed
-	helmRelease, err := helmAgent.GetRelease("porter-agent", 0, false)
+	helmRelease, err := helmAgent.GetRelease(context.Background(), "porter-agent", 0, false)
 
 	if err != nil || helmRelease == nil {
 		return nil
 	}
 
-	_, err = helmAgent.UninstallChart("porter-agent")
+	_, err = helmAgent.UninstallChart(context.Background(), "porter-agent")
 
 	if err != nil {
 		return err

--- a/api/server/handlers/cluster/upgrade_agent.go
+++ b/api/server/handlers/cluster/upgrade_agent.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -39,13 +40,13 @@ func (c *UpgradeAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	currRelease, err := helmAgent.GetRelease("porter-agent", 0, false)
+	currRelease, err := helmAgent.GetRelease(context.Background(), "porter-agent", 0, false)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
 	}
 
-	chart, err := loader.LoadChartPublic(c.Config().ServerConf.DefaultAddonHelmRepoURL, "porter-agent", "")
+	chart, err := loader.LoadChartPublic(context.Background(), c.Config().ServerConf.DefaultAddonHelmRepoURL, "porter-agent", "")
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
@@ -56,7 +57,7 @@ func (c *UpgradeAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	// TODO: update values
 	// newValues["redis"] =
 
-	_, err = helmAgent.UpgradeReleaseByValues(&helm.UpgradeReleaseConfig{
+	_, err = helmAgent.UpgradeReleaseByValues(context.Background(), &helm.UpgradeReleaseConfig{
 		Chart:      chart,
 		Name:       "porter-agent",
 		Values:     newValues,

--- a/api/server/handlers/namespace/create_env_group.go
+++ b/api/server/handlers/namespace/create_env_group.go
@@ -1,6 +1,7 @@
 package namespace
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -185,7 +186,7 @@ func rolloutApplications(
 				Values:     newConfig,
 			}
 
-			_, err = helmAgent.UpgradeReleaseByValues(conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)
+			_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)
 
 			if err != nil {
 				mu.Lock()

--- a/api/server/handlers/namespace/list_releases.go
+++ b/api/server/handlers/namespace/list_releases.go
@@ -1,6 +1,7 @@
 package namespace
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/porter-dev/porter/api/server/authz"
@@ -48,7 +49,7 @@ func (c *ListReleasesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	releases, err := helmAgent.ListReleases(namespace, request.ReleaseListFilter)
+	releases, err := helmAgent.ListReleases(context.Background(), namespace, request.ReleaseListFilter)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/api/server/handlers/release/create.go
+++ b/api/server/handlers/release/create.go
@@ -119,7 +119,7 @@ func (c *CreateReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		request.TemplateVersion = ""
 	}
 
-	chart, err := loader.LoadChartPublic(request.RepoURL, request.TemplateName, request.TemplateVersion)
+	chart, err := loader.LoadChartPublic(ctx, request.RepoURL, request.TemplateName, request.TemplateVersion)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(telemetry.Error(ctx, span, err, "error loading public chart")))
 		return
@@ -154,7 +154,7 @@ func (c *CreateReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		Registries: registries,
 	}
 
-	helmRelease, err := helmAgent.InstallChart(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
+	helmRelease, err := helmAgent.InstallChart(ctx, conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 			telemetry.Error(ctx, span, err, "error installing a new chart"),

--- a/api/server/handlers/release/create_addon.go
+++ b/api/server/handlers/release/create_addon.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -91,7 +92,7 @@ func (c *CreateAddonHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Registries: registries,
 	}
 
-	helmRelease, err := helmAgent.InstallChart(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
+	helmRelease, err := helmAgent.InstallChart(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 			fmt.Errorf("error installing a new chart: %s", err.Error()),
@@ -124,7 +125,7 @@ type LoadAddonChartOpts struct {
 func LoadChart(config *config.Config, opts *LoadAddonChartOpts) (*chart.Chart, error) {
 	// if the chart repo url is one of the specified application/addon charts, just load public
 	if opts.RepoURL == config.ServerConf.DefaultAddonHelmRepoURL || opts.RepoURL == config.ServerConf.DefaultApplicationHelmRepoURL {
-		return loader.LoadChartPublic(opts.RepoURL, opts.TemplateName, opts.TemplateVersion)
+		return loader.LoadChartPublic(context.Background(), opts.RepoURL, opts.TemplateName, opts.TemplateVersion)
 	} else {
 		// load the helm repos in the project
 		hrs, err := config.Repo.HelmRepo().ListHelmReposByProjectID(opts.ProjectID)
@@ -141,12 +142,13 @@ func LoadChart(config *config.Config, opts *LoadAddonChartOpts) (*chart.Chart, e
 						return nil, err
 					}
 
-					return loader.LoadChart(&loader.BasicAuthClient{
-						Username: string(basic.Username),
-						Password: string(basic.Password),
-					}, hr.RepoURL, opts.TemplateName, opts.TemplateVersion)
+					return loader.LoadChart(context.Background(),
+						&loader.BasicAuthClient{
+							Username: string(basic.Username),
+							Password: string(basic.Password),
+						}, hr.RepoURL, opts.TemplateName, opts.TemplateVersion)
 				} else {
-					return loader.LoadChartPublic(hr.RepoURL, opts.TemplateName, opts.TemplateVersion)
+					return loader.LoadChartPublic(context.Background(), hr.RepoURL, opts.TemplateName, opts.TemplateVersion)
 				}
 			}
 		}

--- a/api/server/handlers/release/delete.go
+++ b/api/server/handlers/release/delete.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -43,7 +44,7 @@ func (c *DeleteReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_, err = helmAgent.UninstallChart(helmRelease.Name)
+	_, err = helmAgent.UninstallChart(context.Background(), helmRelease.Name)
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))

--- a/api/server/handlers/release/get_history.go
+++ b/api/server/handlers/release/get_history.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/porter-dev/porter/api/server/authz"
@@ -40,7 +41,7 @@ func (c *GetReleaseHistoryHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	// get the name of the application
 	name, _ := requestutils.GetURLParamString(r, types.URLParamReleaseName)
-	history, err := helmAgent.GetReleaseHistory(name)
+	history, err := helmAgent.GetReleaseHistory(context.Background(), name)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/api/server/handlers/release/update_image_batch.go
+++ b/api/server/handlers/release/update_image_batch.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -75,7 +76,7 @@ func (c *UpdateImageBatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		go func() {
 			defer wg.Done()
 			// read release via agent
-			rel, err := helmAgent.GetRelease(releases[index].Name, 0, false)
+			rel, err := helmAgent.GetRelease(context.Background(), releases[index].Name, 0, false)
 			if err != nil {
 				// if this is a release not found error, just return - the release has likely been deleted from the underlying
 				// cluster but has not been deleted from the Porter database yet
@@ -104,7 +105,7 @@ func (c *UpdateImageBatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 					Values:     rel.Config,
 				}
 
-				_, err = helmAgent.UpgradeReleaseByValues(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
+				_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
 
 				if err != nil {
 					// if this is a release not found error, just return - the release has likely been deleted from the underlying

--- a/api/server/handlers/release/update_rollback.go
+++ b/api/server/handlers/release/update_rollback.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -48,7 +49,7 @@ func (c *RollbackReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = helmAgent.RollbackRelease(helmRelease.Name, request.Revision)
+	err = helmAgent.RollbackRelease(context.Background(), helmRelease.Name, request.Revision)
 
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(

--- a/api/server/handlers/release/upgrade.go
+++ b/api/server/handlers/release/upgrade.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -116,7 +117,7 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	// if LatestRevision is set, check that the revision matches the latest revision in the database
 	if request.LatestRevision != 0 {
-		currHelmRelease, err := helmAgent.GetRelease(helmRelease.Name, 0, false)
+		currHelmRelease, err := helmAgent.GetRelease(context.Background(), helmRelease.Name, 0, false)
 		if err != nil {
 			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 				fmt.Errorf("could not retrieve latest revision"),
@@ -153,7 +154,7 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	newHelmRelease, upgradeErr := helmAgent.UpgradeRelease(conf, request.Values, c.Config().DOConf,
+	newHelmRelease, upgradeErr := helmAgent.UpgradeRelease(context.Background(), conf, request.Values, c.Config().DOConf,
 		c.Config().ServerConf.DisablePullSecretsInjection, request.IgnoreDependencies)
 
 	if upgradeErr == nil && newHelmRelease != nil {

--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -84,7 +85,7 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rel, err := helmAgent.GetRelease(release.Name, 0, true)
+	rel, err := helmAgent.GetRelease(context.Background(), release.Name, 0, true)
 	if err != nil {
 		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return
@@ -168,7 +169,7 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		),
 	}
 
-	rel, err = helmAgent.UpgradeReleaseByValues(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
+	rel, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
 
 	if err != nil {
 		notifyOpts.Status = notifier.StatusHelmFailed

--- a/api/server/handlers/stack/helpers.go
+++ b/api/server/handlers/stack/helpers.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"context"
+
 	"github.com/porter-dev/porter/api/server/shared/config"
 	"github.com/porter-dev/porter/api/types"
 	"github.com/porter-dev/porter/internal/helm"
@@ -28,7 +30,7 @@ func applyAppResource(opts *applyAppResourceOpts) (*release.Release, error) {
 		opts.request.TemplateVersion = ""
 	}
 
-	chart, err := loader.LoadChartPublic(opts.request.TemplateRepoURL, opts.request.TemplateName, opts.request.TemplateVersion)
+	chart, err := loader.LoadChartPublic(context.Background(), opts.request.TemplateRepoURL, opts.request.TemplateName, opts.request.TemplateVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,7 @@ func applyAppResource(opts *applyAppResourceOpts) (*release.Release, error) {
 		"revision": opts.stackRevision,
 	}
 
-	return opts.helmAgent.InstallChart(conf, opts.config.DOConf, opts.config.ServerConf.DisablePullSecretsInjection)
+	return opts.helmAgent.InstallChart(context.Background(), conf, opts.config.DOConf, opts.config.ServerConf.DisablePullSecretsInjection)
 }
 
 type rollbackAppResourceOpts struct {
@@ -63,7 +65,7 @@ type rollbackAppResourceOpts struct {
 }
 
 func rollbackAppResource(opts *rollbackAppResourceOpts) error {
-	return opts.helmAgent.RollbackRelease(opts.name, int(opts.helmRevisionID))
+	return opts.helmAgent.RollbackRelease(context.Background(), opts.name, int(opts.helmRevisionID))
 }
 
 type updateAppResourceTagOpts struct {
@@ -82,7 +84,7 @@ type updateAppResourceTagOpts struct {
 
 func updateAppResourceTag(opts *updateAppResourceTagOpts) error {
 	// read the current release to get the current values
-	rel, err := opts.helmAgent.GetRelease(opts.name, 0, true)
+	rel, err := opts.helmAgent.GetRelease(context.Background(), opts.name, 0, true)
 	if err != nil {
 		return err
 	}
@@ -104,7 +106,7 @@ func updateAppResourceTag(opts *updateAppResourceTagOpts) error {
 		StackRevision: opts.stackRevision,
 	}
 
-	_, err = opts.helmAgent.UpgradeReleaseByValues(conf, opts.config.DOConf,
+	_, err = opts.helmAgent.UpgradeReleaseByValues(context.Background(), conf, opts.config.DOConf,
 		opts.config.ServerConf.DisablePullSecretsInjection, false)
 
 	return err
@@ -116,7 +118,7 @@ type deleteAppResourceOpts struct {
 }
 
 func deleteAppResource(opts *deleteAppResourceOpts) error {
-	_, err := opts.helmAgent.UninstallChart(opts.name)
+	_, err := opts.helmAgent.UninstallChart(context.Background(), opts.name)
 
 	return err
 }

--- a/api/server/handlers/template/get.go
+++ b/api/server/handlers/template/get.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -49,7 +50,7 @@ func (t *TemplateGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		request.RepoURL = t.Config().ServerConf.DefaultApplicationHelmRepoURL
 	}
 
-	chart, err := loader.LoadChartPublic(request.RepoURL, name, version)
+	chart, err := loader.LoadChartPublic(context.Background(), request.RepoURL, name, version)
 	if err != nil {
 		t.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/api/server/handlers/template/get_upgrade_notes.go
+++ b/api/server/handlers/template/get_upgrade_notes.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -51,7 +52,7 @@ func (t *TemplateGetUpgradeNotesHandler) ServeHTTP(w http.ResponseWriter, r *htt
 		prevVersion = "v0.0.0"
 	}
 
-	chart, err := loader.LoadChartPublic(request.RepoURL, name, version)
+	chart, err := loader.LoadChartPublic(context.Background(), request.RepoURL, name, version)
 	if err != nil {
 		t.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/api/server/handlers/v1/env_group/create.go
+++ b/api/server/handlers/v1/env_group/create.go
@@ -1,6 +1,7 @@
 package env_group
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -201,7 +202,7 @@ func rolloutApplications(
 				Values:     newConfig,
 			}
 
-			_, err = helmAgent.UpgradeReleaseByValues(conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)
+			_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)
 
 			if err != nil {
 				mu.Lock()

--- a/api/server/handlers/v1/release/upgrade.go
+++ b/api/server/handlers/v1/release/upgrade.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -118,7 +119,7 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	// if LatestRevision is set, check that the revision matches the latest revision in the database
 	if request.LatestRevision != 0 {
-		currHelmRelease, err := helmAgent.GetRelease(helmRelease.Name, 0, false)
+		currHelmRelease, err := helmAgent.GetRelease(context.Background(), helmRelease.Name, 0, false)
 		if err != nil {
 			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(
 				fmt.Errorf("could not retrieve latest revision"),
@@ -138,7 +139,7 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	newHelmRelease, upgradeErr := helmAgent.UpgradeReleaseByValues(conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
+	newHelmRelease, upgradeErr := helmAgent.UpgradeReleaseByValues(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
 
 	if upgradeErr == nil && newHelmRelease != nil {
 		helmRelease = newHelmRelease

--- a/api/server/handlers/v1/template/get.go
+++ b/api/server/handlers/v1/template/get.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -81,7 +82,7 @@ func (t *TemplateGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		version = ""
 	}
 
-	chart, err := loader.LoadChartPublic(request.RepoURL, name, version)
+	chart, err := loader.LoadChartPublic(context.Background(), request.RepoURL, name, version)
 	if err != nil {
 		t.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/api/server/handlers/v1/template/get_upgrade_notes.go
+++ b/api/server/handlers/v1/template/get_upgrade_notes.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -83,7 +84,7 @@ func (t *TemplateGetUpgradeNotesHandler) ServeHTTP(w http.ResponseWriter, r *htt
 		prevVersion = "v0.0.0"
 	}
 
-	chart, err := loader.LoadChartPublic(request.RepoURL, name, version)
+	chart, err := loader.LoadChartPublic(context.Background(), request.RepoURL, name, version)
 	if err != nil {
 		t.HandleAPIError(w, r, apierrors.NewErrInternal(err))
 		return

--- a/internal/helm/agent_test.go
+++ b/internal/helm/agent_test.go
@@ -1,6 +1,7 @@
 package helm_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stefanmcshane/helm/pkg/storage/driver"
@@ -223,7 +224,7 @@ func TestGetReleases(t *testing.T) {
 		// namespace, so we have to reset the namespace of the storage driver
 		agent.ActionConfig.Releases.Driver.(*driver.Memory).SetNamespace(tc.namespace)
 
-		rel, err := agent.GetRelease(tc.getName, tc.getVersion, false)
+		rel, err := agent.GetRelease(context.Background(), tc.getName, tc.getVersion, false)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -256,7 +257,7 @@ func TestListReleaseHistory(t *testing.T) {
 		// namespace, so we have to reset the namespace of the storage driver
 		agent.ActionConfig.Releases.Driver.(*driver.Memory).SetNamespace(tc.namespace)
 
-		releases, err := agent.GetReleaseHistory("wordpress")
+		releases, err := agent.GetReleaseHistory(context.Background(), "wordpress")
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -325,12 +326,12 @@ func TestRollbackRelease(t *testing.T) {
 		// namespace, so we have to reset the namespace of the storage driver
 		agent.ActionConfig.Releases.Driver.(*driver.Memory).SetNamespace(tc.namespace)
 
-		err := agent.RollbackRelease("wordpress", 1)
+		err := agent.RollbackRelease(context.Background(), "wordpress", 1)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
 
-		rel, err := agent.GetRelease(tc.getName, tc.getVersion, false)
+		rel, err := agent.GetRelease(context.Background(), tc.getName, tc.getVersion, false)
 		if err != nil {
 			t.Errorf("%v", err)
 		}

--- a/internal/helm/repo/repo.go
+++ b/internal/helm/repo/repo.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/porter-dev/porter/api/types"
@@ -78,7 +79,7 @@ func (hr *HelmRepo) getChartBasic(
 		Password: string(basic.Password),
 	}
 
-	return loader.LoadChart(client, hr.RepoURL, chartName, chartVersion)
+	return loader.LoadChart(context.Background(), client, hr.RepoURL, chartName, chartVersion)
 }
 
 func ValidateRepoURL(

--- a/internal/kubernetes/envgroup/create.go
+++ b/internal/kubernetes/envgroup/create.go
@@ -1,6 +1,7 @@
 package envgroup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -190,7 +191,7 @@ func GetSyncedReleases(helmAgent *helm.Agent, configMap *v1.ConfigMap) ([]*relea
 	appStrArr := strings.Split(appStr, ",")
 
 	// list all latest helm releases and check them against app string
-	releases, err := helmAgent.ListReleases(configMap.Namespace, &types.ReleaseListFilter{
+	releases, err := helmAgent.ListReleases(context.Background(), configMap.Namespace, &types.ReleaseListFilter{
 		StatusFilter: []string{
 			"deployed",
 			"uninstalled",

--- a/internal/opa/opa.go
+++ b/internal/opa/opa.go
@@ -172,7 +172,7 @@ func (runner *KubernetesOPARunner) runHelmReleaseQueries(name string, collection
 	var helmReleases []*release.Release
 
 	if collection.Match.Name != "" {
-		helmRelease, err := helmAgent.GetRelease(collection.Match.Name, 0, false)
+		helmRelease, err := helmAgent.GetRelease(context.Background(), collection.Match.Name, 0, false)
 
 		if err != nil {
 			if collection.MustExist && strings.Contains(err.Error(), "not found") {
@@ -204,7 +204,7 @@ func (runner *KubernetesOPARunner) runHelmReleaseQueries(name string, collection
 
 		helmReleases = append(helmReleases, helmRelease)
 	} else if collection.Match.ChartName != "" {
-		prefilterReleases, err := helmAgent.ListReleases(collection.Match.Namespace, &types.ReleaseListFilter{
+		prefilterReleases, err := helmAgent.ListReleases(context.Background(), collection.Match.Namespace, &types.ReleaseListFilter{
 			ByDate: true,
 			StatusFilter: []string{
 				"deployed",

--- a/internal/templater/helm/values/writer.go
+++ b/internal/templater/helm/values/writer.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/porter-dev/porter/internal/helm"
@@ -42,7 +43,7 @@ func (w *TemplateWriter) Create(
 		Values:    vals,
 	}
 
-	_, err := w.Agent.InstallChart(conf, nil, false)
+	_, err := w.Agent.InstallChart(context.Background(), conf, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,7 @@ func (w *TemplateWriter) Update(
 		Values: vals,
 	}
 
-	_, err := w.Agent.UpgradeReleaseByValues(conf, nil, false, false)
+	_, err := w.Agent.UpgradeReleaseByValues(context.Background(), conf, nil, false, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding telemetry to all the helm agent.go methods (for the purpose of getting more information on the legacy and stack create release methods). 

Note: I added `context.Background()` to all method calls that weren't involved with the create release methods. When we go back to properly add telemetry to these handlers, we MUST replace the `context.Background()` with the `ctx` generated from the telemetry span (otherwise, the helm method spans won't be properly linked).