### PR TITLE
chore: ensure all setup-go calls have the same arguments

### DIFF
--- a/.github/workflows/porter_stack_porter-ui.yml
+++ b/.github/workflows/porter_stack_porter-ui.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
           cache: false
           go-version: '1.20.5'
+          go-version-file: go.mod
       - name: Download Go Modules
         run: go mod download
       - name: Build Server Binary

--- a/.github/workflows/pr_push_checks.yaml
+++ b/.github/workflows/pr_push_checks.yaml
@@ -20,12 +20,13 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: porter-go-${{ hashFiles('**/go.sum') }}
-      - name: Download Go Modules
-        run: go mod download
       - uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
           cache: false
+          go-version: '1.20.5'
+          go-version-file: go.mod
+      - name: Download Go Modules
+        run: go mod download
       - name: Run Go tests
         run: go test ./${{ matrix.folder }}/...
   linting:
@@ -35,6 +36,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
+          go-version: '1.20.5'
+          go-version-file: go.mod
       - uses: actions/checkout@v3
       - name: Setup Go Cache
         uses: actions/cache@v3

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -112,9 +112,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          cache: false
+          go-version: '1.20.5'
+          go-version-file: go.mod
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -182,9 +184,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          cache: false
+          go-version: '1.20.5'
+          go-version-file: go.mod
       - name: Write Dashboard Environment Variables
         run: |
           cat >./dashboard/.env <<EOL

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
           cache: false
           go-version: '1.20.5'
+          go-version-file: go.mod
       - name: Download Go Modules
         run: go mod download
       - name: Build Server Binary


### PR DESCRIPTION
## What does this PR do?

We were using a combination of arguments and action versions previously. This change ensures we're always doing the same thing when using golang.
