### PR TITLE
Update prerelease.yaml to exit successfully when update-new-release-tests is a no-op

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -567,14 +567,14 @@ jobs:
           git config user.name "Update Bot"
           git config user.email "support@porter.run"
 
-          git diff --quiet --exit-code || git add . && git commit -m "Update to Porter GHA version ${{steps.tag_name.outputs.tag}}" && git push -f
+          git diff --quiet --exit-code || (git add . && git commit -m "Update to Porter GHA version ${{steps.tag_name.outputs.tag}}" && git push -f)
 
           git checkout test-preview-env
           git merge main -m "Merge with main"
 
           sed -i 's/TEST:v.*/TEST:${{ steps.tag_name.outputs.tag }}/g' porter.yaml
 
-          git diff --quiet --exit-code || git add . && git commit -m "Update to Porter GHA version ${{steps.tag_name.outputs.tag}}" && git push -f
+          git diff --quiet --exit-code || (git add . && git commit -m "Update to Porter GHA version ${{steps.tag_name.outputs.tag}}" && git push -f)
   run-new-release-tests-workflows:
     name: Run new-release-tests Porter workflows
     runs-on: ubuntu-latest


### PR DESCRIPTION
Missing parentheses to ignore git commit command (which exits with 1 when there is nothing to commit)
