### PR TITLE
update predeploy job charts on every run

### DIFF
--- a/api/server/handlers/porter_app/create.go
+++ b/api/server/handlers/porter_app/create.go
@@ -268,12 +268,19 @@ func (c *CreatePorterAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 					}
 					return
 				} else {
+					chart, err := loader.LoadChartPublic(ctx, c.Config().Metadata.DefaultAppHelmRepoURL, "job", "")
+					if err != nil {
+						c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(fmt.Errorf("error loading release job chart: %w", err), http.StatusBadRequest))
+						return
+					}
+
 					conf := &helm.UpgradeReleaseConfig{
 						Name:       helmRelease.Name,
 						Cluster:    cluster,
 						Repo:       c.Repo(),
 						Registries: registries,
 						Values:     releaseJobValues,
+						Chart:      chart,
 					}
 					_, err = helmAgent.UpgradeReleaseByValues(ctx, conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
 					if err != nil {

--- a/api/server/handlers/porter_app/list_events.go
+++ b/api/server/handlers/porter_app/list_events.go
@@ -179,8 +179,6 @@ func (p *PorterAppEventListHandler) updateExistingAppEvent(ctx context.Context, 
 		}
 	}
 
-	fmt.Println("STEFAN", *actionRun.Status, actionRun.Conclusion, event.Status)
-
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-app-event-updated-status", Value: event.Status})
 
 	err = p.Repo().PorterAppEvent().UpdateEvent(ctx, &event)


### PR DESCRIPTION
- Predeploy job charts were being set when the job was created, and never updated afterwards. If the job was created on a 1.24 cluster (which supports `batch/v1beta1`), then updated to 1.25(which doesnt support `batch/v1beta1`), then job updates would fail