### PR TITLE
fix: hide network metric if the service is not of type web

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/ExpandedApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/ExpandedApp.tsx
@@ -692,7 +692,7 @@ const ExpandedApp: React.FC<Props> = ({ ...props }) => {
           filterOpts={queryParamOpts}
         />;
       case "metrics":
-        return <MetricsSection currentChart={appData.chart} appName={appData.app.name} serviceName={queryParamOpts.service} />;
+        return <MetricsSection currentChart={appData.chart} appName={appData.app.name} serviceName={queryParamOpts.service} services={services} />;
       case "debug":
         return <StatusSectionFC currentChart={appData.chart} />;
       case "environment":

--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import api from "shared/api";
 import { Context } from "shared/Context";
 import { ChartType } from "shared/types";
+import { Service } from "../../new-app-flow/serviceTypes";
 
 import TabSelector from "components/TabSelector";
 import SelectRow from "components/form-components/SelectRow";
@@ -20,12 +21,14 @@ type PropsType = {
   currentChart: ChartType;
   appName: string;
   serviceName?: string;
+  services: Service[];
 };
 
 const MetricsSection: React.FunctionComponent<PropsType> = ({
   currentChart,
   appName,
   serviceName,
+  services,
 }) => {
   const [selectedController, setSelectedController] = useState<any>(null);
   const [selectedRange, setSelectedRange] = useState("1H");
@@ -84,10 +87,18 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
         return;
       }
       const metrics: Metric[] = [];
-      const metricTypes: MetricType[] = ["cpu", "memory", "network"];
+      const metricTypes: MetricType[] = ["cpu", "memory"];
 
       const serviceName: string = selectedController?.metadata.labels["app.kubernetes.io/name"]
       const isHpaEnabled: boolean = currentChart?.config?.[serviceName]?.autoscaling?.enabled
+
+      const shortServiceName: string = getServiceNameFromControllerName(selectedController?.metadata?.name, appName)
+      for (let i = 0; i < services.length; i++) {
+        const service = services[i];
+        if (service.name === shortServiceName && service.type === "web") {
+          metricTypes.push("network");
+        }
+      }
 
       if (isHpaEnabled) {
         metricTypes.push("hpa_replicas");

--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/MetricsSection.tsx
@@ -93,11 +93,8 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       const isHpaEnabled: boolean = currentChart?.config?.[serviceName]?.autoscaling?.enabled
 
       const shortServiceName: string = getServiceNameFromControllerName(selectedController?.metadata?.name, appName)
-      for (let i = 0; i < services.length; i++) {
-        const service = services[i];
-        if (service.name === shortServiceName && service.type === "web") {
-          metricTypes.push("network");
-        }
+      if (services.some(svc => svc.name === shortServiceName && svc.type === "web")) {
+         metricTypes.push("network");
       }
 
       if (isHpaEnabled) {


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

Issue Number: 1474

We show the network metric in all cases.

## What is the new behavior?

Network metrics are hidden if we aren't filtering the service to a web type.

## Technical Spec/Implementation Notes
