### PR TITLE
more azure support

### DIFF
--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -201,6 +201,7 @@ func (c *Client) GetGARAuthorizationToken(
 func (c *Client) GetACRAuthorizationToken(
 	ctx context.Context,
 	projectID uint,
+	req *types.GetRegistryACRTokenRequest,
 ) (*types.GetRegistryTokenResponse, error) {
 	resp := &types.GetRegistryTokenResponse{}
 
@@ -209,7 +210,7 @@ func (c *Client) GetACRAuthorizationToken(
 			"/projects/%d/registries/acr/token",
 			projectID,
 		),
-		nil,
+		req,
 		resp,
 	)
 

--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -216,6 +216,25 @@ func (c *Client) GetACRAuthorizationToken(
 	return resp, err
 }
 
+// GetACRDockerConfigFile gets an ACR Docker config file
+func (c *Client) GetACRDockerConfigFile(
+	ctx context.Context,
+	projectID uint,
+) (*types.GetRegistryTokenResponse, error) {
+	resp := &types.GetRegistryTokenResponse{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/registries/acr/token",
+			projectID,
+		),
+		nil,
+		resp,
+	)
+
+	return resp, err
+}
+
 // GetDockerhubAuthorizationToken gets a Docker Hub authorization token
 func (c *Client) GetDockerhubAuthorizationToken(
 	ctx context.Context,

--- a/api/server/handlers/cluster/install_agent.go
+++ b/api/server/handlers/cluster/install_agent.go
@@ -140,12 +140,13 @@ func (c *InstallAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	conf := &helm.InstallChartConfig{
-		Chart:     chart,
-		Name:      "porter-agent",
-		Namespace: "porter-agent-system",
-		Cluster:   cluster,
-		Repo:      c.Repo(),
-		Values:    porterAgentValues,
+		Chart:                     chart,
+		Name:                      "porter-agent",
+		Namespace:                 "porter-agent-system",
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Values:                    porterAgentValues,
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}
 
 	_, err = helmAgent.InstallChart(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)

--- a/api/server/handlers/cluster/upgrade_agent.go
+++ b/api/server/handlers/cluster/upgrade_agent.go
@@ -58,12 +58,13 @@ func (c *UpgradeAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	// newValues["redis"] =
 
 	_, err = helmAgent.UpgradeReleaseByValues(context.Background(), &helm.UpgradeReleaseConfig{
-		Chart:      chart,
-		Name:       "porter-agent",
-		Values:     newValues,
-		Cluster:    cluster,
-		Repo:       c.Repo(),
-		Registries: []*models.Registry{},
+		Chart:                     chart,
+		Name:                      "porter-agent",
+		Values:                    newValues,
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Registries:                []*models.Registry{},
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)
 
 	if err != nil {

--- a/api/server/handlers/namespace/create_env_group.go
+++ b/api/server/handlers/namespace/create_env_group.go
@@ -179,11 +179,12 @@ func rolloutApplications(
 			}
 
 			conf := &helm.UpgradeReleaseConfig{
-				Name:       releases[index].Name,
-				Cluster:    cluster,
-				Repo:       config.Repo,
-				Registries: registries,
-				Values:     newConfig,
+				Name:                      releases[index].Name,
+				Cluster:                   cluster,
+				Repo:                      config.Repo,
+				Registries:                registries,
+				Values:                    newConfig,
+				ClusterControlPlaneClient: config.ClusterControlPlaneClient,
 			}
 
 			_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)

--- a/api/server/handlers/project_integration/create_azure.go
+++ b/api/server/handlers/project_integration/create_azure.go
@@ -3,6 +3,8 @@ package project_integration
 import (
 	"net/http"
 
+	"github.com/porter-dev/porter/internal/telemetry"
+
 	"github.com/bufbuild/connect-go"
 
 	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
@@ -31,12 +33,17 @@ func NewCreateAzureHandler(
 }
 
 func (p *CreateAzureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	user, _ := r.Context().Value(types.UserScope).(*models.User)
-	project, _ := r.Context().Value(types.ProjectScope).(*models.Project)
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-create-azure-connection")
+	defer span.End()
+
+	user, _ := ctx.Value(types.UserScope).(*models.User)
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
 
 	request := &types.CreateAzureRequest{}
 
 	if ok := p.DecodeAndValidate(w, r, request); !ok {
+		err := telemetry.Error(ctx, span, nil, "error decoding and validating request")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
 
@@ -44,7 +51,8 @@ func (p *CreateAzureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	az, err := p.Repo().AzureIntegration().CreateAzureIntegration(az)
 	if err != nil {
-		p.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		err := telemetry.Error(ctx, span, err, "error creating azure integration")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
 
@@ -59,12 +67,20 @@ func (p *CreateAzureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		TenantId:               request.AzureTenantID,
 		ServicePrincipalSecret: []byte(request.ServicePrincipalKey),
 	})
-	_, err = p.Config().ClusterControlPlaneClient.CreateAzureConnection(r.Context(), req)
-
+	resp, err := p.Config().ClusterControlPlaneClient.CreateAzureConnection(ctx, req)
 	if err != nil {
-		p.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		err := telemetry.Error(ctx, span, err, "error creating azure connection")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
+
+	if resp.Msg == nil || resp.Msg.CredentialsIdentifier == "" {
+		err := telemetry.Error(ctx, span, err, "no cloud credential identifier returned")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	res.CloudProviderCredentialIdentifier = resp.Msg.CredentialsIdentifier
 
 	p.WriteResult(w, r, res)
 }

--- a/api/server/handlers/project_integration/create_azure.go
+++ b/api/server/handlers/project_integration/create_azure.go
@@ -60,14 +60,14 @@ func (p *CreateAzureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AzureIntegration: az.ToAzureIntegrationType(),
 	}
 
-	req := connect.NewRequest(&porterv1.CreateAzureConnectionRequest{
+	req := connect.NewRequest(&porterv1.SaveAzureCredentialsRequest{
 		ProjectId:              int64(project.ID),
 		ClientId:               request.AzureClientID,
 		SubscriptionId:         request.AzureSubscriptionID,
 		TenantId:               request.AzureTenantID,
 		ServicePrincipalSecret: []byte(request.ServicePrincipalKey),
 	})
-	resp, err := p.Config().ClusterControlPlaneClient.CreateAzureConnection(ctx, req)
+	resp, err := p.Config().ClusterControlPlaneClient.SaveAzureCredentials(ctx, req)
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "error creating azure connection")
 		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
@@ -75,7 +75,7 @@ func (p *CreateAzureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if resp.Msg == nil || resp.Msg.CredentialsIdentifier == "" {
-		err := telemetry.Error(ctx, span, err, "no cloud credential identifier returned")
+		err := telemetry.Error(ctx, span, nil, "no cloud credential identifier returned")
 		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}

--- a/api/server/handlers/registry/get_token.go
+++ b/api/server/handlers/registry/get_token.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/porter-dev/porter/internal/telemetry"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/bufbuild/connect-go"
 	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
@@ -18,9 +21,6 @@ import (
 	"github.com/porter-dev/porter/internal/models"
 	"github.com/porter-dev/porter/internal/oauth"
 	"github.com/porter-dev/porter/internal/registry"
-	"github.com/porter-dev/porter/internal/telemetry"
-
-	"github.com/aws/aws-sdk-go/aws/arn"
 )
 
 type RegistryGetECRTokenHandler struct {
@@ -402,12 +402,18 @@ func NewRegistryGetACRTokenHandler(
 }
 
 func (c *RegistryGetACRTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	proj, _ := r.Context().Value(types.ProjectScope).(*models.Project)
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-acr-token")
+	defer span.End()
+
+	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "project-id", Value: proj.ID})
 
 	// list registries and find one that matches the region
 	regs, err := c.Repo().Registry().ListRegistriesByProjectID(proj.ID)
 	if err != nil {
-		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		err := telemetry.Error(ctx, span, err, "error getting registries by project id")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
 
@@ -415,20 +421,56 @@ func (c *RegistryGetACRTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	var expiresAt *time.Time
 
 	for _, reg := range regs {
-		if reg.AzureIntegrationID != 0 && strings.Contains(reg.URL, "azurecr.io") {
-			_reg := registry.Registry(*reg)
-			username, pw, err := _reg.GetACRCredentials(c.Repo())
-			if err != nil {
-				c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
-				continue
+		if strings.Contains(reg.URL, "azurecr.io") {
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "registry-name", Value: reg.Name})
+
+			if proj.CapiProvisionerEnabled {
+				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "capi-provisioned", Value: true})
+
+				tokenReq := connect.NewRequest(&porterv1.TokenForRegistryRequest{
+					ProjectId:   int64(proj.ID),
+					RegistryUri: reg.URL,
+				})
+				tokenResp, err := c.Config().ClusterControlPlaneClient.TokenForRegistry(ctx, tokenReq)
+				if err != nil {
+					err := telemetry.Error(ctx, span, err, "error getting token response from ccp")
+					c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+					return
+				}
+
+				if tokenResp.Msg == nil || tokenResp.Msg.Token == "" {
+					err := telemetry.Error(ctx, span, err, "no token found in response")
+					c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+					return
+				}
+
+				token = tokenResp.Msg.Token
+
+				// we'll just set an arbitrary 30-day expiry time (this is not enforced)
+				timeExpires := time.Now().Add(30 * 24 * 3600 * time.Second)
+				expiresAt = &timeExpires
+			} else if reg.AzureIntegrationID != 0 {
+				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "capi-provisioned", Value: false})
+
+				_reg := registry.Registry(*reg)
+				username, pw, err := _reg.GetACRCredentials(c.Repo())
+				if err != nil {
+					c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+					continue
+				}
+
+				token = base64.StdEncoding.EncodeToString([]byte(string(username) + ":" + string(pw)))
+				// we'll just set an arbitrary 30-day expiry time (this is not enforced)
+				timeExpires := time.Now().Add(30 * 24 * 3600 * time.Second)
+				expiresAt = &timeExpires
 			}
-
-			token = base64.StdEncoding.EncodeToString([]byte(string(username) + ":" + string(pw)))
-
-			// we'll just set an arbitrary 30-day expiry time (this is not enforced)
-			timeExpires := time.Now().Add(30 * 24 * 3600 * time.Second)
-			expiresAt = &timeExpires
 		}
+	}
+
+	if token == "" {
+		err := telemetry.Error(ctx, span, nil, "missing token")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
 	}
 
 	resp := &types.GetRegistryTokenResponse{

--- a/api/server/handlers/release/create.go
+++ b/api/server/handlers/release/create.go
@@ -142,13 +142,14 @@ func (c *CreateReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	conf := &helm.InstallChartConfig{
-		Chart:      chart,
-		Name:       request.Name,
-		Namespace:  namespace,
-		Values:     request.Values,
-		Cluster:    cluster,
-		Repo:       c.Repo(),
-		Registries: registries,
+		Chart:                     chart,
+		Name:                      request.Name,
+		Namespace:                 namespace,
+		Values:                    request.Values,
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Registries:                registries,
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}
 
 	helmRelease, err := helmAgent.InstallChart(ctx, conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)

--- a/api/server/handlers/release/create_addon.go
+++ b/api/server/handlers/release/create_addon.go
@@ -83,13 +83,14 @@ func (c *CreateAddonHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	conf := &helm.InstallChartConfig{
-		Chart:      chart,
-		Name:       request.Name,
-		Namespace:  namespace,
-		Values:     request.Values,
-		Cluster:    cluster,
-		Repo:       c.Repo(),
-		Registries: registries,
+		Chart:                     chart,
+		Name:                      request.Name,
+		Namespace:                 namespace,
+		Values:                    request.Values,
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Registries:                registries,
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}
 
 	helmRelease, err := helmAgent.InstallChart(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection)

--- a/api/server/handlers/release/update_image_batch.go
+++ b/api/server/handlers/release/update_image_batch.go
@@ -98,11 +98,12 @@ func (c *UpdateImageBatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				rel.Config["paused"] = true
 
 				conf := &helm.UpgradeReleaseConfig{
-					Name:       releases[index].Name,
-					Cluster:    cluster,
-					Repo:       c.Repo(),
-					Registries: registries,
-					Values:     rel.Config,
+					Name:                      releases[index].Name,
+					Cluster:                   cluster,
+					Repo:                      c.Repo(),
+					Registries:                registries,
+					Values:                    rel.Config,
+					ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 				}
 
 				_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, c.Config().DOConf, c.Config().ServerConf.DisablePullSecretsInjection, false)

--- a/api/server/handlers/release/upgrade_webhook.go
+++ b/api/server/handlers/release/upgrade_webhook.go
@@ -144,11 +144,12 @@ func (c *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	conf := &helm.UpgradeReleaseConfig{
-		Name:       release.Name,
-		Cluster:    cluster,
-		Repo:       c.Repo(),
-		Registries: registries,
-		Values:     rel.Config,
+		Name:                      release.Name,
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Registries:                registries,
+		Values:                    rel.Config,
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}
 
 	slackInts, _ := c.Repo().SlackIntegration().ListSlackIntegrationsByProjectID(release.ProjectID)

--- a/api/server/handlers/stack/helpers.go
+++ b/api/server/handlers/stack/helpers.go
@@ -36,13 +36,14 @@ func applyAppResource(opts *applyAppResourceOpts) (*release.Release, error) {
 	}
 
 	conf := &helm.InstallChartConfig{
-		Chart:      chart,
-		Name:       opts.request.Name,
-		Namespace:  opts.namespace,
-		Values:     opts.request.Values,
-		Cluster:    opts.cluster,
-		Repo:       opts.config.Repo,
-		Registries: opts.registries,
+		Chart:                     chart,
+		Name:                      opts.request.Name,
+		Namespace:                 opts.namespace,
+		Values:                    opts.request.Values,
+		Cluster:                   opts.cluster,
+		Repo:                      opts.config.Repo,
+		Registries:                opts.registries,
+		ClusterControlPlaneClient: opts.config.ClusterControlPlaneClient,
 	}
 
 	if conf.Values == nil {
@@ -95,11 +96,12 @@ func updateAppResourceTag(opts *updateAppResourceTagOpts) error {
 	rel.Config["image"] = image
 
 	conf := &helm.UpgradeReleaseConfig{
-		Name:       opts.name,
-		Cluster:    opts.cluster,
-		Repo:       opts.config.Repo,
-		Registries: opts.registries,
-		Values:     rel.Config,
+		Name:                      opts.name,
+		Cluster:                   opts.cluster,
+		Repo:                      opts.config.Repo,
+		Registries:                opts.registries,
+		Values:                    rel.Config,
+		ClusterControlPlaneClient: opts.config.ClusterControlPlaneClient,
 
 		// stack related info
 		StackName:     opts.stackName,

--- a/api/server/handlers/v1/env_group/create.go
+++ b/api/server/handlers/v1/env_group/create.go
@@ -195,11 +195,12 @@ func rolloutApplications(
 			}
 
 			conf := &helm.UpgradeReleaseConfig{
-				Name:       releases[index].Name,
-				Cluster:    cluster,
-				Repo:       config.Repo,
-				Registries: registries,
-				Values:     newConfig,
+				Name:                      releases[index].Name,
+				Cluster:                   cluster,
+				Repo:                      config.Repo,
+				Registries:                registries,
+				Values:                    newConfig,
+				ClusterControlPlaneClient: config.ClusterControlPlaneClient,
 			}
 
 			_, err = helmAgent.UpgradeReleaseByValues(context.Background(), conf, config.DOConf, config.ServerConf.DisablePullSecretsInjection, false)

--- a/api/server/handlers/v1/release/upgrade.go
+++ b/api/server/handlers/v1/release/upgrade.go
@@ -64,10 +64,11 @@ func (c *UpgradeReleaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	conf := &helm.UpgradeReleaseConfig{
-		Name:       helmRelease.Name,
-		Cluster:    cluster,
-		Repo:       c.Repo(),
-		Registries: registries,
+		Name:                      helmRelease.Name,
+		Cluster:                   cluster,
+		Repo:                      c.Repo(),
+		Registries:                registries,
+		ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
 	}
 
 	// if the chart version is set, load a chart from the repo

--- a/api/server/shared/config/loader/init_ee.go
+++ b/api/server/shared/config/loader/init_ee.go
@@ -5,7 +5,6 @@ package loader
 
 import (
 	eeBilling "github.com/porter-dev/porter/ee/billing"
-	"github.com/porter-dev/porter/ee/integrations/vault"
 	"github.com/porter-dev/porter/ee/models"
 	"github.com/porter-dev/porter/internal/billing"
 )

--- a/api/types/project_integration.go
+++ b/api/types/project_integration.go
@@ -170,6 +170,7 @@ type CreateAzureRequest struct {
 
 type CreateAzureResponse struct {
 	*AzureIntegration
+	CloudProviderCredentialIdentifier string `json:"cloud_provider_credentials_id"`
 }
 
 type ListAzureResponse []*AzureIntegration

--- a/api/types/registry.go
+++ b/api/types/registry.go
@@ -176,6 +176,10 @@ type GetRegistryTokenResponse struct {
 	ExpiresAt *time.Time `json:"expires_at"`
 }
 
+type GetRegistryACRTokenRequest struct {
+	ServerURL string `schema:"server_url"`
+}
+
 type GetRegistryGCRTokenRequest struct {
 	ServerURL string `schema:"server_url"`
 }

--- a/cli/cmd/docker/agent.go
+++ b/cli/cmd/docker/agent.go
@@ -334,6 +334,8 @@ func (a *Agent) getPullOptions(image string) (types.ImagePullOptions, error) {
 		return types.ImagePullOptions{}, err
 	}
 
+	fmt.Println(authConfigEncoded)
+
 	return types.ImagePullOptions{
 		RegistryAuth: authConfigEncoded,
 		Platform:     "linux/amd64",

--- a/cli/cmd/docker/auth.go
+++ b/cli/cmd/docker/auth.go
@@ -254,7 +254,8 @@ func (a *AuthGetter) GetACRCredentials(serverURL string, projID uint) (user stri
 	cachedEntry := a.Cache.Get(serverURL)
 	var token string
 
-	if cachedEntry != nil && cachedEntry.IsValid(time.Now()) {
+	if false && cachedEntry != nil && cachedEntry.IsValid(time.Now()) {
+		fmt.Println("reuse token: ", token)
 		token = cachedEntry.AuthorizationToken
 	} else {
 		// get a token from the server

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -133,7 +133,7 @@
     },
     "../../api-contracts/generated/js": {
       "name": "@porter-dev/api-contracts",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^1.1.0"

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,7 +12,7 @@
         "@loadable/component": "^5.15.2",
         "@material-ui/core": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
-        "@porter-dev/api-contracts": "^0.0.63",
+        "@porter-dev/api-contracts": "file:../../api-contracts/generated/js",
         "@sentry/react": "^6.13.2",
         "@sentry/tracing": "^6.13.2",
         "@tanstack/react-query": "^4.13.0",
@@ -129,6 +129,14 @@
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.0"
+      }
+    },
+    "../../api-contracts/generated/js": {
+      "name": "@porter-dev/api-contracts",
+      "version": "0.0.64",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1935,11 +1943,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bufbuild/protobuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.1.1.tgz",
-      "integrity": "sha512-1dS2m3jabfW2XL2K6//41wZkO4XJOZtpe0bKLuta0BvK5LxNRyUBSSN5835n3bIFiNJKFWhDnzZEMrV7QVGFfQ=="
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2430,12 +2433,8 @@
       }
     },
     "node_modules/@porter-dev/api-contracts": {
-      "version": "0.0.63",
-      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.63.tgz",
-      "integrity": "sha512-ItrMS4ifqf/1BhbXj29pqgeTZzC0z6P7QaCppLF24sYFgoEvCUg/O6Ve0PxrpEjdNg3Dx30Qmy0gavcJODGV5g==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.1.0"
-      }
+      "resolved": "../../api-contracts/generated/js",
+      "link": true
     },
     "node_modules/@sentry/browser": {
       "version": "6.19.7",
@@ -16220,11 +16219,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bufbuild/protobuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.1.1.tgz",
-      "integrity": "sha512-1dS2m3jabfW2XL2K6//41wZkO4XJOZtpe0bKLuta0BvK5LxNRyUBSSN5835n3bIFiNJKFWhDnzZEMrV7QVGFfQ=="
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -16564,9 +16558,7 @@
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@porter-dev/api-contracts": {
-      "version": "0.0.63",
-      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.63.tgz",
-      "integrity": "sha512-ItrMS4ifqf/1BhbXj29pqgeTZzC0z6P7QaCppLF24sYFgoEvCUg/O6Ve0PxrpEjdNg3Dx30Qmy0gavcJODGV5g==",
+      "version": "file:../../api-contracts/generated/js",
       "requires": {
         "@bufbuild/protobuf": "^1.1.0"
       }

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,7 +12,7 @@
         "@loadable/component": "^5.15.2",
         "@material-ui/core": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
-        "@porter-dev/api-contracts": "file:../../api-contracts/generated/js",
+        "@porter-dev/api-contracts": "^0.0.66",
         "@sentry/react": "^6.13.2",
         "@sentry/tracing": "^6.13.2",
         "@tanstack/react-query": "^4.13.0",
@@ -129,14 +129,6 @@
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.0"
-      }
-    },
-    "../../api-contracts/generated/js": {
-      "name": "@porter-dev/api-contracts",
-      "version": "0.0.65",
-      "license": "MIT",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1943,6 +1935,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.1.tgz",
+      "integrity": "sha512-cwwGvLGqvoaOZmoP5+i4v/rbW+rHkguvTehuZyM2p/xpmaNSdT2h3B7kHw33aiffv35t1XrYHIkdJSEkSEMJuA=="
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2433,8 +2430,12 @@
       }
     },
     "node_modules/@porter-dev/api-contracts": {
-      "resolved": "../../api-contracts/generated/js",
-      "link": true
+      "version": "0.0.66",
+      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.66.tgz",
+      "integrity": "sha512-RkmHrTWt1Ta3BDpI6Ne6HSlxa8FLBayLwxm2vCfJZrYI2v0BvGoSy6kf7SCBVhMx+GbluWTlMgdAaQ6ymYo34w==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.1.0"
+      }
     },
     "node_modules/@sentry/browser": {
       "version": "6.19.7",
@@ -3095,7 +3096,7 @@
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -16219,6 +16220,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bufbuild/protobuf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.1.tgz",
+      "integrity": "sha512-cwwGvLGqvoaOZmoP5+i4v/rbW+rHkguvTehuZyM2p/xpmaNSdT2h3B7kHw33aiffv35t1XrYHIkdJSEkSEMJuA=="
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -16312,7 +16318,8 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "requires": {}
     },
     "@ironplans/api": {
       "version": "0.4.1",
@@ -16492,7 +16499,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -16558,7 +16566,9 @@
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@porter-dev/api-contracts": {
-      "version": "file:../../api-contracts/generated/js",
+      "version": "0.0.66",
+      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.66.tgz",
+      "integrity": "sha512-RkmHrTWt1Ta3BDpI6Ne6HSlxa8FLBayLwxm2vCfJZrYI2v0BvGoSy6kf7SCBVhMx+GbluWTlMgdAaQ6ymYo34w==",
       "requires": {
         "@bufbuild/protobuf": "^1.1.0"
       }
@@ -16805,7 +16815,8 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
       "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -17118,7 +17129,7 @@
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -18014,13 +18025,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "anser": {
       "version": "2.1.1",
@@ -20937,7 +20950,8 @@
     "goober": {
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.12.tgz",
-      "integrity": "sha512-yXHAvO08FU1JgTXX6Zn6sYCUFfB/OJSX8HHjDSgerZHZmFKAb08cykp5LBw5QnmyMcZyPRMqkdyHUSSzge788Q=="
+      "integrity": "sha512-yXHAvO08FU1JgTXX6Zn6sYCUFfB/OJSX8HHjDSgerZHZmFKAb08cykp5LBw5QnmyMcZyPRMqkdyHUSSzge788Q==",
+      "requires": {}
     },
     "good-listener": {
       "version": "1.2.2",
@@ -21323,7 +21337,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -22200,7 +22215,8 @@
     "markdown-to-jsx": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz",
-      "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg=="
+      "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==",
+      "requires": {}
     },
     "material-colors": {
       "version": "1.2.6",
@@ -23118,7 +23134,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -23409,7 +23426,8 @@
     "react-animate-height": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ=="
+      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "requires": {}
     },
     "react-color": {
       "version": "2.19.3",
@@ -23513,7 +23531,8 @@
     "react-onclickoutside": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
-      "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA=="
+      "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA==",
+      "requires": {}
     },
     "react-popper": {
       "version": "2.3.0",
@@ -23563,7 +23582,8 @@
     "react-table": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA=="
+      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",
@@ -25335,7 +25355,8 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",
@@ -26629,7 +26650,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,7 @@
     "@loadable/component": "^5.15.2",
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
-    "@porter-dev/api-contracts": "file:../../api-contracts/generated/js",
+    "@porter-dev/api-contracts": "^0.0.66",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "@tanstack/react-query": "^4.13.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,7 @@
     "@loadable/component": "^5.15.2",
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
-    "@porter-dev/api-contracts": "^0.0.63",
+    "@porter-dev/api-contracts": "file:../../api-contracts/generated/js",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "@tanstack/react-query": "^4.13.0",

--- a/dashboard/src/components/AzureCredentialForm.tsx
+++ b/dashboard/src/components/AzureCredentialForm.tsx
@@ -52,7 +52,7 @@ const AzureCredentialForm: React.FC<Props> = ({ goBack, proceed }) => {
       )
       .then(({ data }) => {
         setIsLoading(false);
-        proceed(data.id);
+        proceed(data.cloud_provider_credentials_id);
       })
       .catch((err) => {
         console.error(err);

--- a/dashboard/src/components/AzureProvisionerSettings.tsx
+++ b/dashboard/src/components/AzureProvisionerSettings.tsx
@@ -113,7 +113,7 @@ const AzureProvisionerSettings: React.FC<Props> = (props) => {
         projectId: currentProject.id,
         kind: EnumKubernetesKind.AKS,
         cloudProvider: EnumCloudProvider.AZURE,
-        cloudProviderCredentialsId: "",
+        cloudProviderCredentialsId: props.credentialId,
         kindValues: {
           case: "aksKind",
           value: new AKS({

--- a/dashboard/src/components/ProvisionerFlow.tsx
+++ b/dashboard/src/components/ProvisionerFlow.tsx
@@ -17,7 +17,7 @@ const providers = ["aws", "gcp", "azure"];
 
 type Props = {};
 
-const ProvisionerFlow: React.FC<Props> = ({ }) => {
+const ProvisionerFlow: React.FC<Props> = ({}) => {
   const {
     usage,
     hasBillingEnabled,
@@ -40,11 +40,7 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
 
   const markStepCostConsent = async (step: string, provider: string) => {
     try {
-      await api.updateOnboardingStep(
-        "<token>",
-        { step, provider },
-        {}
-      );
+      await api.updateOnboardingStep("<token>", { step, provider }, {});
     } catch (err) {
       console.log(err);
     }
@@ -80,7 +76,7 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
                         provider === "gcp"
                       )
                     ) {
-                      openCostConsentModal(provider)
+                      openCostConsentModal(provider);
                     }
                   }}
                 >
@@ -101,7 +97,7 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
               setShowCostConfirmModal={setShowCostConfirmModal}
               markCostConsentComplete={() => {
                 try {
-                  markStepCostConsent("cost-consent-complete", "aws")
+                  markStepCostConsent("cost-consent-complete", "aws");
                 } catch (err) {
                   console.log(err);
                 }
@@ -126,7 +122,7 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
                 setShowCostConfirmModal={setShowCostConfirmModal}
                 markCostConsentComplete={() => {
                   try {
-                    markStepCostConsent("cost-consent-complete", "azure")
+                    markStepCostConsent("cost-consent-complete", "azure");
                   } catch (err) {
                     console.log(err);
                   }
@@ -141,7 +137,8 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
                       console.log(err);
                     }
                   }
-                }} />
+                }}
+              />
             )))}
       </>
     );
@@ -169,7 +166,8 @@ const ProvisionerFlow: React.FC<Props> = ({ }) => {
       (selectedProvider === "azure" && (
         <AzureCredentialForm
           goBack={() => setCurrentStep("cloud")}
-          proceed={() => {
+          proceed={(id) => {
+            setCredentialId(id);
             setCurrentStep("cluster");
           }}
         />

--- a/dashboard/src/components/ProvisionerFlow.tsx
+++ b/dashboard/src/components/ProvisionerFlow.tsx
@@ -65,14 +65,14 @@ const ProvisionerFlow: React.FC<Props> = ({}) => {
                   key={i}
                   disabled={
                     isUsageExceeded ||
-                    (provider === "azure" && !featurePreview) ||
+                    // (provider === "azure" && !featurePreview) ||
                     provider === "gcp"
                   }
                   onClick={() => {
                     if (
                       !(
                         isUsageExceeded ||
-                        (provider === "azure" && !featurePreview) ||
+                        // (provider === "azure" && !featurePreview) ||
                         provider === "gcp"
                       )
                     ) {

--- a/dashboard/src/main/home/app-dashboard/new-app-flow/GithubActionModal.tsx
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/GithubActionModal.tsx
@@ -17,7 +17,6 @@ import Error from "components/porter/Error";
 import Container from "components/porter/Container";
 import Checkbox from "components/porter/Checkbox";
 
-
 type Props = RouteComponentProps & {
   closeModal: () => void;
   githubAppInstallationID?: number;
@@ -30,7 +29,7 @@ type Props = RouteComponentProps & {
   deployPorterApp?: () => Promise<boolean>;
   deploymentError?: string;
   porterYamlPath?: string;
-}
+};
 
 type Choice = "open_pr" | "copy";
 
@@ -53,9 +52,26 @@ const GithubActionModal: React.FC<Props> = ({
   const [isChecked, setIsChecked] = React.useState<boolean>(false);
 
   const submit = async () => {
-    if (githubAppInstallationID && githubRepoOwner && githubRepoName && branch && stackName && projectId && clusterId) {
+    console.log(
+      githubAppInstallationID,
+      githubRepoOwner,
+      githubRepoName,
+      branch,
+      stackName,
+      projectId,
+      clusterId
+    );
+    if (
+      githubAppInstallationID &&
+      githubRepoOwner &&
+      githubRepoName &&
+      branch &&
+      stackName &&
+      projectId &&
+      clusterId
+    ) {
       try {
-        setLoading(true)
+        setLoading(true);
         // this creates the dummy chart
         var success = true;
         if (deployPorterApp) {
@@ -71,7 +87,7 @@ const GithubActionModal: React.FC<Props> = ({
               github_repo_owner: githubRepoOwner,
               github_repo_name: githubRepoName,
               branch,
-              open_pr: (choice === "open_pr" || isChecked),
+              open_pr: choice === "open_pr" || isChecked,
               porter_yaml_path: porterYamlPath,
             },
             {
@@ -89,37 +105,47 @@ const GithubActionModal: React.FC<Props> = ({
           props.history.push(`/apps/${stackName}`);
         }
       } catch (error) {
-        console.log(error)
+        console.log(error);
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     } else {
       console.log("missing information");
     }
-  }
+  };
   return (
     <Modal closeModal={closeModal}>
-      <Text size={16}>
-        Continuous Integration (CI) with GitHub Actions
-      </Text>
+      <Text size={16}>Continuous Integration (CI) with GitHub Actions</Text>
       <Spacer height="15px" />
       <Text color="helper">
-        In order to automatically update your services every time new code is pushed to your GitHub branch, the following file must exist in your GitHub repository:
+        In order to automatically update your services every time new code is
+        pushed to your GitHub branch, the following file must exist in your
+        GitHub repository:
       </Text>
       <Spacer y={0.5} />
       <ExpandableSection
         noWrapper
         expandText="[+] Show code"
         collapseText="[-] Hide code"
-        Header={
-          <ModalHeader>.github/workflows/porter.yml</ModalHeader>
-        }
+        Header={<ModalHeader>.github/workflows/porter.yml</ModalHeader>}
         isInitiallyExpanded
         spaced
-        copy={getGithubAction(projectId, clusterId, stackName, branch, porterYamlPath)}
+        copy={getGithubAction(
+          projectId,
+          clusterId,
+          stackName,
+          branch,
+          porterYamlPath
+        )}
         ExpandedSection={
           <YamlEditor
-            value={getGithubAction(projectId, clusterId, stackName, branch, porterYamlPath)}
+            value={getGithubAction(
+              projectId,
+              clusterId,
+              stackName,
+              branch,
+              porterYamlPath
+            )}
             readOnly={true}
             height="300px"
           />
@@ -127,15 +153,25 @@ const GithubActionModal: React.FC<Props> = ({
       />
       <Spacer y={1} />
       <Text color="helper">
-        Porter can open a PR for you to approve and merge this file into your repository, or you can add it yourself. If you allow Porter to open a PR, you will be redirected to the PR in a new tab after submitting below.
+        Porter can open a PR for you to approve and merge this file into your
+        repository, or you can add it yourself. If you allow Porter to open a
+        PR, you will be redirected to the PR in a new tab after submitting
+        below.
       </Text>
       <Spacer y={1} />
       {deployPorterApp ? (
         <>
           <Select
             options={[
-              { label: "I authorize Porter to open a PR on my behalf (recommended)", value: "open_pr" },
-              { label: "I will copy the file into my repository myself", value: "copy" },
+              {
+                label:
+                  "I authorize Porter to open a PR on my behalf (recommended)",
+                value: "open_pr",
+              },
+              {
+                label: "I will copy the file into my repository myself",
+                value: "copy",
+              },
             ]}
             setValue={(x: string) => setChoice(x as Choice)}
             width="100%"
@@ -145,9 +181,13 @@ const GithubActionModal: React.FC<Props> = ({
             onClick={submit}
             width={"110px"}
             loadingText={"Submitting..."}
-            status={loading ? "loading" : deploymentError ? (
-              <Error message={deploymentError} />
-            ) : undefined}
+            status={
+              loading ? (
+                "loading"
+              ) : deploymentError ? (
+                <Error message={deploymentError} />
+              ) : undefined
+            }
           >
             Deploy app
           </Button>
@@ -158,26 +198,28 @@ const GithubActionModal: React.FC<Props> = ({
             checked={isChecked}
             toggleChecked={() => setIsChecked(!isChecked)}
           >
-            <Text>
-              I authorize Porter to open a PR on my behalf
-            </Text>
+            <Text>I authorize Porter to open a PR on my behalf</Text>
           </Checkbox>
           <Spacer y={1} />
           <Button
             disabled={!isChecked}
             onClick={submit}
             loadingText={"Submitting..."}
-            status={loading ? "loading" : deploymentError ? (
-              <Error message={deploymentError} />
-            ) : undefined}
+            status={
+              loading ? (
+                "loading"
+              ) : deploymentError ? (
+                <Error message={deploymentError} />
+              ) : undefined
+            }
           >
             Open a PR for me
           </Button>
         </>
       )}
     </Modal>
-  )
-}
+  );
+};
 
 export default withRouter(GithubActionModal);
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/porter-dev/porter
 
 go 1.20
 
-replace github.com/porter-dev/api-contracts v0.0.63 => ../api-contracts
-
 require (
 	cloud.google.com/go v0.105.0 // indirect
 	github.com/AlecAivazis/survey/v2 v2.2.9
@@ -78,7 +76,7 @@ require (
 	github.com/honeycombio/otel-launcher-go v0.2.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.0.63
+	github.com/porter-dev/api-contracts v0.0.66
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/porter-dev/porter
 
 go 1.20
 
+replace github.com/porter-dev/api-contracts v0.0.63 => ../api-contracts
+
 require (
 	cloud.google.com/go v0.105.0 // indirect
 	github.com/AlecAivazis/survey/v2 v2.2.9

--- a/go.sum
+++ b/go.sum
@@ -1490,6 +1490,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
+github.com/porter-dev/api-contracts v0.0.66 h1:sqK6Xu6QtC6cvhXoI1NbsdaruQK23yw07llbn14CWbc=
+github.com/porter-dev/api-contracts v0.0.66/go.mod h1:qr2L58mJLr5DUGV5OPw3REiSrQvJq6TgkKyEWP95dyU=
 github.com/porter-dev/switchboard v0.0.0-20221019155755-67ff2bf04935 h1:hfb3nt3AJXIBbevu6ARTg9SdOkMP6WLbKBiG5hT5rcc=
 github.com/porter-dev/switchboard v0.0.0-20221019155755-67ff2bf04935/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/go.sum
+++ b/go.sum
@@ -1490,8 +1490,6 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.0.63 h1:ZC2uURhfPmuknnNm9atM+7y3yW6YBCaR1vRQ9EvHCQc=
-github.com/porter-dev/api-contracts v0.0.63/go.mod h1:qr2L58mJLr5DUGV5OPw3REiSrQvJq6TgkKyEWP95dyU=
 github.com/porter-dev/switchboard v0.0.0-20221019155755-67ff2bf04935 h1:hfb3nt3AJXIBbevu6ARTg9SdOkMP6WLbKBiG5hT5rcc=
 github.com/porter-dev/switchboard v0.0.0-20221019155755-67ff2bf04935/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/porter-dev/api-contracts/generated/go/porter/v1/porterv1connect"
+
 	"github.com/porter-dev/porter/internal/telemetry"
 
 	"github.com/pkg/errors"
@@ -196,11 +198,12 @@ func (a *Agent) GetReleaseHistory(
 }
 
 type UpgradeReleaseConfig struct {
-	Name       string
-	Values     map[string]interface{}
-	Cluster    *models.Cluster
-	Repo       repository.Repository
-	Registries []*models.Registry
+	Name                      string
+	Values                    map[string]interface{}
+	Cluster                   *models.Cluster
+	Repo                      repository.Repository
+	Registries                []*models.Registry
+	ClusterControlPlaneClient porterv1connect.ClusterControlPlaneServiceClient
 
 	// Optional, if chart should be overriden
 	Chart *chart.Chart
@@ -282,6 +285,7 @@ func (a *Agent) UpgradeReleaseByValues(
 		conf.Registries,
 		doAuth,
 		disablePullSecretsInjection,
+		conf.ClusterControlPlaneClient,
 	)
 
 	if err != nil {
@@ -425,13 +429,14 @@ func (a *Agent) UpgradeReleaseByValues(
 
 // InstallChartConfig is the config required to install a chart
 type InstallChartConfig struct {
-	Chart      *chart.Chart
-	Name       string
-	Namespace  string
-	Values     map[string]interface{}
-	Cluster    *models.Cluster
-	Repo       repository.Repository
-	Registries []*models.Registry
+	Chart                     *chart.Chart
+	Name                      string
+	Namespace                 string
+	Values                    map[string]interface{}
+	Cluster                   *models.Cluster
+	Repo                      repository.Repository
+	Registries                []*models.Registry
+	ClusterControlPlaneClient porterv1connect.ClusterControlPlaneServiceClient
 }
 
 // InstallChartFromValuesBytes reads the raw values and calls Agent.InstallChart
@@ -509,6 +514,7 @@ func (a *Agent) InstallChart(
 		conf.Registries,
 		doAuth,
 		disablePullSecretsInjection,
+		conf.ClusterControlPlaneClient,
 	)
 
 	if err != nil {
@@ -576,6 +582,7 @@ func (a *Agent) UpgradeInstallChart(
 		conf.Registries,
 		doAuth,
 		disablePullSecretsInjection,
+		conf.ClusterControlPlaneClient,
 	)
 
 	if err != nil {

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/porter-dev/api-contracts/generated/go/porter/v1/porterv1connect"
+
 	goerrors "errors"
 
 	"github.com/porter-dev/porter/api/server/shared/websocket"
@@ -1908,13 +1910,14 @@ func (a *Agent) CreateImagePullSecrets(
 	namespace string,
 	linkedRegs map[string]*models.Registry,
 	doAuth *oauth2.Config,
+	ccpClient porterv1connect.ClusterControlPlaneServiceClient,
 ) (map[string]string, error) {
 	res := make(map[string]string)
 
 	for key, val := range linkedRegs {
 		_reg := registry.Registry(*val)
 
-		data, err := _reg.GetDockerConfigJSON(repo, doAuth)
+		data, err := _reg.GetDockerConfigJSON(repo, doAuth, ccpClient)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -52,7 +52,7 @@ func (r *Registry) ToRegistryType() *types.Registry {
 		}
 	} else if r.DOIntegrationID != 0 {
 		serv = types.DOCR
-	} else if r.AzureIntegrationID != 0 {
+	} else if r.AzureIntegrationID != 0 || strings.Contains(r.URL, "azurecr") {
 		serv = types.ACR
 	} else if strings.Contains(r.URL, "index.docker.io") {
 		serv = types.DockerHub

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1758,7 +1758,7 @@ func (r *Registry) GetDockerConfigJSON(
 		return nil, telemetry.Error(ctx, span, err, "error reading project id")
 	}
 
-	if proj.CapiProvisionerEnabled {
+	if proj.CapiProvisionerEnabled && strings.Contains(r.URL, ".azurecr") {
 		dockerConfigReq := connect.NewRequest(&porterv1.DockerConfigFileForRegistryRequest{
 			ProjectId:   int64(proj.ID),
 			RegistryUri: r.URL,
@@ -1775,7 +1775,12 @@ func (r *Registry) GetDockerConfigJSON(
 		return dockerConfigResp.Msg.DockerConfigFile, nil
 	}
 
-	return nil, telemetry.Error(ctx, span, nil, "no docker config file found")
+	marshalledConf, err := json.Marshal(conf)
+	if err != nil {
+		return nil, telemetry.Error(ctx, span, err, "error marshalling conf")
+	}
+
+	return marshalledConf, nil
 }
 
 func (r *Registry) getECRDockerConfigFile(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,22 @@
   "name": "porter",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "@porter-dev/api-contracts": "file:../api-contracts/generated/js"
+      }
+    },
+    "../api-contracts/generated/js": {
+      "version": "0.0.64",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.1.0"
+      }
+    },
+    "node_modules/@porter-dev/api-contracts": {
+      "resolved": "../api-contracts/generated/js",
+      "link": true
+    }
+  }
 }


### PR DESCRIPTION
Three changes:

1. CCP CreateAzureConnection api call now returns a credential id, which needs to be passed the contract on the frontend
2. new CCP ListRepositories, TokenForRegistry, and DockerConfigFileForRegistry api calls replace the old integration id methods (for the DockerConfigFile, this means I need to pass the CCP client all the way down to the call, which I do in part by adding it to the Upgrade/InstallChart configs)
3. unnecessary formatting courtesy of goland 

This PR should not be merged until these two are merged: 
https://github.com/porter-dev/api-contracts/pull/4
https://github.com/porter-dev/cluster-control-plane/pull/104