### PR TITLE
app view services and overrides

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -13,7 +13,7 @@
         "@loadable/component": "^5.15.2",
         "@material-ui/core": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
-        "@porter-dev/api-contracts": "^0.0.86",
+        "@porter-dev/api-contracts": "^0.0.93",
         "@react-spring/web": "^9.6.1",
         "@sentry/react": "^6.13.2",
         "@sentry/tracing": "^6.13.2",
@@ -2454,9 +2454,9 @@
       }
     },
     "node_modules/@porter-dev/api-contracts": {
-      "version": "0.0.86",
-      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.86.tgz",
-      "integrity": "sha512-nihcZuR+FsbbBBr+7gIsvpxSJvRS+eGurSAElytN5LIimL8TbYN4T+7EDAA0sDvRp95qF7B+vdezPbHTsWRkcA==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.93.tgz",
+      "integrity": "sha512-BPJKvCNUXsVGw2rp3SC04fp6lYRTliEdxxORs/SxbxkQOysZxs21K/lAHmti7LIlqyFStil+g+gKyTCQSyWagg==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.1.0"
       }
@@ -16943,9 +16943,9 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@porter-dev/api-contracts": {
-      "version": "0.0.86",
-      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.86.tgz",
-      "integrity": "sha512-nihcZuR+FsbbBBr+7gIsvpxSJvRS+eGurSAElytN5LIimL8TbYN4T+7EDAA0sDvRp95qF7B+vdezPbHTsWRkcA==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@porter-dev/api-contracts/-/api-contracts-0.0.93.tgz",
+      "integrity": "sha512-BPJKvCNUXsVGw2rp3SC04fp6lYRTliEdxxORs/SxbxkQOysZxs21K/lAHmti7LIlqyFStil+g+gKyTCQSyWagg==",
       "requires": {
         "@bufbuild/protobuf": "^1.1.0"
       }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "@loadable/component": "^5.15.2",
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
-    "@porter-dev/api-contracts": "^0.0.86",
+    "@porter-dev/api-contracts": "^0.0.93",
     "@react-spring/web": "^9.6.1",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",

--- a/dashboard/src/lib/hooks/useAppValidation.ts
+++ b/dashboard/src/lib/hooks/useAppValidation.ts
@@ -54,56 +54,56 @@ export const useAppValidation = ({
 
   const validateApp = useCallback(
     async (data: PorterAppFormData) => {
-      try {
-        if (!currentProject || !currentCluster) {
-          throw new Error("No project or cluster selected");
-        }
-
-        if (!deploymentTargetID) {
-          throw new Error("No deployment target selected");
-        }
-
-        const proto = clientAppToProto(data);
-        const commit_sha = await match(data.source)
-          .with({ type: "github" }, async (src) => {
-            const { commit_sha } = await getBranchHead({
-              projectID: currentProject.id,
-              source: src,
-            });
-            return commit_sha;
-          })
-          .with({ type: "docker-registry" }, () => {
-            return "";
-          })
-          .exhaustive();
-
-        const res = await api.validatePorterApp(
-          "<token>",
-          {
-            b64_app_proto: btoa(proto.toJsonString()),
-            deployment_target_id: deploymentTargetID,
-            commit_sha,
-          },
-          {
-            project_id: currentProject.id,
-            cluster_id: currentCluster.id,
-          }
-        );
-
-        const validAppData = await z
-          .object({
-            validate_b64_app_proto: z.string(),
-          })
-          .parseAsync(res.data);
-
-        const validatedAppProto = PorterApp.fromJsonString(
-          atob(validAppData.validate_b64_app_proto)
-        );
-
-        return validatedAppProto;
-      } catch (err) {
-        return null;
+      if (!currentProject || !currentCluster) {
+        throw new Error("No project or cluster selected");
       }
+
+      if (!deploymentTargetID) {
+        throw new Error("No deployment target selected");
+      }
+
+      const proto = clientAppToProto(data);
+      const commit_sha = await match(data.source)
+        .with({ type: "github" }, async (src) => {
+          const { commit_sha } = await getBranchHead({
+            projectID: currentProject.id,
+            source: src,
+          });
+          return commit_sha;
+        })
+        .with({ type: "docker-registry" }, () => {
+          return "";
+        })
+        .exhaustive();
+
+      const res = await api.validatePorterApp(
+        "<token>",
+        {
+          b64_app_proto: btoa(
+            proto.toJsonString({
+              emitDefaultValues: true,
+            })
+          ),
+          deployment_target_id: deploymentTargetID,
+          commit_sha,
+        },
+        {
+          project_id: currentProject.id,
+          cluster_id: currentCluster.id,
+        }
+      );
+
+      const validAppData = await z
+        .object({
+          validate_b64_app_proto: z.string(),
+        })
+        .parseAsync(res.data);
+
+      const validatedAppProto = PorterApp.fromJsonString(
+        atob(validAppData.validate_b64_app_proto)
+      );
+
+      return validatedAppProto;
     },
     [deploymentTargetID, currentProject, currentCluster]
   );

--- a/dashboard/src/lib/hooks/usePorterYaml.ts
+++ b/dashboard/src/lib/hooks/usePorterYaml.ts
@@ -1,6 +1,6 @@
 import { PorterApp } from "@porter-dev/api-contracts";
 import { useQuery } from "@tanstack/react-query";
-import { SourceOptions, defaultServicesWithOverrides } from "lib/porter-apps";
+import { SourceOptions, serviceOverrides } from "lib/porter-apps";
 import { ClientService } from "lib/porter-apps/services";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { Context } from "shared/Context";
@@ -12,6 +12,16 @@ type DetectedServices = {
   predeploy?: ClientService;
 };
 
+type PorterYamlStatus =
+  | {
+      loading: true;
+      detectedServices: null;
+    }
+  | {
+      detectedServices: DetectedServices | null;
+      loading: false;
+    };
+
 /*
  *
  * usePorterYaml is a hook that will fetch the porter.yaml file from the
@@ -19,25 +29,31 @@ type DetectedServices = {
  * added to an app by default with read-only values.
  *
  */
-export const usePorterYaml = (source: SourceOptions) => {
+export const usePorterYaml = ({
+  source,
+  useDefaults = true,
+}: {
+  source: SourceOptions | null;
+  useDefaults?: boolean;
+}): PorterYamlStatus => {
   const { currentProject, currentCluster } = useContext(Context);
   const [
     detectedServices,
     setDetectedServices,
   ] = useState<DetectedServices | null>(null);
 
-  const { data } = useQuery(
+  const { data, status } = useQuery(
     [
       "getPorterYamlContents",
       currentProject?.id,
-      source.git_branch,
-      source.git_repo_name,
+      source?.git_branch,
+      source?.git_repo_name,
     ],
     async () => {
       if (!currentProject) {
         return;
       }
-      if (source.type !== "github") {
+      if (source?.type !== "github") {
         return;
       }
       const res = await api.getPorterYamlContents(
@@ -59,7 +75,7 @@ export const usePorterYaml = (source: SourceOptions) => {
     },
     {
       enabled:
-        source.type === "github" &&
+        source?.type === "github" &&
         Boolean(source.git_repo_name) &&
         Boolean(source.git_branch),
     }
@@ -92,8 +108,9 @@ export const usePorterYaml = (source: SourceOptions) => {
           .parseAsync(res.data);
         const proto = PorterApp.fromJsonString(atob(data.b64_app_proto));
 
-        const { services, predeploy } = defaultServicesWithOverrides({
+        const { services, predeploy } = serviceOverrides({
           overrides: proto,
+          useDefaults,
         });
 
         if (services.length || predeploy) {
@@ -127,5 +144,15 @@ export const usePorterYaml = (source: SourceOptions) => {
     }
   }, [data]);
 
-  return detectedServices;
+  if (status === "loading") {
+    return {
+      loading: true,
+      detectedServices: null,
+    };
+  }
+
+  return {
+    detectedServices,
+    loading: false,
+  };
 };

--- a/dashboard/src/lib/porter-apps/services.ts
+++ b/dashboard/src/lib/porter-apps/services.ts
@@ -228,12 +228,17 @@ export function serializeService(service: ClientService): SerializedService {
 
 // deserializeService converts a SerializedService to a ClientService
 // A deserialized ClientService represents the state of a service in the UI and which fields are editable
-export function deserializeService(
-  service: SerializedService,
-  override?: SerializedService
-): ClientService {
+export function deserializeService({
+  service,
+  override,
+  expanded,
+}: {
+  service: SerializedService;
+  override?: SerializedService;
+  expanded?: boolean;
+}): ClientService {
   const baseService = {
-    expanded: true,
+    expanded,
     canDelete: !override,
     name: ServiceField.string(service.name, override?.name),
     run: ServiceField.string(service.run, override?.run),

--- a/dashboard/src/lib/porter-apps/values.ts
+++ b/dashboard/src/lib/porter-apps/values.ts
@@ -10,7 +10,7 @@ export type ServiceString = z.infer<typeof serviceStringValidator>;
 // ServiceNumber is a number value in a service that can be read-only or editable
 export const serviceNumberValidator = z.object({
   readOnly: z.boolean(),
-  value: z.number(),
+  value: z.coerce.number(),
 });
 export type ServiceNumber = z.infer<typeof serviceNumberValidator>;
 

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -423,7 +423,11 @@ const Home: React.FC<Props> = (props) => {
               )}
             </Route>
             <Route path="/apps/:appName/:tab">
-              <ExpandedApp />
+              {currentProject?.validate_apply_v2 ? (
+                <AppView />
+              ) : (
+                <ExpandedApp />
+              )}
             </Route>
             <Route path="/apps/:appName">
               {currentProject?.validate_apply_v2 ? (

--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -1,7 +1,5 @@
-import React, { useContext, useMemo } from "react";
-import { AppRevision } from "lib/revisions/types";
-import { PorterApp } from "@porter-dev/api-contracts";
-import { useForm } from "react-hook-form";
+import React, { useEffect, useMemo } from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import {
   PorterAppFormData,
   SourceOptions,
@@ -9,27 +7,56 @@ import {
   porterAppFormValidator,
 } from "lib/porter-apps";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { PorterAppRecord } from "./AppView";
 import RevisionsList from "./RevisionsList";
-import { Context } from "shared/Context";
-import { useDefaultDeploymentTarget } from "lib/hooks/useDeploymentTarget";
+import { useLatestRevision } from "./LatestRevisionContext";
+import Spacer from "components/porter/Spacer";
+import TabSelector from "components/TabSelector";
+import { useHistory } from "react-router";
+import { match } from "ts-pattern";
+import Overview from "./tabs/Overview";
+
+// commented out tabs are not yet implemented
+// will be included as support is available based on data from app revisions rather than helm releases
+const validTabs = [
+  // "activity",
+  // "events",
+  "overview",
+  // "logs",
+  // "metrics",
+  // "debug",
+  "environment",
+  "build-settings",
+  "settings",
+  // "helm-values",
+  // "job-history",
+] as const;
+const DEFAULT_TAB = "overview";
+type ValidTab = typeof validTabs[number];
 
 type AppDataContainerProps = {
-  latestRevision: AppRevision;
-  porterApp: PorterAppRecord;
+  tabParam?: string;
 };
 
-const AppDataContainer: React.FC<AppDataContainerProps> = ({
-  latestRevision,
-  porterApp,
-}) => {
-  const { currentProject, currentCluster } = useContext(Context);
-  const deploymentTarget = useDefaultDeploymentTarget();
+const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
+  const history = useHistory();
+  const {
+    porterApp,
+    latestProto,
+    latestRevision,
+    projectId,
+    clusterId,
+    deploymentTargetId,
+    servicesFromYaml,
+  } = useLatestRevision();
 
-  const latestProto = useMemo(
-    () => PorterApp.fromJsonString(atob(latestRevision.b64_app_proto)),
-    [latestRevision]
-  );
+  const currentTab = useMemo(() => {
+    if (tabParam && validTabs.includes(tabParam as ValidTab)) {
+      return tabParam as ValidTab;
+    }
+
+    return DEFAULT_TAB;
+  }, [tabParam]);
+
   const latestSource: SourceOptions = useMemo(() => {
     if (porterApp.image_repo_uri) {
       const [repository, tag] = porterApp.image_repo_uri.split(":");
@@ -55,28 +82,46 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({
     reValidateMode: "onSubmit",
     resolver: zodResolver(porterAppFormValidator),
     defaultValues: {
-      app: clientAppFromProto(latestProto),
+      app: clientAppFromProto(latestProto, servicesFromYaml),
       source: latestSource,
     },
   });
+  const { reset } = porterAppFormMethods;
 
-  if (!currentProject || !currentCluster) {
-    return null;
-  }
-
-  if (!deploymentTarget) {
-    return null;
-  }
+  useEffect(() => {
+    if (servicesFromYaml) {
+      reset({
+        app: clientAppFromProto(latestProto, servicesFromYaml),
+        source: latestSource,
+      });
+    }
+  }, [servicesFromYaml]);
 
   return (
-    <RevisionsList
-      latestRevisionNumber={latestRevision.revision_number}
-      deploymentTargetId={deploymentTarget?.deployment_target_id}
-      projectId={currentProject.id}
-      clusterId={currentCluster.id}
-      appName={porterApp.name}
-      sourceType={latestSource.type}
-    />
+    <FormProvider {...porterAppFormMethods}>
+      <RevisionsList
+        latestRevisionNumber={latestRevision.revision_number}
+        deploymentTargetId={deploymentTargetId}
+        projectId={projectId}
+        clusterId={clusterId}
+        appName={porterApp.name}
+        sourceType={latestSource.type}
+      />
+      <Spacer y={1} />
+      <TabSelector
+        noBuffer
+        options={[{ label: "Overview", value: "overview" }]}
+        currentTab={currentTab}
+        setCurrentTab={() => {
+          history.push(`/apps/${porterApp.name}/${currentTab}`);
+        }}
+      />
+      <Spacer y={1} />
+      {match(currentTab)
+        .with("overview", () => <Overview />)
+        .otherwise(() => null)}
+      <Spacer y={2} />
+    </FormProvider>
   );
 };
 

--- a/dashboard/src/main/home/app-dashboard/app-view/AppHeader.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppHeader.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from "react";
+
+import Container from "components/porter/Container";
+import Icon from "components/porter/Icon";
+
+import web from "assets/web.png";
+import box from "assets/box.png";
+import github from "assets/github-white.png";
+import pr_icon from "assets/pull_request_icon.svg";
+
+import { PorterApp } from "@porter-dev/api-contracts";
+import { useLatestRevision } from "./LatestRevisionContext";
+import Spacer from "components/porter/Spacer";
+import Text from "components/porter/Text";
+import styled from "styled-components";
+
+// Buildpack icons
+const icons = [
+  "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/ruby/ruby-plain.svg",
+  "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-plain.svg",
+  "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-plain.svg",
+  "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original-wordmark.svg",
+  web,
+];
+
+const AppHeader: React.FC = () => {
+  const { latestProto, porterApp } = useLatestRevision();
+
+  const gitData = useMemo(() => {
+    if (
+      !porterApp.git_branch ||
+      !porterApp.repo_name ||
+      !porterApp.git_repo_id
+    ) {
+      return null;
+    }
+
+    return {
+      id: porterApp.git_repo_id,
+      branch: porterApp.git_branch,
+      repo: porterApp.repo_name,
+    };
+  }, [porterApp]);
+
+  const getIconSvg = (build: PorterApp["build"]) => {
+    if (!build) {
+      return box;
+    }
+
+    const bp = build.buildpacks[0].split("/")[1];
+    switch (bp) {
+      case "ruby":
+        return icons[0];
+      case "nodejs":
+        return icons[1];
+      case "python":
+        return icons[2];
+      case "go":
+        return icons[3];
+      default:
+        return box;
+    }
+  };
+
+  return (
+    <Container row>
+      <Icon src={getIconSvg(latestProto.build)} height={"24px"} />
+      <Spacer inline x={1} />
+      <Text size={21}>{latestProto.name}</Text>
+      {gitData && (
+        <>
+          <Spacer inline x={1} />
+          <Container row>
+            <A target="_blank" href={`https://github.com/${gitData.repo}`}>
+              <SmallIcon src={github} />
+              <Text size={13}>{gitData.repo}</Text>
+            </A>
+          </Container>
+          <Spacer inline x={1} />
+          <TagWrapper>
+            Branch
+            <BranchTag>
+              <BranchIcon src={pr_icon} />
+              {gitData.branch}
+            </BranchTag>
+          </TagWrapper>
+        </>
+      )}
+      {!gitData && porterApp.image_repo_uri && (
+        <>
+          <Spacer inline x={1} />
+          <Container row>
+            <SmallIcon
+              height="19px"
+              src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/97_Docker_logo_logos-512.png"
+            />
+            <Text size={13} color="helper">
+              {porterApp.image_repo_uri}
+            </Text>
+          </Container>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default AppHeader
+
+const A = styled.a`
+  display: flex;
+  align-items: center;
+`;
+const SmallIcon = styled.img<{ opacity?: string; height?: string }>`
+  height: ${(props) => props.height || "15px"};
+  opacity: ${(props) => props.opacity || 1};
+  margin-right: 10px;
+`;
+const BranchIcon = styled.img`
+  height: 14px;
+  opacity: 0.65;
+  margin-right: 5px;
+`;
+const TagWrapper = styled.div`
+  height: 20px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff44;
+  border: 1px solid #ffffff44;
+  border-radius: 3px;
+  padding-left: 6px;
+`;
+const BranchTag = styled.div`
+  height: 20px;
+  margin-left: 6px;
+  color: #aaaabb;
+  background: #ffffff22;
+  border-radius: 3px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0px 6px;
+  padding-left: 7px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/dashboard/src/main/home/app-dashboard/app-view/LatestRevisionContext.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/LatestRevisionContext.tsx
@@ -1,0 +1,215 @@
+import React, { useMemo } from "react";
+import { PorterApp } from "@porter-dev/api-contracts";
+import { useQuery } from "@tanstack/react-query";
+import { useDefaultDeploymentTarget } from "lib/hooks/useDeploymentTarget";
+import { createContext, useContext } from "react";
+import { Context } from "shared/Context";
+import api from "shared/api";
+import { PorterAppRecord, porterAppValidator } from "./AppView";
+import { z } from "zod";
+import { AppRevision, appRevisionValidator } from "lib/revisions/types";
+import Loading from "components/Loading";
+import Container from "components/porter/Container";
+import Text from "components/porter/Text";
+import Spacer from "components/porter/Spacer";
+import Link from "components/porter/Link";
+import notFound from "assets/not-found.png";
+import styled from "styled-components";
+import { SourceOptions } from "lib/porter-apps";
+import { usePorterYaml } from "lib/hooks/usePorterYaml";
+import { ClientService } from "lib/porter-apps/services";
+
+export const LatestRevisionContext = createContext<
+  | {
+      porterApp: PorterAppRecord;
+      latestRevision: AppRevision;
+      latestProto: PorterApp;
+      servicesFromYaml: {
+        services: ClientService[];
+        predeploy?: ClientService;
+      } | null;
+      clusterId: number;
+      projectId: number;
+      deploymentTargetId: string;
+    }
+  | undefined
+>(undefined);
+
+export const useLatestRevision = () => {
+  const context = useContext(LatestRevisionContext);
+  if (context === undefined) {
+    throw new Error(
+      "useLatestRevision must be used within a LatestRevisionContext"
+    );
+  }
+  return context;
+};
+
+export const LatestRevisionProvider = ({
+  appName,
+  children,
+}: {
+  appName?: string;
+  children: JSX.Element;
+}) => {
+  const { currentCluster, currentProject } = useContext(Context);
+  const deploymentTarget = useDefaultDeploymentTarget();
+
+  const appParamsExist =
+    !!appName && !!currentCluster && !!currentProject && !!deploymentTarget;
+
+  const { data: porterApp, status: porterAppStatus } = useQuery(
+    ["getPorterApp", currentCluster?.id, currentProject?.id, appName],
+    async () => {
+      if (!appParamsExist) {
+        return;
+      }
+
+      const res = await api.getPorterApp(
+        "<token>",
+        {},
+        {
+          cluster_id: currentCluster.id,
+          project_id: currentProject.id,
+          name: appName,
+        }
+      );
+
+      const porterApp = await porterAppValidator.parseAsync(res.data);
+      return porterApp;
+    },
+    {
+      enabled: appParamsExist,
+    }
+  );
+
+  const { data: latestRevision, status } = useQuery(
+    ["appRevisions", currentProject?.id, currentCluster?.id],
+    async () => {
+      if (!appParamsExist) {
+        return;
+      }
+      const res = await api.getLatestRevision(
+        "<token>",
+        {
+          deployment_target_id: deploymentTarget.deployment_target_id,
+        },
+        {
+          project_id: currentProject.id,
+          cluster_id: currentCluster.id,
+          porter_app_name: appName,
+        }
+      );
+
+      const revisionData = await z
+        .object({
+          app_revision: appRevisionValidator,
+        })
+        .parseAsync(res.data);
+
+      return revisionData.app_revision;
+    },
+    {
+      enabled: appParamsExist,
+    }
+  );
+
+  const latestSource: SourceOptions | null = useMemo(() => {
+    if (!porterApp) {
+      return null;
+    }
+
+    if (porterApp.image_repo_uri) {
+      const [repository, tag] = porterApp.image_repo_uri.split(":");
+      return {
+        type: "docker-registry",
+        image: {
+          repository,
+          tag,
+        },
+      };
+    }
+
+    return {
+      type: "github",
+      git_repo_id: porterApp.git_repo_id ?? 0,
+      git_repo_name: porterApp.repo_name ?? "",
+      git_branch: porterApp.git_branch ?? "",
+      porter_yaml_path: porterApp.porter_yaml_path ?? "./porter.yaml",
+    };
+  }, [porterApp]);
+
+  const { loading: porterYamlLoading, detectedServices } = usePorterYaml({
+    source: latestSource,
+    useDefaults: false,
+  });
+
+  const latestProto = useMemo(() => {
+    if (!latestRevision) {
+      return;
+    }
+
+    return PorterApp.fromJsonString(atob(latestRevision.b64_app_proto));
+  }, [latestRevision]);
+
+  if (
+    status === "loading" ||
+    porterAppStatus === "loading" ||
+    !appParamsExist ||
+    porterYamlLoading
+  ) {
+    return <Loading />;
+  }
+
+  if (
+    status === "error" ||
+    porterAppStatus === "error" ||
+    !latestRevision ||
+    !latestProto ||
+    !porterApp
+  ) {
+    return (
+      <Placeholder>
+        <Container row>
+          <PlaceholderIcon src={notFound} />
+          <Text color="helper">
+            No application matching "{appName}" was found.
+          </Text>
+        </Container>
+        <Spacer y={1} />
+        <Link to="/apps">Return to dashboard</Link>
+      </Placeholder>
+    );
+  }
+
+  return (
+    <LatestRevisionContext.Provider
+      value={{
+        latestRevision,
+        latestProto,
+        porterApp,
+        clusterId: currentCluster.id,
+        projectId: currentProject.id,
+        deploymentTargetId: deploymentTarget.deployment_target_id,
+        servicesFromYaml: detectedServices,
+      }}
+    >
+      {children}
+    </LatestRevisionContext.Provider>
+  );
+};
+
+const PlaceholderIcon = styled.img`
+  height: 13px;
+  margin-right: 12px;
+  opacity: 0.65;
+`;
+const Placeholder = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 13px;
+`;

--- a/dashboard/src/main/home/app-dashboard/app-view/RevisionsList.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/RevisionsList.tsx
@@ -84,14 +84,22 @@ const RevisionsList: React.FC<Props> = ({
                 <Tr disableHover>
                   <Th>Revision no.</Th>
                   <Th>Timestamp</Th>
-                  <Th>Image Tag</Th>
+                  <Th>
+                    {revisionsWithProto[0]?.app_proto.build
+                      ? "Commit SHA"
+                      : "Image Tag"}
+                  </Th>
                   <Th>Rollback</Th>
                 </Tr>
                 {revisionsWithProto.map((revision) => (
                   <Tr key={revision.revision_number}>
                     <Td>{revision.revision_number}</Td>
                     <Td>{readableDate(revision.updated_at)}</Td>
-                    <Td>{revision.app_proto.image?.tag}</Td>
+                    <Td>
+                      {revision.app_proto.build
+                        ? revision.app_proto.build.commitSha.substring(0, 7)
+                        : revision.app_proto.image?.tag}
+                    </Td>
                     <Td>
                       <RollbackButton
                         disabled={

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
@@ -1,0 +1,62 @@
+import { PorterApp } from "@porter-dev/api-contracts";
+import Spacer from "components/porter/Spacer";
+import Text from "components/porter/Text";
+import { PorterAppFormData } from "lib/porter-apps";
+import React, { useMemo } from "react";
+import { useFormContext, useFormState } from "react-hook-form";
+import ServiceList from "../../validate-apply/services-settings/ServiceList";
+import {
+  defaultSerialized,
+  deserializeService,
+} from "lib/porter-apps/services";
+import Error from "components/porter/Error";
+import Button from "components/porter/Button";
+
+const Overview: React.FC = () => {
+  const { formState } = useFormContext<PorterAppFormData>();
+
+  const buttonStatus = useMemo(() => {
+    if (formState.isSubmitting) {
+      return "loading";
+    }
+
+    if (Object.keys(formState.errors).length > 0) {
+      return <Error message="Unable to update app" />;
+    }
+
+    return "";
+  }, [formState.isSubmitting, formState.errors]);
+
+  return (
+    <>
+      <Text size={16}>Pre-deploy job</Text>
+      <Spacer y={0.5} />
+      <ServiceList
+        limitOne={true}
+        addNewText={"Add a new pre-deploy job"}
+        prePopulateService={deserializeService({
+          service: defaultSerialized({
+            name: "pre-deploy",
+            type: "predeploy",
+          }),
+        })}
+        isPredeploy
+      />
+      <Spacer y={0.5} />
+      <Text size={16}>Application services</Text>
+      <Spacer y={0.5} />
+      <ServiceList addNewText={"Add a new service"} />
+      <Spacer y={0.75} />
+      <Button
+        type="submit"
+        status={buttonStatus}
+        loadingText={"Updating..."}
+        disabled={formState.isSubmitting || !formState.isDirty}
+      >
+        Update app
+      </Button>
+    </>
+  );
+};
+
+export default Overview;

--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -15,7 +15,11 @@ import { ControlledInput } from "components/porter/ControlledInput";
 import Link from "components/porter/Link";
 
 import { Context } from "shared/Context";
-import { PorterAppFormData, SourceOptions, porterAppFormValidator } from "lib/porter-apps";
+import {
+  PorterAppFormData,
+  SourceOptions,
+  porterAppFormValidator,
+} from "lib/porter-apps";
 import DashboardHeader from "main/home/cluster-dashboard/DashboardHeader";
 import SourceSelector from "../new-app-flow/SourceSelector";
 import Button from "components/porter/Button";
@@ -131,6 +135,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
 
   const onSubmit = handleSubmit(async (data) => {
     try {
+      setDeployError("");
       const validatedAppProto = await validateApp(data);
       setValidatedAppProto(validatedAppProto);
 
@@ -334,7 +339,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
       setError("app.name", {
         message: "An app with this name already exists",
       });
-      return
+      return;
     }
   }, [porterApps, name]);
 

--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -126,7 +126,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
   const build = watch("app.build");
   const image = watch("source.image");
   const services = watch("app.services");
-  const servicesFromYaml = usePorterYaml(source);
+  const { detectedServices: servicesFromYaml } = usePorterYaml({ source });
   const deploymentTarget = useDefaultDeploymentTarget();
   const { updateAppStep } = useAppAnalytics(name);
   const { validateApp } = useAppValidation({
@@ -449,10 +449,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
                       )}
                     </Container>
                     <Spacer y={0.5} />
-                    <ServiceList
-                      defaultExpanded={true}
-                      addNewText={"Add a new service"}
-                    />
+                    <ServiceList addNewText={"Add a new service"} />
                   </>,
                   <>
                     <Text size={16}>Environment variables (optional)</Text>
@@ -475,12 +472,12 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
                       <ServiceList
                         limitOne={true}
                         addNewText={"Add a new pre-deploy job"}
-                        prePopulateService={deserializeService(
-                          defaultSerialized({
+                        prePopulateService={deserializeService({
+                          service: defaultSerialized({
                             name: "pre-deploy",
                             type: "predeploy",
-                          })
-                        )}
+                          }),
+                        })}
                         isPredeploy
                       />
                     </>

--- a/dashboard/src/main/home/app-dashboard/validate-apply/services-settings/ServiceContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/services-settings/ServiceContainer.tsx
@@ -39,7 +39,7 @@ const ServiceContainer: React.FC<ServiceProps> = ({
   update,
   remove,
 }) => {
-  const [height, setHeight] = useState<Height>("auto");
+  const [height, setHeight] = useState<Height>(service.expanded ? "auto" : 0);
 
   const UPPER_BOUND = 0.75;
 
@@ -233,13 +233,15 @@ const ServiceContainer: React.FC<ServiceProps> = ({
         contentClassName="auto-content"
         duration={300}
       >
-        <StyledSourceBox
-          showExpanded={service.expanded}
-          chart={chart}
-          hasFooter={chart && service && getHasBuiltImage()}
-        >
-          {renderTabs(service)}
-        </StyledSourceBox>
+        {height !== 0 && (
+          <StyledSourceBox
+            showExpanded={service.expanded}
+            chart={chart}
+            hasFooter={chart && service && getHasBuiltImage()}
+          >
+            {renderTabs(service)}
+          </StyledSourceBox>
+        )}
       </AnimateHeight>
       {chart &&
         service &&
@@ -333,29 +335,9 @@ const ServiceHeader = styled.div<{
     transform: ${(props: { showExpanded?: boolean; chart: any }) =>
       props.showExpanded ? "" : "rotate(-90deg)"};
   }
-
-  animation: fadeIn 0.3s 0s;
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
 `;
 
 const Icon = styled.img`
   height: 18px;
   margin-right: 15px;
-
-  animation: fadeIn 0.3s 0s;
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
 `;

--- a/dashboard/src/main/home/app-dashboard/validate-apply/services-settings/ServiceList.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/services-settings/ServiceList.tsx
@@ -41,7 +41,6 @@ type AddServiceFormValues = z.infer<typeof addServiceFormValidator>;
 
 type ServiceListProps = {
   addNewText: string;
-  defaultExpanded?: boolean;
   limitOne?: boolean;
   prePopulateService?: ClientService;
   isPredeploy?: boolean;
@@ -125,7 +124,9 @@ const ServiceList: React.FC<ServiceListProps> = ({
   };
 
   const onSubmit = handleSubmit(async (data) => {
-    append(deserializeService(defaultSerialized(data)));
+    append(
+      deserializeService({ service: defaultSerialized(data), expanded: true })
+    );
     reset();
     setShowAddServiceModal(false);
   });
@@ -241,7 +242,17 @@ const I = styled.i`
   justify-content: center;
 `;
 
-const ServicesContainer = styled.div``;
+const ServicesContainer = styled.div`
+  animation: fadeIn 0.3s 0s;
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
 
 const AddServiceButton = styled.div`
   color: #aaaabb;


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [X] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

- Current functionality exists in the ExpandedApp 

## What is the new behavior?

- This PR gets porter yaml v2 to parity on the "Overview" tab. The goal is to display services read in from the latest revision and mark values as read only if defined in porter.yaml
- Note: currently missing a functional StatusFooter, which will be addressed in a followup PR

## Technical Spec/Implementation Notes
<img width="1582" alt="Screenshot 2023-08-28 at 11 30 44 AM" src="https://github.com/porter-dev/porter/assets/104453631/3560c908-4bc6-40e2-a783-d33b923cfdec">

