### PR TITLE
chore: remove kubernetes 1.25.x as an option

### DIFF
--- a/dashboard/src/components/ProvisionerSettings.tsx
+++ b/dashboard/src/components/ProvisionerSettings.tsx
@@ -82,7 +82,6 @@ const machineTypeOptions = [
 
 const clusterVersionOptions = [
   { value: "v1.24.0", label: "1.24.0" },
-  { value: "v1.25.0", label: "1.25.0" },
 ];
 
 type Props = RouteComponentProps & {


### PR DESCRIPTION
## What does this PR do?

- We don't support 1.25.x - there is an issue with the kube-proxy addon
- Clients can only choose 1.24 now
- We are upgrading clients directly to 1.27 in the near future

We should just avoid this as an option for now, as it is confusing if working locally.
