### PR TITLE
fix update and delete issues

### DIFF
--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -201,16 +201,19 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
   });
 
   useEffect(() => {
-    if (servicesFromYaml) {
-      reset({
-        app: clientAppFromProto(latestProto, servicesFromYaml),
-        source: latestSource,
-        deletions: {
-          serviceNames: [],
-        },
-      });
-    }
-  }, [servicesFromYaml, currentTab, latestProto]);
+    reset({
+      app: clientAppFromProto(latestProto, servicesFromYaml),
+      source: latestSource,
+      deletions: {
+        serviceNames: [],
+      },
+    });
+  }, [
+    servicesFromYaml,
+    currentTab,
+    latestProto,
+    latestRevision.revision_number,
+  ]);
 
   return (
     <FormProvider {...porterAppFormMethods}>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/BuildSettings.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/BuildSettings.tsx
@@ -22,7 +22,7 @@ const BuildSettings: React.FC<Props> = ({
     watch,
     formState: { isSubmitting, errors },
   } = useFormContext<PorterAppFormData>();
-  const { projectId } = useLatestRevision();
+  const { projectId, latestRevision } = useLatestRevision();
 
   const build = watch("app.build");
   const source = watch("source");
@@ -59,7 +59,15 @@ const BuildSettings: React.FC<Props> = ({
         <Text>Re-run build and deploy on save</Text>
       </Checkbox>
       <Spacer y={1} />
-      <Button type="submit" status={buttonStatus}>
+      <Button
+        type="submit"
+        status={buttonStatus}
+        disabled={
+          isSubmitting ||
+          latestRevision.status === "CREATED" ||
+          latestRevision.status === "AWAITING_BUILD_ARTIFACT"
+        }
+      >
         Save build settings
       </Button>
     </>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
@@ -6,8 +6,10 @@ import Button from "components/porter/Button";
 import Error from "components/porter/Error";
 import { useFormContext } from "react-hook-form";
 import { PorterAppFormData } from "lib/porter-apps";
+import { useLatestRevision } from "../LatestRevisionContext";
 
 const Environment: React.FC = () => {
+  const { latestRevision } = useLatestRevision();
   const {
     formState: { isSubmitting, errors },
   } = useFormContext<PorterAppFormData>();
@@ -31,7 +33,16 @@ const Environment: React.FC = () => {
       <Text color="helper">Shared among all services.</Text>
       <EnvVariables />
       <Spacer y={0.5} />
-      <Button type="submit" status={buttonStatus} loadingText={"Updating..."}>
+      <Button
+        type="submit"
+        status={buttonStatus}
+        loadingText={"Updating..."}
+        disabled={
+          isSubmitting ||
+          latestRevision.status === "CREATED" ||
+          latestRevision.status === "AWAITING_BUILD_ARTIFACT"
+        }
+      >
         Update app
       </Button>
     </>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
@@ -15,7 +15,7 @@ import { useLatestRevision } from "../LatestRevisionContext";
 
 const Overview: React.FC = () => {
   const { formState } = useFormContext<PorterAppFormData>();
-  const { porterApp, latestProto } = useLatestRevision();
+  const { porterApp, latestProto, latestRevision } = useLatestRevision();
 
   const buttonStatus = useMemo(() => {
     if (formState.isSubmitting) {
@@ -52,13 +52,21 @@ const Overview: React.FC = () => {
       )}
       <Text size={16}>Application services</Text>
       <Spacer y={0.5} />
-      <ServiceList addNewText={"Add a new service"} fieldArrayName={"app.services"} existingServiceNames={Object.keys(latestProto.services)} />
+      <ServiceList
+        addNewText={"Add a new service"}
+        fieldArrayName={"app.services"}
+        existingServiceNames={Object.keys(latestProto.services)}
+      />
       <Spacer y={0.75} />
       <Button
         type="submit"
         status={buttonStatus}
         loadingText={"Updating..."}
-        disabled={formState.isSubmitting || !formState.isDirty}
+        disabled={
+          formState.isSubmitting ||
+          latestRevision.status === "CREATED" ||
+          latestRevision.status === "AWAITING_BUILD_ARTIFACT"
+        }
       >
         Update app
       </Button>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Settings.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Settings.tsx
@@ -10,8 +10,10 @@ import DeleteApplicationModal from "../../expanded-app/DeleteApplicationModal";
 import { useLatestRevision } from "../LatestRevisionContext";
 import api from "shared/api";
 import { useAppAnalytics } from "lib/hooks/useAppAnalytics";
+import { useQueryClient } from "@tanstack/react-query";
 
 const Settings: React.FC = () => {
+  const queryClient = useQueryClient();
   const history = useHistory();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { porterApp, clusterId, projectId } = useLatestRevision();
@@ -62,6 +64,7 @@ const Settings: React.FC = () => {
             name: porterApp.name,
           }
         );
+        void queryClient.invalidateQueries();
 
         if (!deleteWorkflow) {
           return;

--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
@@ -6,14 +6,12 @@ import { useLatestRevision } from "../../app-view/LatestRevisionContext";
 import styled from "styled-components";
 import { readableDate } from "shared/string_utils";
 import Text from "components/porter/Text";
-import { useGithubWorkflow } from "lib/hooks/useGithubWorkflow";
 import { useFormContext } from "react-hook-form";
 import {
   PorterAppFormData,
   SourceOptions,
   clientAppFromProto,
 } from "lib/porter-apps";
-import GHStatusBanner from "./GHStatusBanner";
 
 type RevisionTableContentsProps = {
   latestRevisionNumber: number;
@@ -191,6 +189,9 @@ const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
                           servicesFromYaml
                         ),
                         source: latestSource,
+                        deletions: {
+                          serviceNames: [],
+                        },
                       });
                       setPreviewRevision(
                         isLatestDeployedRevision


### PR DESCRIPTION
## POR-1687
## POR-1686
## POR-1690
## POR-1685

## What does this PR do?

- Invalidates queries once an app is deleted (this could be more granular, but works for now given how little useQuery is used)
- resets form regardless of porter.yaml being used or not, ensuring banner disappears if no new changes are made
- Fixes reverts by ensuring that empty deletions are set, as they are a required field in the form
- Buttons are disabled if an app is awaiting build

