### PR TITLE
chore: remove errant console.log from project selection modal

### DIFF
--- a/dashboard/src/main/home/sidebar/ProjectSelectionModal.tsx
+++ b/dashboard/src/main/home/sidebar/ProjectSelectionModal.tsx
@@ -105,7 +105,6 @@ const ProjectSelectionModal: React.FC<Props> = ({
             if (clusters_list?.length > 0) {
               setCurrentCluster(clusters_list[0]);
               if (project.simplified_view_enabled) {
-                console.log("HERE BITCH")
                 pushFiltered(props, "/apps", ["project_id"], {});
               }
               else {


### PR DESCRIPTION
## POR-
N/A

## What does this PR do?

This PR removes an errant console.log from the project selection modal. We probably should have a lint rule of some sort, but since we currently use `console.log` for error handling (yuck) that might not be easy to do just yet.