### PR TITLE
include commit sha on create

### DIFF
--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -131,6 +131,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
   const { updateAppStep } = useAppAnalytics(name);
   const { validateApp } = useAppValidation({
     deploymentTargetID: deploymentTarget?.deployment_target_id,
+    creating: true,
   });
 
   const onSubmit = handleSubmit(async (data) => {


### PR DESCRIPTION
## What does this PR do?

- We want to make sure that revisions always include a commit sha, but the first revision (when creating an app) won't be able to pull from the previous so we need to explicitly include it
