### PR TITLE
fix: properly parse null raw labels for logs

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
@@ -34,7 +34,7 @@ const agentLogMetadataValidator = z.object({
     revision: z.string(),
     output_stream: z.string(),
     app_name: z.string(),
-    // raw_labels: rawLabelsValidator.optional(),
+    raw_labels: rawLabelsValidator.nullish(),
 });
 
 export const agentLogValidator = z.object({


### PR DESCRIPTION
The raw labels field will be null if the porter-agent is running on a version early than 3.1.7. `.optional()` only succeeds in cases where the field is `undefined`; `.nullish()` allws cases where field is `undefined` or `null`.

Tested by running porter-agent at 3.1.6, replicated bug where logs failed to parse with `.optional()`, confirmed that `.nullish()` handles parse properly. 