### PR TITLE
fix: prevent config override on edit hook

### DIFF
--- a/api/server/handlers/environment/update_environment_settings.go
+++ b/api/server/handlers/environment/update_environment_settings.go
@@ -145,7 +145,14 @@ func (c *UpdateEnvironmentSettingsHandler) ServeHTTP(w http.ResponseWriter, r *h
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "found", Value: found})
 
 		if !found {
+			webhookURL := getGithubWebhookURLFromUID(c.Config().ServerConf.ServerURL, string(env.WebhookID))
+
 			hook.Events = append(hook.Events, "push")
+			hook.Config = map[string]interface{}{
+				"url":          webhookURL,
+				"content_type": "json",
+				"secret":       c.Config().ServerConf.GithubIncomingWebhookSecret,
+			}
 
 			_, _, err := client.Repositories.EditHook(
 				context.Background(), env.GitRepoOwner, env.GitRepoName, env.GithubWebhookID, hook,


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?

EditHook call to GitHub was overriding any unset Config options, including Secret. Payload sig verification was failing as a result.

## Technical Spec/Implementation Notes
