### PR TITLE
feat: pin node/npm versions and run npm build in CI

### DIFF
--- a/.github/workflows/pr_push_checks.yaml
+++ b/.github/workflows/pr_push_checks.yaml
@@ -1,6 +1,8 @@
 name: PR Checks
+
 on:
   - pull_request
+
 jobs:
   testing_matrix:
     strategy:
@@ -29,3 +31,37 @@ jobs:
         run: go vet ./${{ matrix.folder }}/...
       - name: Run Go tests
         run: go test ./${{ matrix.folder }}/...
+  build-npm:
+    name: Running smoke test npm build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Setup NPM
+        working-directory: dashboard
+        run: |
+          # installing updated npm
+
+          # Verify npm works before capturing and ensure its stderr is inspectable later
+          version="$(jq -r '.engines.npm' package.json)"
+          npm --version 2>&1 1>/dev/null
+
+          npm_version="$(npm --version)"
+          echo "Bootstrapping npm $version (replacing $npm_version)..."
+          npm install --unsafe-perm -g --quiet "npm@$version"
+
+          # Verify npm works before capturing and ensure its stderr is inspectable later
+          npm --version 2>&1 1>/dev/null
+          echo "npm $(npm --version) installed"
+      - name: Install NPM Dependencies
+        working-directory: dashboard
+        run: |
+          npm i --legacy-peer-deps
+      - name: Run NPM Build
+        working-directory: dashboard
+        run: |
+          npm run build

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -70,6 +70,10 @@
     "valtio": "^1.2.4",
     "zod": "^3.20.2"
   },
+  "engines": {
+    "node": ">=16 <17",
+    "npm": "9.7.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js",


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): Tests

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Previously, local development did not pin Node/NPM, resulting in developer environments drifting from what is run in CI.

Additionally, CI never ran `npm run build`, meaning a user's change could not build in the relevant node version but still get merged by virtue of running on a developer's machine.

## What is the new behavior?

We want to ensure our builds always succeed in CI prior to merging changes. This change adds that step to CI.

Additionally, we now pin npm and node in the dashboard's package.json.

## Technical Spec/Implementation Notes

N/A