### PR TITLE
chore: remove unused variables in ProjectButton.tsx

### DIFF
--- a/dashboard/src/main/home/sidebar/ProjectButton.tsx
+++ b/dashboard/src/main/home/sidebar/ProjectButton.tsx
@@ -22,7 +22,7 @@ const ProjectButton: React.FC<PropsType> = (props) => {
   const context = useContext(Context);
   const [showGHAModal, setShowGHAModal] = useState<boolean>(false);
 
-  const { setCurrentProject, setCurrentCluster, user } = context;
+  const { user } = context;
 
   useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);


### PR DESCRIPTION
## What does this PR do?

This removes unused references to `setCurrentProject` and `setCurrentCluster` from ProjectButton.tsx.