### PR TITLE
POR-1728 Build env vars

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -414,6 +414,7 @@ func (c *Client) UpdateRevisionStatus(
 	return resp, err
 }
 
+// GetBuildEnv returns the build environment for a given app proto
 func (c *Client) GetBuildEnv(
 	ctx context.Context,
 	projectID uint, clusterID uint,

--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -413,3 +413,26 @@ func (c *Client) UpdateRevisionStatus(
 
 	return resp, err
 }
+
+func (c *Client) GetBuildEnv(
+	ctx context.Context,
+	projectID uint, clusterID uint,
+	base64AppProto string,
+) (*porter_app.GetBuildEnvResponse, error) {
+	resp := &porter_app.GetBuildEnvResponse{}
+
+	req := &porter_app.GetBuildEnvRequest{
+		Base64AppProto: base64AppProto,
+	}
+
+	err := c.postRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/build-env",
+			projectID, clusterID,
+		),
+		req,
+		resp,
+	)
+
+	return resp, err
+}

--- a/api/server/handlers/porter_app/get_build_env.go
+++ b/api/server/handlers/porter_app/get_build_env.go
@@ -71,6 +71,12 @@ func (c *GetBuildEnvHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if request.Base64AppProto == "" {
+		err := telemetry.Error(ctx, span, nil, "app proto is empty")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
 	decoded, err := base64.StdEncoding.DecodeString(request.Base64AppProto)
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "error decoding base yaml")

--- a/api/server/handlers/porter_app/get_build_env.go
+++ b/api/server/handlers/porter_app/get_build_env.go
@@ -1,0 +1,141 @@
+package porter_app
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	"github.com/porter-dev/api-contracts/generated/go/helpers"
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	"github.com/porter-dev/porter/api/server/authz"
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/porter_app"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+// GetBuildEnvHandler is the handler for the /apps/build-env endpoint
+type GetBuildEnvHandler struct {
+	handlers.PorterHandlerReadWriter
+	authz.KubernetesAgentGetter
+}
+
+// NewGetBuildEnvHandler handles GET requests to the /apps/build-env endpoint
+func NewGetBuildEnvHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *GetBuildEnvHandler {
+	return &GetBuildEnvHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
+	}
+}
+
+// GetBuildEnvRequest is the request object for the /apps/build-env endpoint
+type GetBuildEnvRequest struct {
+	Base64AppProto string `json:"b64_app_proto"`
+}
+
+// GetBuildEnvResponse is the response object for the /apps/build-env endpoint
+type GetBuildEnvResponse struct {
+	BuildEnvVariables map[string]string `json:"build_env_variables"`
+}
+
+// ServeHTTP translates the request into a GetBuildEnvRequest request, uses the proto to query the cluster for the build env, and returns the response
+func (c *GetBuildEnvHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-get-build-env")
+	defer span.End()
+
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "project-id", Value: project.ID},
+		telemetry.AttributeKV{Key: "cluster-id", Value: cluster.ID},
+	)
+
+	if !project.GetFeatureFlag(models.ValidateApplyV2, c.Config().LaunchDarklyClient) {
+		err := telemetry.Error(ctx, span, nil, "project does not have validate apply v2 enabled")
+		c.HandleAPIError(w, r, apierrors.NewErrForbidden(err))
+		return
+	}
+
+	request := &ApplyPorterAppRequest{}
+	if ok := c.DecodeAndValidate(w, r, request); !ok {
+		err := telemetry.Error(ctx, span, nil, "error decoding request")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(request.Base64AppProto)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error decoding base yaml")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	appProto := &porterv1.PorterApp{}
+	err = helpers.UnmarshalContractObject(decoded, appProto)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error unmarshalling app proto")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	deploymentTargets, err := c.Repo().DeploymentTarget().List(project.ID)
+	if err != nil {
+		err = telemetry.Error(ctx, span, err, "error reading deployment targets")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	if len(deploymentTargets) == 0 {
+		err := telemetry.Error(ctx, span, nil, "no deployment targets found")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	if len(deploymentTargets) > 1 {
+		err = telemetry.Error(ctx, span, err, "more than one deployment target found")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	deploymentTarget := deploymentTargets[0]
+
+	agent, err := c.GetAgent(r, cluster, "")
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting agent")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	envFromProtoInp := porter_app.AppEnvironmentFromProtoInput{
+		App:              appProto,
+		DeploymentTarget: deploymentTarget,
+		K8SAgent:         agent,
+	}
+	envGroups, err := porter_app.AppEnvironmentFromProto(ctx, envFromProtoInp)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting app environment from revision")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	buildEnvVariables := make(map[string]string)
+	for _, envGroup := range envGroups {
+		for key, val := range envGroup.Variables {
+			buildEnvVariables[key] = val
+		}
+	}
+
+	res := &GetBuildEnvResponse{
+		BuildEnvVariables: buildEnvVariables,
+	}
+
+	c.WriteResult(w, r, res)
+}

--- a/api/server/handlers/porter_app/get_build_env.go
+++ b/api/server/handlers/porter_app/get_build_env.go
@@ -104,14 +104,18 @@ func (c *GetBuildEnvHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
-
 	if len(deploymentTargets) > 1 {
-		err = telemetry.Error(ctx, span, err, "more than one deployment target found")
+		err = telemetry.Error(ctx, span, nil, "more than one deployment target found")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
 
 	deploymentTarget := deploymentTargets[0]
+	if deploymentTarget.ClusterID != int(cluster.ID) {
+		err := telemetry.Error(ctx, span, nil, "deployment target does not belong to cluster")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
 
 	agent, err := c.GetAgent(r, cluster, "")
 	if err != nil {

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -949,7 +949,7 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
-	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/metrics -> porter_app.NewUpdateAppRevisionStatusHandler
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/revisions/{app_revision_id} -> porter_app.NewUpdateAppRevisionStatusHandler
 	updateAppRevisionStatusEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
 			Verb:   types.APIVerbUpdate,
@@ -975,6 +975,35 @@ func getPorterAppRoutes(
 	routes = append(routes, &router.Route{
 		Endpoint: updateAppRevisionStatusEndpoint,
 		Handler:  updateAppRevisionStatusHandler,
+		Router:   r,
+	})
+
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/build-env -> porter_app.NewGetBuildEnvHandler
+	getBuildEnvEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbUpdate,
+			Method: types.HTTPVerbPost,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: "/apps/build-env",
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	getBuildEnvHandler := porter_app.NewGetBuildEnvHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: getBuildEnvEndpoint,
+		Handler:  getBuildEnvHandler,
 		Router:   r,
 	})
 

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -139,6 +139,12 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		buildSettings.CurrentImageTag = currentImageTag
 		buildSettings.ProjectID = cliConf.Project
 
+		buildEnv, err := client.GetBuildEnv(ctx, cliConf.Project, cliConf.Cluster, base64AppProto)
+		if err != nil {
+			return fmt.Errorf("error getting build env: %w", err)
+		}
+		buildSettings.Env = buildEnv.BuildEnvVariables
+
 		err = build(ctx, client, buildSettings)
 		buildMetadata := make(map[string]interface{})
 		buildMetadata["end_time"] = time.Now().UTC()

--- a/cli/cmd/v2/build.go
+++ b/cli/cmd/v2/build.go
@@ -91,6 +91,7 @@ func build(ctx context.Context, client api.Client, inp buildInput) error {
 			BuildContext:      buildCtx,
 			DockerfilePath:    dockerfilePath,
 			IsDockerfileInCtx: isDockerfileInCtx,
+			Env:               inp.Env,
 		}
 
 		err = dockerAgent.BuildLocal(
@@ -107,6 +108,7 @@ func build(ctx context.Context, client api.Client, inp buildInput) error {
 			ImageRepo:    imageURL,
 			Tag:          tag,
 			BuildContext: inp.BuildContext,
+			Env:          inp.Env,
 		}
 
 		buildConfig := &types.BuildConfig{

--- a/internal/models/deployment_target.go
+++ b/internal/models/deployment_target.go
@@ -5,6 +5,13 @@ import (
 	"gorm.io/gorm"
 )
 
+type DeploymentTargetSelectorType string
+
+const (
+	// DeploymentTargetSelectorType_Namespace indicates that the selector is a namespace
+	DeploymentTargetSelectorType_Namespace DeploymentTargetSelectorType = "NAMESPACE"
+)
+
 // DeploymentTarget represents a deployment target on a given cluster
 type DeploymentTarget struct {
 	gorm.Model
@@ -22,5 +29,5 @@ type DeploymentTarget struct {
 	Selector string `json:"selector"`
 
 	// SelectorType is the kind of selector (i.e. NAMESPACE or LABEL).
-	SelectorType string `json:"selector_type"`
+	SelectorType DeploymentTargetSelectorType `json:"selector_type"`
 }

--- a/internal/models/deployment_target.go
+++ b/internal/models/deployment_target.go
@@ -5,6 +5,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// DeploymentTargetSelectorType is the type of selector for a deployment target
 type DeploymentTargetSelectorType string
 
 const (

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -1,0 +1,75 @@
+package porter_app
+
+import (
+	"context"
+
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	"github.com/porter-dev/porter/internal/kubernetes"
+	"github.com/porter-dev/porter/internal/kubernetes/environment_groups"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+type envVariarableOptions struct {
+	includeSecrets bool
+}
+
+// EnvVariableOption is a function that modifies AppEnvironmentFromProto
+type EnvVariableOption func(*envVariarableOptions)
+
+type AppEnvironmentFromProtoInput struct {
+	App              *porterv1.PorterApp
+	DeploymentTarget *models.DeploymentTarget
+	K8SAgent         *kubernetes.Agent
+}
+
+// AppEnvironmentFromProto returns all envfironment groups referenced in an app proto with their variables
+func AppEnvironmentFromProto(ctx context.Context, inp AppEnvironmentFromProtoInput, varOpts ...EnvVariableOption) ([]environment_groups.EnvironmentGroup, error) {
+	ctx, span := telemetry.NewSpan(ctx, "porter-app-env-from-proto")
+	defer span.End()
+
+	var envGroups []environment_groups.EnvironmentGroup
+
+	if inp.DeploymentTarget == nil {
+		return nil, telemetry.Error(ctx, span, nil, "must provide a deployment target")
+	}
+	if inp.K8SAgent == nil {
+		return nil, telemetry.Error(ctx, span, nil, "must provide a kubernetes agent")
+	}
+	if inp.App == nil {
+		return nil, telemetry.Error(ctx, span, nil, "must provide an app")
+	}
+
+	var opts envVariarableOptions
+	for _, opt := range varOpts {
+		opt(&opts)
+	}
+
+	var namespace string
+	switch inp.DeploymentTarget.SelectorType {
+	case models.DeploymentTargetSelectorType_Namespace:
+		namespace = inp.DeploymentTarget.Selector
+	default:
+		return envGroups, telemetry.Error(ctx, span, nil, "deployment target selector type not supported")
+	}
+
+	for _, envGroupRef := range inp.App.EnvGroups {
+		envGroup, err := environment_groups.EnvironmentGroupInTargetNamespace(ctx, inp.K8SAgent, environment_groups.EnvironmentGroupInTargetNamespaceInput{
+			Name:      envGroupRef.GetName(),
+			Version:   int(envGroupRef.GetVersion()),
+			Namespace: namespace,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if !opts.includeSecrets {
+			envGroup.SecretVariables = nil
+		}
+
+		envGroups = append(envGroups, envGroup)
+	}
+
+	return envGroups, nil
+}

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -67,7 +67,6 @@ func AppEnvironmentFromProto(ctx context.Context, inp AppEnvironmentFromProtoInp
 			Version:   int(envGroupRef.GetVersion()),
 			Namespace: namespace,
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -17,6 +17,7 @@ type envVariarableOptions struct {
 // EnvVariableOption is a function that modifies AppEnvironmentFromProto
 type EnvVariableOption func(*envVariarableOptions)
 
+// AppEnvironmentFromProtoInput is the input struct for AppEnvironmentFromProto
 type AppEnvironmentFromProtoInput struct {
 	App              *porterv1.PorterApp
 	DeploymentTarget *models.DeploymentTarget

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -17,6 +17,13 @@ type envVariarableOptions struct {
 // EnvVariableOption is a function that modifies AppEnvironmentFromProto
 type EnvVariableOption func(*envVariarableOptions)
 
+// WithSecrets includes secrets in the environment groups
+func WithSecrets() EnvVariableOption {
+	return func(opts *envVariarableOptions) {
+		opts.includeSecrets = true
+	}
+}
+
 // AppEnvironmentFromProtoInput is the input struct for AppEnvironmentFromProto
 type AppEnvironmentFromProtoInput struct {
 	App              *porterv1.PorterApp


### PR DESCRIPTION
## POR-1728
## What does this PR do?

- Endpoint for retrieving all public env vars associated with a given app revision
- Feed those vars into build opts when running build from apply
