### PR TITLE
fix: respect launchdarkly responses for feature flags when doing a full page refresh

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -134,35 +134,15 @@ const Home: React.FC<Props> = (props) => {
       } else if (projectList.length > 0 && !currentProject) {
         setProjects(projectList);
 
-        let foundProject = null;
-        if (id) {
-          projectList.forEach((project: ProjectListType, i: number) => {
-            if (project.id === id) {
-              foundProject = project;
-            }
-          });
-
-          const project = await api
-            .getProject("<token>", {}, { id: projectList[0].id })
-            .then((res) => res.data as ProjectType);
-
-          setCurrentProject(foundProject || project);
+        if (!id) {
+          id = Number(localStorage.getItem("currentProject")) || projectList[0].id
         }
-        if (!foundProject) {
-          projectList.forEach((project: ProjectListType, i: number) => {
-            if (
-              project.id.toString() ===
-              localStorage.getItem("currentProject")
-            ) {
-              foundProject = project;
-            }
-          });
-          const project = await api
-            .getProject("<token>", {}, { id: projectList[0].id })
-            .then((res) => res.data as ProjectType);
 
-          setCurrentProject(foundProject || project);
-        }
+        const project = await api
+          .getProject("<token>", {}, { id: id })
+          .then((res) => res.data as ProjectType);
+
+        setCurrentProject(project);
       }
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## What does this PR do?

This change fixes an issue where we used the cached (bad) version from `/projects`, which uses the db values. We need to re-pull the project from `/projects/{project_id}` in order to fetch the current feature flags.