### PR TITLE
fix: properly query for the cpu/memory autoscaling thresholds

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
@@ -149,7 +149,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
               "<token>",
               {
                 metric: hpaMetricType,
-                shouldsum: true,
+                shouldsum: false,
                 kind: kind,
                 name: selectedController?.metadata.name,
                 namespace: currentChart.namespace,

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -443,7 +443,7 @@ func createHPAAbsoluteCPUThresholdQuery(cpuMetricName, metricName, podSelectionR
 	}
 
 	requestCPUOne := fmt.Sprintf(
-		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
+		`avg by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
 		hpaMetricName,
 		cpuMetricName,
 		kubeMetricsPodSelectorOne,
@@ -452,13 +452,13 @@ func createHPAAbsoluteCPUThresholdQuery(cpuMetricName, metricName, podSelectionR
 	)
 
 	targetCPUUtilThresholdOne := fmt.Sprintf(
-		`%s{%s} / 100`,
+		`%s{%s} / 50`,
 		metricName,
 		kubeMetricsHPASelectorOne,
 	)
 
 	requestCPUTwo := fmt.Sprintf(
-		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
+		`avg by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
 		hpaMetricName,
 		cpuMetricName,
 		kubeMetricsPodSelectorTwo,
@@ -467,7 +467,7 @@ func createHPAAbsoluteCPUThresholdQuery(cpuMetricName, metricName, podSelectionR
 	)
 
 	targetCPUUtilThresholdTwo := fmt.Sprintf(
-		`%s{%s} / 100`,
+		`%s{%s} / 50`,
 		metricName,
 		kubeMetricsHPASelectorTwo,
 	)
@@ -512,7 +512,7 @@ func createHPAAbsoluteMemoryThresholdQuery(memMetricName, metricName, podSelecti
 	}
 
 	requestMemOne := fmt.Sprintf(
-		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
+		`avg by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
 		hpaMetricName,
 		memMetricName,
 		kubeMetricsPodSelectorOne,
@@ -521,13 +521,13 @@ func createHPAAbsoluteMemoryThresholdQuery(memMetricName, metricName, podSelecti
 	)
 
 	targetMemUtilThresholdOne := fmt.Sprintf(
-		`%s{%s} / 100`,
+		`%s{%s} / 50`,
 		metricName,
 		kubeMetricsHPASelectorOne,
 	)
 
 	requestMemTwo := fmt.Sprintf(
-		`sum by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
+		`avg by (%s) (label_replace(%s{%s},"%s", "%s", "", ""))`,
 		hpaMetricName,
 		memMetricName,
 		kubeMetricsPodSelectorTwo,
@@ -536,7 +536,7 @@ func createHPAAbsoluteMemoryThresholdQuery(memMetricName, metricName, podSelecti
 	)
 
 	targetMemUtilThresholdTwo := fmt.Sprintf(
-		`%s{%s} / 100`,
+		`%s{%s} / 50`,
 		metricName,
 		kubeMetricsHPASelectorTwo,
 	)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [x] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Issue Number: 1474

Previously, we would show the sum of all autoscaling thresholds for each pod, resulting in a wildly incorrect graph.

## What is the new behavior?

Fixing the sum issue, we still had our metrics downscaled by half, so we need to decrease the divisor by half in order to get the correct values.

The query itself might be incorrect/simplifiable, but at least for now things work as expected.

## Technical Spec/Implementation Notes

<img width="836" alt="Screenshot 2023-08-24 at 1 12 11 PM" src="https://github.com/porter-dev/porter/assets/141160579/8ff1ef8f-bf78-4199-baa7-bfcb3bda16d4">
