### PR TITLE
fix: do not show throughput chart when not referencing a web service

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsChart.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsChart.tsx
@@ -32,6 +32,7 @@ export const secondsBeforeNow: { [range: string]: number } = {
 
 type PropsType = {
     currentChart: ChartTypeWithExtendedConfig;
+    isHpaEnabled: boolean;
     pods: any[];
     selectedController: any;
     selectedIngress: any;
@@ -43,6 +44,7 @@ type PropsType = {
 
 const MetricsChart: React.FunctionComponent<PropsType> = ({
     currentChart,
+    isHpaEnabled,
     pods,
     selectedController,
     selectedIngress,
@@ -59,7 +61,6 @@ const MetricsChart: React.FunctionComponent<PropsType> = ({
     const [areaData, setAreaData] = useState<NormalizedNginxStatusMetricsData[]>([]);
     const [hpaData, setHpaData] = useState<NormalizedMetricsData[]>([]);
     const [hpaEnabled, setHpaEnabled] = useState(false);
-    const [showHpaToggle, setShowHpaToggle] = useState(false);
     const [isLoading, setIsLoading] = useState(0);
 
     const { currentCluster, currentProject, setCurrentError } = useContext(
@@ -109,13 +110,9 @@ const MetricsChart: React.FunctionComponent<PropsType> = ({
                 kind = "Ingress";
             }
 
-            const serviceName: string = selectedController?.metadata.labels["app.kubernetes.io/name"]
-            const isHpaEnabled: boolean = currentChart?.config?.[serviceName]?.autoscaling?.enabled
-
             setIsLoading((prev) => prev + 1);
             setAggregatedData({});
             setIsAggregated(shouldsum);
-            setShowHpaToggle(isHpaEnabled);
             setHpaEnabled(isHpaEnabled);
 
             const aggregatedMetricsRequest = api.getMetrics(
@@ -338,7 +335,7 @@ const MetricsChart: React.FunctionComponent<PropsType> = ({
             )}
             {data.length > 0 && isLoading === 0 && (
                 <>
-                    {showHpaToggle &&
+                    {isHpaEnabled &&
                         ["cpu", "memory"].includes(selectedMetric) && (
                             <CheckboxRow
                                 toggle={() => setHpaEnabled((prev: any) => !prev)}

--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
@@ -171,16 +171,45 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       });
   };
 
+  const getServiceName = (): string => {
+    return selectedController?.metadata.labels["app.kubernetes.io/name"]
+  };
+
+  const isHpaEnabled = (): boolean => {
+    const serviceName: string = getServiceName()
+    return currentChart?.config?.[serviceName]?.autoscaling?.enabled
+  };
+
+  const isWebService = (): boolean => {
+    const serviceName: string = getServiceName()
+    return currentChart?.config?.[serviceName]?.ingress?.enabled
+  };
+
   const renderHpaChart = () => {
-    const serviceName: string = selectedController?.metadata.labels["app.kubernetes.io/name"]
-    const isHpaEnabled: boolean = currentChart?.config?.[serviceName]?.autoscaling?.enabled
-    return isHpaEnabled ? (
+    return isHpaEnabled() ? (
       <MetricsChart
         currentChart={currentChart}
+        isHpaEnabled={isHpaEnabled()}
         selectedController={selectedController}
         selectedIngress={selectedIngress}
         selectedMetric="hpa_replicas"
         selectedMetricLabel="Number of replicas"
+        selectedPod="All"
+        selectedRange={selectedRange}
+        pods={pods}
+      />
+    ) : null
+  };
+
+  const renderThroughputChart = () => {
+    return isWebService() ? (
+      <MetricsChart
+        currentChart={currentChart}
+        isHpaEnabled={isHpaEnabled()}
+        selectedController={selectedController}
+        selectedIngress={selectedIngress}
+        selectedMetric="nginx:status"
+        selectedMetricLabel="Throughput"
         selectedPod="All"
         selectedRange={selectedRange}
         pods={pods}
@@ -229,6 +258,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       </MetricsHeader>
       <MetricsChart
         currentChart={currentChart}
+        isHpaEnabled={isHpaEnabled()}
         selectedController={selectedController}
         selectedIngress={selectedIngress}
         selectedMetric="cpu"
@@ -239,6 +269,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       />
       <MetricsChart
         currentChart={currentChart}
+        isHpaEnabled={isHpaEnabled()}
         selectedController={selectedController}
         selectedIngress={selectedIngress}
         selectedMetric="memory"
@@ -249,6 +280,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       />
       <MetricsChart
         currentChart={currentChart}
+        isHpaEnabled={isHpaEnabled()}
         selectedController={selectedController}
         selectedIngress={selectedIngress}
         selectedMetric="network"
@@ -257,20 +289,12 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
         selectedRange={selectedRange}
         pods={pods}
       />
-      <MetricsChart
-        currentChart={currentChart}
-        selectedController={selectedController}
-        selectedIngress={selectedIngress}
-        selectedMetric="nginx:status"
-        selectedMetricLabel="Throughput"
-        selectedPod="All"
-        selectedRange={selectedRange}
-        pods={pods}
-      />
+      {renderThroughputChart()}
       {renderHpaChart()}
       {currentChart?.chart?.metadata?.name == "ingress-nginx" && (
         <MetricsChart
           currentChart={currentChart}
+          isHpaEnabled={isHpaEnabled()}
           selectedController={selectedController}
           selectedIngress={selectedIngress}
           selectedMetric="nginx:errors"


### PR DESCRIPTION
## Pull request type

- [x] Bugfix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Issue Number: POR-1474

Currently, we show the throughput chart even when not displaying an app without ingress.

## What is the new behavior?

Hide the throughput chart when there is no ingress (and reduce references to the currentChart data).

## Technical Spec/Implementation Notes
