### PR TITLE
CLI Login manual flag patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ staging.sh
 bin
 openapi.yaml
 .idea
+portercli
 
 
 vendor

--- a/cli/cmd/commands/auth.go
+++ b/cli/cmd/commands/auth.go
@@ -133,7 +133,6 @@ func login(ctx context.Context, cliConf config.CLIConfig) error {
 		}
 
 		_, _ = color.New(color.FgGreen).Println("Successfully logged in!")
-
 		return setProjectForUser(ctx, client, cliConf, user.ID)
 
 	}
@@ -189,7 +188,6 @@ func setProjectForUser(ctx context.Context, client api.Client, config config.CLI
 		config.SetProject(ctx, client, projects[0].ID) //nolint:errcheck,gosec // do not want to change logic of CLI. New linter error
 
 		err = setProjectCluster(ctx, client, config, projects[0].ID)
-
 		if err != nil {
 			return err
 		}
@@ -199,6 +197,7 @@ func setProjectForUser(ctx context.Context, client api.Client, config config.CLI
 }
 
 func loginManual(ctx context.Context, cliConf config.CLIConfig, client api.Client) error {
+	client.CookieFilePath = "cookie.json" // required as this uses cookies for auth instead of a token
 	var username, pw string
 
 	fmt.Println("Please log in with an email and password:")
@@ -209,16 +208,13 @@ func loginManual(ctx context.Context, cliConf config.CLIConfig, client api.Clien
 	}
 
 	pw, err = utils.PromptPassword("Password: ")
-
 	if err != nil {
 		return err
 	}
-
 	_, err = client.Login(ctx, &types.LoginUserRequest{
 		Email:    username,
 		Password: pw,
 	})
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->

- patch issue where `--manual` flag should have used the cookie workflow
- add `portercli` to .gitignore for easier debugging locally