### PR TITLE
chore: fix typo in ToClusterType docblock

### DIFF
--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -102,7 +102,7 @@ type Cluster struct {
 	MonitorHelmReleases bool
 }
 
-// ToProjectType generates an external types.Project to be shared over REST
+// ToClusterType generates an external types.Cluster to be shared over REST
 func (c *Cluster) ToClusterType() *types.Cluster {
 	serv := types.Kube
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the docblock on `Cluster.ToClusterType()` to reference ClusterType instead of ProjectType.