### PR TITLE
create or update app env group on cli run

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -414,18 +414,18 @@ func (c *Client) UpdateRevisionStatus(
 	return resp, err
 }
 
-// CreateOrUpdateAppEnvironmentGroup updates the app environment group and creates it if it doesn't exist
-func (c *Client) CreateOrUpdateAppEnvironmentGroup(
+// CreateOrUpdateAppEnvironment updates the app environment group and creates it if it doesn't exist
+func (c *Client) CreateOrUpdateAppEnvironment(
 	ctx context.Context,
 	projectID uint, clusterID uint,
 	appName string,
 	deploymentTargetID string,
 	variables map[string]string,
 	secrets map[string]string,
-) (*porter_app.UpdateAppEnvironmentGroupResponse, error) {
-	resp := &porter_app.UpdateAppEnvironmentGroupResponse{}
+) (*porter_app.UpdateAppEnvironmentResponse, error) {
+	resp := &porter_app.UpdateAppEnvironmentResponse{}
 
-	req := &porter_app.UpdateAppEnvironmentGroupRequest{
+	req := &porter_app.UpdateAppEnvironmentRequest{
 		DeploymentTargetID: deploymentTargetID,
 		Variables:          variables,
 		Secrets:            secrets,
@@ -434,7 +434,7 @@ func (c *Client) CreateOrUpdateAppEnvironmentGroup(
 
 	err := c.postRequest(
 		fmt.Sprintf(
-			"/projects/%d/clusters/%d/apps/%s/update-environment-group",
+			"/projects/%d/clusters/%d/apps/%s/update-environment",
 			projectID, clusterID, appName,
 		),
 		req,

--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -413,3 +413,33 @@ func (c *Client) UpdateRevisionStatus(
 
 	return resp, err
 }
+
+// CreateOrUpdateAppEnvironmentGroup updates the app environment group and creates it if it doesn't exist
+func (c *Client) CreateOrUpdateAppEnvironmentGroup(
+	ctx context.Context,
+	projectID uint, clusterID uint,
+	appName string,
+	deploymentTargetID string,
+	variables map[string]string,
+	secrets map[string]string,
+) (*porter_app.UpdateAppEnvironmentGroupResponse, error) {
+	resp := &porter_app.UpdateAppEnvironmentGroupResponse{}
+
+	req := &porter_app.UpdateAppEnvironmentGroupRequest{
+		DeploymentTargetID: deploymentTargetID,
+		Variables:          variables,
+		Secrets:            secrets,
+		HardUpdate:         false,
+	}
+
+	err := c.postRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/%s/update-environment-group",
+			projectID, clusterID, appName,
+		),
+		req,
+		resp,
+	)
+
+	return resp, err
+}

--- a/api/server/handlers/porter_app/parse_yaml.go
+++ b/api/server/handlers/porter_app/parse_yaml.go
@@ -42,7 +42,9 @@ type ParsePorterYAMLToProtoRequest struct {
 
 // ParsePorterYAMLToProtoResponse is the response object for the /apps/parse endpoint
 type ParsePorterYAMLToProtoResponse struct {
-	B64AppProto string `json:"b64_app_proto"`
+	B64AppProto  string            `json:"b64_app_proto"`
+	EnvVariables map[string]string `json:"env_variables"`
+	EnvSecrets   map[string]string `json:"env_secrets"`
 }
 
 // ServeHTTP receives a base64-encoded porter.yaml, parses the version, and then translates it into a base64-encoded app proto object
@@ -83,7 +85,7 @@ func (c *ParsePorterYAMLToProtoHandler) ServeHTTP(w http.ResponseWriter, r *http
 		return
 	}
 
-	appProto, err := porter_app.ParseYAML(ctx, yaml, request.AppName)
+	appProto, envVariables, err := porter_app.ParseYAML(ctx, yaml, request.AppName)
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "error parsing yaml")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
@@ -105,7 +107,8 @@ func (c *ParsePorterYAMLToProtoHandler) ServeHTTP(w http.ResponseWriter, r *http
 	b64 := base64.StdEncoding.EncodeToString(by)
 
 	response := &ParsePorterYAMLToProtoResponse{
-		B64AppProto: b64,
+		B64AppProto:  b64,
+		EnvVariables: envVariables,
 	}
 
 	c.WriteResult(w, r, response)

--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -168,7 +168,6 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "same-env-group", Value: sameEnvGroup})
 
 		if sameEnvGroup {
-
 			res := &UpdateAppEnvironmentResponse{
 				EnvGroupName:    latestEnvironmentGroup.Name,
 				EnvGroupVersion: latestEnvironmentGroup.Version,

--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -1,0 +1,219 @@
+package porter_app
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/porter-dev/porter/internal/kubernetes/environment_groups"
+	"github.com/porter-dev/porter/internal/repository"
+
+	"github.com/porter-dev/porter/api/server/shared/requestutils"
+
+	"connectrpc.com/connect"
+
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+
+	"github.com/porter-dev/porter/api/server/authz"
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+// UpdateAppEnvironmentGroupHandler handles the /apps/{porter_app_name}/update-environment-group endpoint
+type UpdateAppEnvironmentGroupHandler struct {
+	handlers.PorterHandlerReadWriter
+	authz.KubernetesAgentGetter
+}
+
+// NewUpdateAppEnvironmentGroupHandler returns a new UpdateAppEnvironmentGroupHandler
+func NewUpdateAppEnvironmentGroupHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *UpdateAppEnvironmentGroupHandler {
+	return &UpdateAppEnvironmentGroupHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
+	}
+}
+
+// UpdateAppEnvironmentGroupRequest represents the accepted fields on a request to the /apps/{porter_app_name}/environment-group endpoint
+type UpdateAppEnvironmentGroupRequest struct {
+	DeploymentTargetID string            `schema:"deployment_target_id"`
+	Variables          map[string]string `schema:"variables"`
+	Secrets            map[string]string `schema:"secrets"`
+	// HardUpdate is used to remove any variables that are not specified in the request.  If false, the request will only update the variables specified in the request,
+	// and leave all other variables untouched.
+	HardUpdate bool `schema:"remove_missing"`
+}
+
+// UpdateAppEnvironmentGroupResponse represents the fields on the response object from the /apps/{porter_app_name}/environment-group endpoint
+type UpdateAppEnvironmentGroupResponse struct {
+	EnvGroupName    string `schema:"env_group_name"`
+	EnvGroupVersion int    `schema:"env_group_version"`
+}
+
+// ServeHTTP updates or creates the environment group for an app
+func (c *UpdateAppEnvironmentGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-update-app-env-group")
+	defer span.End()
+	r = r.Clone(ctx)
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
+
+	appName, reqErr := requestutils.GetURLParamString(r, types.URLParamPorterAppName)
+	if reqErr != nil {
+		err := telemetry.Error(ctx, span, nil, "error parsing porter app name")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
+
+	request := &UpdateAppEnvironmentGroupRequest{}
+	if ok := c.DecodeAndValidate(w, r, request); !ok {
+		err := telemetry.Error(ctx, span, nil, "invalid request")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	if request.DeploymentTargetID == "" {
+		err := telemetry.Error(ctx, span, nil, "must provide deployment target id")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: request.DeploymentTargetID})
+
+	deploymentTargetDetailsReq := connect.NewRequest(&porterv1.DeploymentTargetDetailsRequest{
+		ProjectId:          int64(project.ID),
+		DeploymentTargetId: request.DeploymentTargetID,
+	})
+
+	deploymentTargetDetailsResp, err := c.Config().ClusterControlPlaneClient.DeploymentTargetDetails(ctx, deploymentTargetDetailsReq)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting deployment target details from cluster control plane client")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	if deploymentTargetDetailsResp == nil || deploymentTargetDetailsResp.Msg == nil {
+		err := telemetry.Error(ctx, span, err, "deployment target details resp is nil")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	if deploymentTargetDetailsResp.Msg.ClusterId != int64(cluster.ID) {
+		err := telemetry.Error(ctx, span, err, "deployment target details resp cluster id does not match cluster id")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	namespace := deploymentTargetDetailsResp.Msg.Namespace
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "namespace", Value: namespace})
+
+	envGroupName, err := AppEnvGroupName(ctx, appName, request.DeploymentTargetID, cluster.ID, c.Repo().PorterApp())
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting app env group name")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	agent, err := c.GetAgent(r, cluster, "")
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "unable to connect to kubernetes cluster")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	secrets := make(map[string][]byte)
+	for k, v := range request.Secrets {
+		secrets[k] = []byte(v)
+	}
+
+	envGroup := environment_groups.EnvironmentGroup{
+		Name:            envGroupName,
+		Variables:       request.Variables,
+		SecretVariables: secrets,
+		CreatedAtUTC:    time.Now().UTC(),
+	}
+
+	err = environment_groups.CreateOrUpdateBaseEnvironmentGroup(ctx, agent, envGroup)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "unable to create or update base environment group")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	inp := environment_groups.SyncLatestVersionToNamespaceInput{
+		BaseEnvironmentGroupName: envGroupName,
+		TargetNamespace:          namespace,
+	}
+
+	syncedEnvironment, err := environment_groups.SyncLatestVersionToNamespace(ctx, agent, inp)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "unable to create or update synced environment group")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "env-group-versioned-name", Value: syncedEnvironment.EnvironmentGroupVersionedName})
+
+	split := strings.Split(syncedEnvironment.EnvironmentGroupVersionedName, ".")
+	if len(split) != 2 {
+		err := telemetry.Error(ctx, span, err, "unexpected environment group versioned name")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	version, err := strconv.Atoi(split[1])
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error converting environment group version to int")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	res := &UpdateAppEnvironmentGroupResponse{
+		EnvGroupName:    split[0],
+		EnvGroupVersion: version,
+	}
+
+	c.WriteResult(w, r, res)
+}
+
+func AppEnvGroupName(ctx context.Context, appName string, deploymentTargetId string, clusterID uint, porterAppRepository repository.PorterAppRepository) (string, error) {
+	ctx, span := telemetry.NewSpan(ctx, "app-env-group-name")
+	defer span.End()
+
+	if appName == "" {
+		return "", telemetry.Error(ctx, span, nil, "app name is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
+
+	if deploymentTargetId == "" {
+		return "", telemetry.Error(ctx, span, nil, "deployment target id is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: deploymentTargetId})
+
+	if clusterID == 0 {
+		return "", telemetry.Error(ctx, span, nil, "cluster id is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "cluster-id", Value: clusterID})
+
+	porterApp, err := porterAppRepository.ReadPorterAppByName(clusterID, appName)
+	if err != nil {
+		return "", telemetry.Error(ctx, span, err, "error reading porter app by name")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-app-id", Value: porterApp.ID})
+
+	if len(deploymentTargetId) < 6 {
+		return "", telemetry.Error(ctx, span, nil, "deployment target id is too short")
+	}
+
+	return fmt.Sprintf("%d-%s", porterApp.ID, deploymentTargetId[:6]), nil
+}

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -978,5 +978,34 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/update-environment-group -> porter_app.NewUpdateAppEnvironmentGroupHandler
+	updateAppEnvironmentGroupEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbUpdate,
+			Method: types.HTTPVerbPost,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("/apps/{%s}/update-environment-group", types.URLParamPorterAppName),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	updateAppEnvironmentGroupHandler := porter_app.NewUpdateAppEnvironmentGroupHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: updateAppEnvironmentGroupEndpoint,
+		Handler:  updateAppEnvironmentGroupHandler,
+		Router:   r,
+	})
+
 	return routes, newPath
 }

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -978,14 +978,14 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
-	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/update-environment-group -> porter_app.NewUpdateAppEnvironmentGroupHandler
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/update-environment -> porter_app.NewUpdateAppEnvironmentHandler
 	updateAppEnvironmentGroupEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
 			Verb:   types.APIVerbUpdate,
 			Method: types.HTTPVerbPost,
 			Path: &types.Path{
 				Parent:       basePath,
-				RelativePath: fmt.Sprintf("/apps/{%s}/update-environment-group", types.URLParamPorterAppName),
+				RelativePath: fmt.Sprintf("/apps/{%s}/update-environment", types.URLParamPorterAppName),
 			},
 			Scopes: []types.PermissionScope{
 				types.UserScope,
@@ -995,7 +995,7 @@ func getPorterAppRoutes(
 		},
 	)
 
-	updateAppEnvironmentGroupHandler := porter_app.NewUpdateAppEnvironmentGroupHandler(
+	updateAppEnvironmentGroupHandler := porter_app.NewUpdateAppEnvironmentHandler(
 		config,
 		factory.GetDecoderValidator(),
 		factory.GetResultWriter(),

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -26,7 +26,16 @@ import (
 // Apply implements the functionality of the `porter apply` command for validate apply v2 projects
 func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, porterYamlPath string, appName string) error {
 	const forceBuild = true
-	var yamlB64 string
+	var b64AppProto string
+
+	targetResp, err := client.DefaultDeploymentTarget(ctx, cliConf.Project, cliConf.Cluster)
+	if err != nil {
+		return fmt.Errorf("error calling default deployment target endpoint: %w", err)
+	}
+
+	if targetResp.DeploymentTargetID == "" {
+		return errors.New("deployment target id is empty")
+	}
 
 	if len(porterYamlPath) != 0 {
 		porterYaml, err := os.ReadFile(filepath.Clean(porterYamlPath))
@@ -45,7 +54,7 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		if parseResp.B64AppProto == "" {
 			return errors.New("b64 app proto is empty")
 		}
-		yamlB64 = parseResp.B64AppProto
+		b64AppProto = parseResp.B64AppProto
 
 		// override app name if provided
 		appName, err = appNameFromB64AppProto(parseResp.B64AppProto)
@@ -53,16 +62,17 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 			return fmt.Errorf("error getting app name from b64 app proto: %w", err)
 		}
 
+		envGroupResp, err := client.CreateOrUpdateAppEnvironmentGroup(ctx, cliConf.Project, cliConf.Cluster, appName, targetResp.DeploymentTargetID, parseResp.EnvVariables, parseResp.EnvSecrets)
+		if err != nil {
+			return fmt.Errorf("error calling create or update app environment group endpoint: %w", err)
+		}
+
+		b64AppProto, err = updateAppEnvGroupInProto(ctx, b64AppProto, envGroupResp.EnvGroupName, envGroupResp.EnvGroupVersion)
+		if err != nil {
+			return fmt.Errorf("error updating app env group in proto: %w", err)
+		}
+
 		color.New(color.FgGreen).Printf("Successfully parsed Porter YAML: applying app \"%s\"\n", appName) // nolint:errcheck,gosec
-	}
-
-	targetResp, err := client.DefaultDeploymentTarget(ctx, cliConf.Project, cliConf.Cluster)
-	if err != nil {
-		return fmt.Errorf("error calling default deployment target endpoint: %w", err)
-	}
-
-	if targetResp.DeploymentTargetID == "" {
-		return errors.New("deployment target id is empty")
 	}
 
 	var commitSHA string
@@ -74,7 +84,7 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		commitSHA = commit.Sha
 	}
 
-	validateResp, err := client.ValidatePorterApp(ctx, cliConf.Project, cliConf.Cluster, appName, yamlB64, targetResp.DeploymentTargetID, commitSHA)
+	validateResp, err := client.ValidatePorterApp(ctx, cliConf.Project, cliConf.Cluster, appName, b64AppProto, targetResp.DeploymentTargetID, commitSHA)
 	if err != nil {
 		return fmt.Errorf("error calling validate endpoint: %w", err)
 	}
@@ -336,4 +346,43 @@ func imageTagFromBase64AppProto(base64AppProto string) (string, error) {
 	}
 
 	return app.Image.Tag, nil
+}
+
+func updateAppEnvGroupInProto(ctx context.Context, base64AppProto string, envGroupName string, envGroupVersion int) (string, error) {
+	var editedB64AppProto string
+
+	decoded, err := base64.StdEncoding.DecodeString(base64AppProto)
+	if err != nil {
+		return editedB64AppProto, fmt.Errorf("unable to decode base64 app for revision: %w", err)
+	}
+
+	app := &porterv1.PorterApp{}
+	err = helpers.UnmarshalContractObject(decoded, app)
+	if err != nil {
+		return editedB64AppProto, fmt.Errorf("unable to unmarshal app for revision: %w", err)
+	}
+
+	envGroupExists := false
+	for _, envGroup := range app.EnvGroups {
+		if envGroup.Name == envGroupName {
+			envGroup.Version = int64(envGroupVersion)
+			envGroupExists = true
+			break
+		}
+	}
+	if !envGroupExists {
+		app.EnvGroups = append(app.EnvGroups, &porterv1.EnvGroup{
+			Name:    envGroupName,
+			Version: int64(envGroupVersion),
+		})
+	}
+
+	marshalled, err := helpers.MarshalContractObject(ctx, app)
+	if err != nil {
+		return editedB64AppProto, fmt.Errorf("unable to marshal app back to json: %w", err)
+	}
+
+	editedB64AppProto = base64.StdEncoding.EncodeToString(marshalled)
+
+	return editedB64AppProto, nil
 }

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -73,7 +73,7 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 			return fmt.Errorf("error getting app name from b64 app proto: %w", err)
 		}
 
-		envGroupResp, err := client.CreateOrUpdateAppEnvironmentGroup(ctx, cliConf.Project, cliConf.Cluster, appName, targetResp.DeploymentTargetID, parseResp.EnvVariables, parseResp.EnvSecrets)
+		envGroupResp, err := client.CreateOrUpdateAppEnvironment(ctx, cliConf.Project, cliConf.Cluster, appName, targetResp.DeploymentTargetID, parseResp.EnvVariables, parseResp.EnvSecrets)
 		if err != nil {
 			return fmt.Errorf("error calling create or update app environment group endpoint: %w", err)
 		}

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -1,0 +1,42 @@
+package porter_app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/porter-dev/porter/internal/repository"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+// AppEnvGroupName returns the name of the environment group for the app
+func AppEnvGroupName(ctx context.Context, appName string, deploymentTargetId string, clusterID uint, porterAppRepository repository.PorterAppRepository) (string, error) {
+	ctx, span := telemetry.NewSpan(ctx, "app-env-group-name")
+	defer span.End()
+
+	if appName == "" {
+		return "", telemetry.Error(ctx, span, nil, "app name is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
+
+	if deploymentTargetId == "" {
+		return "", telemetry.Error(ctx, span, nil, "deployment target id is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: deploymentTargetId})
+
+	if clusterID == 0 {
+		return "", telemetry.Error(ctx, span, nil, "cluster id is empty")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "cluster-id", Value: clusterID})
+
+	porterApp, err := porterAppRepository.ReadPorterAppByName(clusterID, appName)
+	if err != nil {
+		return "", telemetry.Error(ctx, span, err, "error reading porter app by name")
+	}
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-app-id", Value: porterApp.ID})
+
+	if len(deploymentTargetId) < 6 {
+		return "", telemetry.Error(ctx, span, nil, "deployment target id is too short")
+	}
+
+	return fmt.Sprintf("%d-%s", porterApp.ID, deploymentTargetId[:6]), nil
+}

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -83,7 +83,6 @@ func AppEnvironmentFromProto(ctx context.Context, inp AppEnvironmentFromProtoInp
 	return envGroups, nil
 }
 
-
 // AppEnvGroupName returns the name of the environment group for the app
 func AppEnvGroupName(ctx context.Context, appName string, deploymentTargetId string, clusterID uint, porterAppRepository repository.PorterAppRepository) (string, error) {
 	ctx, span := telemetry.NewSpan(ctx, "app-env-group-name")

--- a/internal/porter_app/parse.go
+++ b/internal/porter_app/parse.go
@@ -23,48 +23,49 @@ const (
 )
 
 // ParseYAML converts a Porter YAML file into a PorterApp proto object
-func ParseYAML(ctx context.Context, porterYaml []byte, appName string) (*porterv1.PorterApp, error) {
+func ParseYAML(ctx context.Context, porterYaml []byte, appName string) (*porterv1.PorterApp, map[string]string, error) {
 	ctx, span := telemetry.NewSpan(ctx, "porter-app-parse-yaml")
 	defer span.End()
 
 	if porterYaml == nil {
-		return nil, telemetry.Error(ctx, span, nil, "porter yaml input is nil")
+		return nil, nil, telemetry.Error(ctx, span, nil, "porter yaml input is nil")
 	}
 
 	version := &yamlVersion{}
 	err := yaml.Unmarshal(porterYaml, version)
 	if err != nil {
-		return nil, telemetry.Error(ctx, span, err, "error unmarshaling porter yaml")
+		return nil, nil, telemetry.Error(ctx, span, err, "error unmarshaling porter yaml")
 	}
 
 	var appProto *porterv1.PorterApp
+	var envVariables map[string]string
 
 	switch version.Version {
 	case PorterYamlVersion_V2:
-		appProto, err = v2.AppProtoFromYaml(ctx, porterYaml, appName)
+		appProto, envVariables, err = v2.AppProtoFromYaml(ctx, porterYaml, appName)
 		if err != nil {
-			return nil, telemetry.Error(ctx, span, err, "error converting v2 yaml to proto")
+			return nil, nil, telemetry.Error(ctx, span, err, "error converting v2 yaml to proto")
 		}
 	// backwards compatibility for old porter.yaml files
 	// track this span in telemetry and reach out to customers who are still using old porter.yaml if they exist.
 	// once no one is converting from old porter.yaml, we can remove this code
 	case PorterYamlVersion_V1, "":
 		if appName == "" {
-			return nil, telemetry.Error(ctx, span, nil, "v1 porter yaml requires externally-provided app name")
+			return nil, nil, telemetry.Error(ctx, span, nil, "v1 porter yaml requires externally-provided app name")
 		}
-		appProto, err = v1.AppProtoFromYaml(ctx, porterYaml, appName)
+		appProto, envVariables, err = v1.AppProtoFromYaml(ctx, porterYaml, appName)
 		if err != nil {
-			return nil, telemetry.Error(ctx, span, err, "error converting v1 yaml to proto")
+			return nil, nil, telemetry.Error(ctx, span, err, "error converting v1 yaml to proto")
 		}
 	default:
-		return nil, telemetry.Error(ctx, span, nil, "porter yaml version not supported")
+		return nil, nil, telemetry.Error(ctx, span, nil, "porter yaml version not supported")
 	}
 
 	if appProto == nil {
-		return nil, telemetry.Error(ctx, span, nil, "porter yaml output is nil")
+		return nil, nil, telemetry.Error(ctx, span, nil, "porter yaml output is nil")
 	}
 
-	return appProto, nil
+	return appProto, envVariables, nil
 }
 
 // yamlVersion is a struct used to unmarshal the version field of a Porter YAML file

--- a/internal/porter_app/parse_test.go
+++ b/internal/porter_app/parse_test.go
@@ -30,10 +30,15 @@ func TestParseYAML(t *testing.T) {
 			want, err := os.ReadFile(fmt.Sprintf("testdata/%s.yaml", tt.porterYamlFileName))
 			is.NoErr(err) // no error expected reading test file
 
-			got, err := ParseYAML(context.Background(), want, "test-app")
+			got, env, err := ParseYAML(context.Background(), want, "test-app")
 			is.NoErr(err) // umbrella chart values should convert to map[string]any without issues
 
 			diffProtoWithFailTest(t, is, tt.want, got)
+
+			is.Equal(env, map[string]string{
+				"PORT":     "8080",
+				"NODE_ENV": "production",
+			})
 		})
 	}
 }
@@ -97,10 +102,6 @@ var result_nobuild = &porterv1.PorterApp{
 			},
 			Type: 1,
 		},
-	},
-	Env: map[string]string{
-		"PORT":     "8080",
-		"NODE_ENV": "production",
 	},
 	Predeploy: &porterv1.Service{
 		Run:          "ls",
@@ -176,10 +177,6 @@ var v1_result_nobuild_no_image = &porterv1.PorterApp{
 			},
 			Type: 1,
 		},
-	},
-	Env: map[string]string{
-		"PORT":     "8080",
-		"NODE_ENV": "production",
 	},
 	Predeploy: &porterv1.Service{
 		Run:          "ls",

--- a/internal/porter_app/v2/yaml.go
+++ b/internal/porter_app/v2/yaml.go
@@ -12,18 +12,18 @@ import (
 )
 
 // AppProtoFromYaml converts a Porter YAML file into a PorterApp proto object
-func AppProtoFromYaml(ctx context.Context, porterYamlBytes []byte, appName string) (*porterv1.PorterApp, error) {
+func AppProtoFromYaml(ctx context.Context, porterYamlBytes []byte, appName string) (*porterv1.PorterApp, map[string]string, error) {
 	ctx, span := telemetry.NewSpan(ctx, "v2-app-proto-from-yaml")
 	defer span.End()
 
 	if porterYamlBytes == nil {
-		return nil, telemetry.Error(ctx, span, nil, "porter yaml is nil")
+		return nil, nil, telemetry.Error(ctx, span, nil, "porter yaml is nil")
 	}
 
 	porterYaml := &PorterYAML{}
 	err := yaml.Unmarshal(porterYamlBytes, porterYaml)
 	if err != nil {
-		return nil, telemetry.Error(ctx, span, err, "error unmarshaling porter yaml")
+		return nil, nil, telemetry.Error(ctx, span, err, "error unmarshaling porter yaml")
 	}
 
 	// if the porter yaml is missing a name field, use the app name that is provided in the request
@@ -33,7 +33,6 @@ func AppProtoFromYaml(ctx context.Context, porterYamlBytes []byte, appName strin
 
 	appProto := &porterv1.PorterApp{
 		Name: porterYaml.Name,
-		Env:  porterYaml.Env,
 	}
 
 	if porterYaml.Build != nil {
@@ -54,19 +53,19 @@ func AppProtoFromYaml(ctx context.Context, porterYamlBytes []byte, appName strin
 	}
 
 	if porterYaml.Services == nil {
-		return nil, telemetry.Error(ctx, span, nil, "porter yaml is missing services")
+		return nil, nil, telemetry.Error(ctx, span, nil, "porter yaml is missing services")
 	}
 
 	services := make(map[string]*porterv1.Service, 0)
 	for name, service := range porterYaml.Services {
 		serviceType, err := protoEnumFromType(name, service)
 		if err != nil {
-			return nil, telemetry.Error(ctx, span, err, "error getting service type")
+			return nil, nil, telemetry.Error(ctx, span, err, "error getting service type")
 		}
 
 		serviceProto, err := serviceProtoFromConfig(service, serviceType)
 		if err != nil {
-			return nil, telemetry.Error(ctx, span, err, "error casting service config")
+			return nil, nil, telemetry.Error(ctx, span, err, "error casting service config")
 		}
 
 		services[name] = serviceProto
@@ -76,12 +75,12 @@ func AppProtoFromYaml(ctx context.Context, porterYamlBytes []byte, appName strin
 	if porterYaml.Predeploy != nil {
 		predeployProto, err := serviceProtoFromConfig(*porterYaml.Predeploy, porterv1.ServiceType_SERVICE_TYPE_JOB)
 		if err != nil {
-			return nil, telemetry.Error(ctx, span, err, "error casting predeploy config")
+			return nil, nil, telemetry.Error(ctx, span, err, "error casting predeploy config")
 		}
 		appProto.Predeploy = predeployProto
 	}
 
-	return appProto, nil
+	return appProto, porterYaml.Env, nil
 }
 
 // PorterYAML represents all the possible fields in a Porter YAML file


### PR DESCRIPTION
This PR adds the ability to update the environment group for an app when running the CLI.

Follow up PR will ensure that a new environment group version is only created if any of the variables change (to reduce unnecessary versions). EDIT: This was also added to this PR.