### PR TITLE
[CUS-618] Use webkit scrollbar to override MacOS hide scrollbar setting

### DIFF
--- a/dashboard/src/components/RadioFilter.tsx
+++ b/dashboard/src/components/RadioFilter.tsx
@@ -178,6 +178,32 @@ const Placeholder = styled.div`
 const ScrollableWrapper = styled.div`
   overflow-y: auto;
   max-height: 350px;
+
+  ::-webkit-scrollbar {
+    width: 5px;
+    :horizontal {
+      height: 8px;
+    }
+  }
+
+  ::-webkit-scrollbar-corner {
+    width: 10px;
+    background: #ffffff11;
+    color: white;
+  }
+
+  ::-webkit-scrollbar-track {
+    width: 10px;
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: darkgrey;
+    outline: 1px solid slategrey;
+    border-radius: 5px;
+  }
 `;
 
 const Relative = styled.div`


### PR DESCRIPTION
## CUS-618
N/A

## What does this PR do?

Add non-default scrollbar such that the mac setting doesn't hide it

<img width="266" alt="image" src="https://github.com/porter-dev/porter/assets/40551216/9acc340a-cf49-43c2-9490-7968fda7caf5">

