### PR TITLE
fix: correct link to dangling resources in porter documentation

### DIFF
--- a/dashboard/src/main/home/modals/UpdateClusterModal.tsx
+++ b/dashboard/src/main/home/modals/UpdateClusterModal.tsx
@@ -120,7 +120,7 @@ class UpdateClusterModal extends Component<PropsType, StateType> {
         {this.renderWarning()}
 
         <Help
-          href="https://docs.getporter.dev/docs/deleting-dangling-resources"
+          href="https://docs.porter.run/other/deleting-dangling-resources"
           target="_blank"
         >
           <i className="material-icons">help_outline</i> How to delete resources


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [x] Docs have been reviewed and added / updated if needed

## What is the current behavior?


The existing docs link points at `https://docs.getporter.dev/docs/deleting-dangling-resources`, which doesn't redirect to the correct page.

## What is the new behavior?

This PR updates the link to the (new) correct location.

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes

N/A