### PR TITLE
fix bug with parsing marking ingress disabled in the UI for v1 porter yaml

### DIFF
--- a/internal/porter_app/v1/types.go
+++ b/internal/porter_app/v1/types.go
@@ -5,7 +5,7 @@ type ServiceConfig struct {
 	Autoscaling      *Autoscaling      `yaml:"autoscaling,omitempty" validate:"excluded_if=Type job"`
 	Container        Container         `yaml:"container"`
 	Health           *Health           `yaml:"health,omitempty" validate:"excluded_unless=Type web"`
-	Ingress          Ingress           `yaml:"ingress"`
+	Ingress          *Ingress          `yaml:"ingress"`
 	ReplicaCount     string            `yaml:"replicaCount"`
 	Resources        Resources         `yaml:"resources"`
 	Service          KubernetesService `yaml:"service"`

--- a/internal/porter_app/v1/yaml.go
+++ b/internal/porter_app/v1/yaml.go
@@ -344,24 +344,26 @@ func webConfigProtoFromConfig(service Service) (*porterv1.WebServiceConfig, erro
 
 	webConfig.HealthCheck = healthCheck
 
-	domains := make([]*porterv1.Domain, 0)
-	for _, domain := range service.Config.Ingress.Hosts {
-		hostName := domain
-		domains = append(domains, &porterv1.Domain{
-			Name: hostName,
-		})
+	if service.Config.Ingress != nil {
+		domains := make([]*porterv1.Domain, 0)
+		for _, domain := range service.Config.Ingress.Hosts {
+			hostName := domain
+			domains = append(domains, &porterv1.Domain{
+				Name: hostName,
+			})
+		}
+		for _, domain := range service.Config.Ingress.PorterHosts {
+			hostName := domain
+			domains = append(domains, &porterv1.Domain{
+				Name: hostName,
+			})
+		}
+		if service.Config.Ingress.Annotations != nil && len(service.Config.Ingress.Annotations) > 0 {
+			return nil, errors.New("annotations are not supported")
+		}
+		webConfig.Domains = domains
+		webConfig.Private = !service.Config.Ingress.Enabled
 	}
-	for _, domain := range service.Config.Ingress.PorterHosts {
-		hostName := domain
-		domains = append(domains, &porterv1.Domain{
-			Name: hostName,
-		})
-	}
-	if service.Config.Ingress.Annotations != nil && len(service.Config.Ingress.Annotations) > 0 {
-		return nil, errors.New("annotations are not supported")
-	}
-	webConfig.Domains = domains
-	webConfig.Private = !service.Config.Ingress.Enabled
 
 	return webConfig, nil
 }


### PR DESCRIPTION
If ingress doesn't exist in the v1 porter yaml, we don't want to include ingress related things in the webConfig; changed Ingress to a pointer to fix that
