### PR TITLE
Updated Prometheus Service LabelSelectors

### DIFF
--- a/dashboard/src/components/porter-form/field-components/KeyValueArray.tsx
+++ b/dashboard/src/components/porter-form/field-components/KeyValueArray.tsx
@@ -81,8 +81,8 @@ const KeyValueArray: React.FC<Props> = (props) => {
 
         setState(() => ({
           synced_env_groups: currentProject?.stacks_enabled ?
-            (Array.isArray(populatedEnvGroups)
-              ? populatedEnvGroups
+            (Array.isArray(values?.synced)
+              ? values?.synced
               : []) :
             (Array.isArray(populatedEnvGroups)
               ? populatedEnvGroups

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -14,18 +14,34 @@ import (
 
 // returns the prometheus service name
 func GetPrometheusService(clientset kubernetes.Interface) (*v1.Service, bool, error) {
-	services, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{
+	// The prometheus-community/prometheus chart @ v15.5.3 uses non-FQDN labels.
+	redundantServices, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=prometheus,component=server,heritage=Helm",
 	})
 	if err != nil {
 		return nil, false, err
 	}
 
-	if len(services.Items) == 0 {
+	// OTOH the same chart @ v22.6.2 uses more standardised labels.
+	upgradedServices, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=server,app.kubernetes.io/instance=prometheus,app.kubernetes.io/managed-by=Helm",
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Check if both service queries are empty - that means there's no compatible Prometheus installation.
+	if len(services.Items) == 0 && len(upgradedServices.Items) == 0 {
 		return nil, false, nil
 	}
 
-	return &services.Items[0], true, nil
+	// Now that we know there is a compatible Prometheus in here somewhere, we'll send the one that's availble.
+	if len(redundantServices.Items) > 0 {
+		return &redundantServices.Items[0], true, nil
+	}
+	if len(upgradedServices.Items) > 0 {
+		return &upgradedServices.Items[0], true, nil
+	}
 }
 
 // returns the prometheus service name

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -31,7 +31,7 @@ func GetPrometheusService(clientset kubernetes.Interface) (*v1.Service, bool, er
 	}
 
 	// Check if both service queries are empty - that means there's no compatible Prometheus installation.
-	if len(services.Items) == 0 && len(upgradedServices.Items) == 0 {
+	if len(redundantServices.Items) == 0 && len(upgradedServices.Items) == 0 {
 		return nil, false, nil
 	}
 

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Returns the prometheus service name. The prometheus-community/prometheus chart @ v15.5.3 uses non-FQDN labels, unlike v22.6.2. This function checks for both labels.
+// GetPrometheusService returns the prometheus service name. The prometheus-community/prometheus chart @ v15.5.3 uses non-FQDN labels, unlike v22.6.2. This function checks for both labels.
 func GetPrometheusService(clientset kubernetes.Interface) (*v1.Service, bool, error) {
 	redundantServices, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=prometheus,component=server,heritage=Helm",
@@ -38,7 +38,7 @@ func GetPrometheusService(clientset kubernetes.Interface) (*v1.Service, bool, er
 	return nil, false, err
 }
 
-// returns the prometheus service name
+// getKubeStateMetricsService returns the prometheus service name
 func getKubeStateMetricsService(clientset kubernetes.Interface) (*v1.Service, bool, error) {
 	services, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=kube-state-metrics",


### PR DESCRIPTION
Modified the GetPrometheusService() function to search for Prometheus services based on updated chart label selectors.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->
At the moment, the backend looks for a Prometheus `Service` it can query, using these selectors: `app=prometheus,component=server,heritage=Helm`. This works for the Prometheus chart @v15.5.3, but more updated versions use different labels. 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Modified the `GetPrometheusService()` function to search for Prometheus services based on updated chart label selectors - it now searches for both old and new selectors, and returns whatever's on the cluster.


## Technical Spec/Implementation Notes
