### PR TITLE
feat: simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,7 @@
-## Pull request type
+## Issue ID
 
-<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->
+<!-- Fill in an issue ID or type "N/A" if there isn't one -->
 
-Please check the type of change your PR introduces:
+## What does this PR do?
 
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Other (please describe):
-
-## Pull request checklist
-
-Please check if your PR fulfills the following requirements:
-
-- [ ] If it's a backend change, tests for the changes have been added and `go test ./...` runs successfully from the root folder.
-- [ ] If it's a frontend change, Prettier has been run
-- [ ] Docs have been reviewed and added / updated if needed
-
-## What is the current behavior?
-
-<!-- Please describe the current behavior that you are modifying, or link to a relevant issue.
-
-Issue Number: N/A
-
--->
-
-## What is the new behavior?
-
-<!-- Please describe the behavior or changes that are being added by this PR. -->
-
-<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-
-## Technical Spec/Implementation Notes
+<!-- What are we reviewing? -->


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Other (please describe): simplified the PR template

## What is the current behavior?

Long PR template

## What is the new behavior?

In an effort to make it more likely that folks will fill out the template, I've removed most of the options in favor of the things that matter:

- an issue id (if applicable)
- a pr description (for context)

Anything that is a task (run prettier, run go test) should be automated via CI and therefore caught before merge.
