### PR TITLE
add services

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/logs/LogSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/logs/LogSection.tsx
@@ -276,6 +276,7 @@ const LogSection: React.FC<Props> = ({
                   logs={logs}
                   appName={appName}
                   filters={filters}
+                  services={services}
                 />
                 <LoadMoreButton
                   active={selectedDate && logs.length !== 0}


### PR DESCRIPTION
Styled logs wasn't using the services at all to route to the service name on clicking the service name pill:

<img width="796" alt="image" src="https://github.com/porter-dev/porter/assets/40551216/c3e8498c-1c4f-4e68-889e-42d143579df2">


Now that services is inputted, we can match on the service name and correctly filter logs after the user clicks:

<img width="810" alt="image" src="https://github.com/porter-dev/porter/assets/40551216/cc409c51-52f4-4bdc-8ca4-999efd71780b">


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
- [ ] If it's a frontend change, Prettier has been run
- [ ] Docs have been reviewed and added / updated if needed

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

-->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Technical Spec/Implementation Notes
