### PR TITLE
create porter app before running apply in cli

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -272,3 +272,61 @@ func (c *Client) CurrentAppRevision(
 
 	return resp, err
 }
+
+type CreatePorterAppDBEntryInput struct {
+	AppName         string
+	GitRepoName     string
+	GitRepoID       uint
+	GitBranch       string
+	ImageRepository string
+	PorterYamlPath  string
+	ImageTag        string
+	Local           bool
+}
+
+// CreatePorterAppDBEntry creates an entry in the porter app
+func (c *Client) CreatePorterAppDBEntry(
+	ctx context.Context,
+	projectID uint, clusterID uint,
+	inp CreatePorterAppDBEntryInput,
+) error {
+	var sourceType porter_app.SourceType
+	var image *porter_app.Image
+	if inp.Local {
+		sourceType = porter_app.SourceType_Local
+	}
+	if inp.GitRepoName != "" {
+		sourceType = porter_app.SourceType_Github
+	}
+	if inp.ImageRepository != "" {
+		sourceType = porter_app.SourceType_DockerRegistry
+		image = &porter_app.Image{
+			Repository: inp.ImageRepository,
+			Tag:        inp.ImageTag,
+		}
+	}
+	if sourceType == "" {
+		return fmt.Errorf("cannot determine source type")
+	}
+
+	req := &porter_app.CreateAppRequest{
+		Name:           inp.AppName,
+		SourceType:     sourceType,
+		GitBranch:      inp.GitBranch,
+		GitRepoName:    inp.GitRepoName,
+		GitRepoID:      inp.GitRepoID,
+		PorterYamlPath: inp.PorterYamlPath,
+		Image:          image,
+	}
+
+	err := c.postRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/create",
+			projectID, clusterID,
+		),
+		req,
+		&types.PorterApp{},
+	)
+
+	return err
+}

--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -273,6 +273,7 @@ func (c *Client) CurrentAppRevision(
 	return resp, err
 }
 
+// CreatePorterAppDBEntryInput is the input struct to CreatePorterAppDBEntry
 type CreatePorterAppDBEntryInput struct {
 	AppName         string
 	GitRepoName     string

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/porter-dev/api-contracts/generated/go/helpers"
@@ -55,6 +56,16 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		return errors.New("validated b64 app proto is empty")
 	}
 	base64AppProto := validateResp.ValidatedBase64AppProto
+
+	createPorterAppDBEntryInp, err := createPorterAppDbEntryInputFromProtoAndEnv(validateResp.ValidatedBase64AppProto)
+	if err != nil {
+		return fmt.Errorf("error creating porter app db entry input from proto: %w", err)
+	}
+
+	err = client.CreatePorterAppDBEntry(ctx, cliConf.Project, cliConf.Cluster, createPorterAppDBEntryInp)
+	if err != nil {
+		return fmt.Errorf("error creating porter app db entry: %w", err)
+	}
 
 	applyResp, err := client.ApplyPorterApp(ctx, cliConf.Project, cliConf.Cluster, validateResp.ValidatedBase64AppProto, targetResp.DeploymentTargetID, "")
 	if err != nil {
@@ -105,6 +116,50 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 
 	color.New(color.FgGreen).Printf("Successfully applied Porter YAML as revision %v, next action: %v\n", applyResp.AppRevisionId, applyResp.CLIAction) // nolint:errcheck,gosec
 	return nil
+}
+
+func createPorterAppDbEntryInputFromProtoAndEnv(base64AppProto string) (api.CreatePorterAppDBEntryInput, error) {
+	var input api.CreatePorterAppDBEntryInput
+
+	decoded, err := base64.StdEncoding.DecodeString(base64AppProto)
+	if err != nil {
+		return input, fmt.Errorf("unable to decode base64 app for revision: %w", err)
+	}
+
+	app := &porterv1.PorterApp{}
+	err = helpers.UnmarshalContractObject(decoded, app)
+	if err != nil {
+		return input, fmt.Errorf("unable to unmarshal app for revision: %w", err)
+	}
+
+	if app.Name == "" {
+		return input, fmt.Errorf("app does not contain name")
+	}
+	input.AppName = app.Name
+
+	if app.Build != nil {
+		if os.Getenv("GITHUB_REPOSITORY_ID") == "" {
+			input.Local = true
+			return input, nil
+		}
+		gitRepoId, err := strconv.Atoi(os.Getenv("GITHUB_REPOSITORY_ID"))
+		if err != nil {
+			return input, fmt.Errorf("unable to parse GITHUB_REPOSITORY_ID to int: %w", err)
+		}
+		input.GitRepoID = uint(gitRepoId)
+		input.GitRepoName = os.Getenv("GITHUB_REPOSITORY")
+		input.GitBranch = os.Getenv("GITHUB_REF_NAME")
+		input.PorterYamlPath = "porter.yaml"
+		return input, nil
+	}
+
+	if app.Image != nil {
+		input.ImageRepository = app.Image.Repository
+		input.ImageTag = app.Image.Tag
+		return input, nil
+	}
+
+	return input, fmt.Errorf("app does not contain build or image settings")
 }
 
 func buildSettingsFromBase64AppProto(base64AppProto string) (buildInput, error) {


### PR DESCRIPTION
We must create a porter app db entry before running apply on the CLI.

This also supports a new type of porter app that is built locally (and so is not connected with a github repo).