### PR TITLE
Skip build for porter auth

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -92,7 +92,7 @@ jobs:
           token: ${{ secrets.PORTER_TOKEN_5 }}
       - name: Update Porter Auth
         timeout-minutes: 20
-        uses: porter-dev/porter-update-action@v0.1.0
+        uses: porter-dev/porter-update-config-action@v0.1.0
         with:
           app: porter-auth
           cluster: "9"


### PR DESCRIPTION
Created a new action to run `update config` which skips builds and image pushes: https://github.com/porter-dev/porter-update-config-action