### PR TITLE
make text in Text nodes selectable

### DIFF
--- a/dashboard/src/components/porter/Text.tsx
+++ b/dashboard/src/components/porter/Text.tsx
@@ -51,5 +51,6 @@ const StyledText = styled.div<{
   font-size: ${props => props.size || 13}px;
   display: inline;
   align-items: center;
+  user-select: text;
   ${props => props.additionalStyles ? props.additionalStyles : ""}
 `;


### PR DESCRIPTION
## Issue ID

https://linear.app/porter/issue/POR-1580/make-text-content-selectable-on-porter-app-dashboard
## What does this PR do?

<img width="818" alt="image" src="https://github.com/porter-dev/porter/assets/40551216/fb58ffa4-808f-4682-9d8f-37a63d43dc57">

