### PR TITLE
[POR-1675] filter out porter app events that are related to cpu or memory overages

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/activity-feed/ActivityFeed.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/activity-feed/ActivityFeed.tsx
@@ -4,8 +4,6 @@ import styled from "styled-components";
 import api from "shared/api";
 import { Context } from "shared/Context";
 
-import refresh from "assets/refresh.png";
-
 import Text from "components/porter/Text";
 
 import EventCard from "./events/cards/EventCard";
@@ -17,8 +15,6 @@ import { feedDate } from "shared/string_utils";
 import Pagination from "components/porter/Pagination";
 import _ from "lodash";
 import Button from "components/porter/Button";
-import Icon from "components/porter/Icon";
-import Container from "components/porter/Container";
 import { PorterAppEvent, PorterAppEventType } from "./events/types";
 
 type Props = {
@@ -41,6 +37,11 @@ const ActivityFeed: React.FC<Props> = ({ chart, stackName, appData }) => {
   const [isPorterAgentInstalling, setIsPorterAgentInstalling] = useState(false);
   const [shouldAnimate, setShouldAnimate] = useState(true);
 
+  // remove this filter when https://linear.app/porter/issue/POR-1676/disable-porter-agent-code-for-cpu-alerts is resolved
+  const isFilteredAppEvent = (event: PorterAppEvent) => {
+    return event.type === PorterAppEventType.APP_EVENT && (event.metadata?.short_summary?.includes("requesting more memory than is available") || event.metadata?.short_summary?.includes("requesting more CPU than is available"));
+  }
+
   const getEvents = async () => {
     setLoading(true)
     if (!currentProject || !currentCluster) {
@@ -61,7 +62,7 @@ const ActivityFeed: React.FC<Props> = ({ chart, stackName, appData }) => {
       );
 
       setNumPages(res.data.num_pages);
-      setEvents(res.data.events?.map((event: any) => PorterAppEvent.toPorterAppEvent(event)) ?? []);
+      setEvents(res.data.events?.map((event: any) => PorterAppEvent.toPorterAppEvent(event)).filter(!isFilteredAppEvent) ?? []);
     } catch (err) {
       setError(err);
     } finally {
@@ -95,7 +96,7 @@ const ActivityFeed: React.FC<Props> = ({ chart, stackName, appData }) => {
       );
       setError(undefined)
       setNumPages(res.data.num_pages);
-      setEvents(res.data.events?.map((event: any) => PorterAppEvent.toPorterAppEvent(event)) ?? []);
+      setEvents(res.data.events?.map((event: any) => PorterAppEvent.toPorterAppEvent(event)).filter(!isFilteredAppEvent) ?? []);
     } catch (err) {
       setError(err);
     }


### PR DESCRIPTION
## POR-1675
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?

hide porter app events that are related to cpu or memory overages until we fix them on the agent side
