### PR TITLE
feat: manually retrieve the latest version for a given helm release when the version is set to 0

### DIFF
--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -189,7 +189,7 @@ func (a *Agent) GetRelease(
 //
 // The ideal case would be if we could sort on the server side, in which case
 // we could Limit results by 1 and not worry about the helm release status label,
-// but Kubernetes only supports ordering results api-side.
+// but Kubernetes only supports ordering results client-side.
 func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
 	ctx, span := telemetry.NewSpan(ctx, "helm-get-latest-version")
 	defer span.End() // This span is one of most frequent spans. We need to sample this.

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -189,7 +189,7 @@ func (a *Agent) GetRelease(
 //
 // The ideal case would be if we could sort on the server side, in which case
 // we could Limit results by 1 and not worry about the helm release status label,
-// but Kubernetes only supports limiting results api-side.
+// but Kubernetes only supports ordering results api-side.
 func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
 	ctx, span := telemetry.NewSpan(ctx, "helm-get-latest-version")
 	defer span.End() // This span is one of most frequent spans. We need to sample this.

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -191,6 +191,13 @@ func (a *Agent) GetRelease(
 // we could Limit results by 1 and not worry about the helm release status label,
 // but Kubernetes only supports limiting results api-side.
 func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
+	ctx, span := telemetry.NewSpan(ctx, "helm-get-latest-version")
+	defer span.End() // This span is one of most frequent spans. We need to sample this.
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "name", Value: name},
+		telemetry.AttributeKV{Key: "namespace", Value: a.Namespace()},
+	)
 	helmStatuses := []string{
 		string(release.StatusDeployed),
 		string(release.StatusFailed),

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -32,9 +32,15 @@ import (
 type Agent struct {
 	ActionConfig *action.Configuration
 	K8sAgent     *kubernetes.Agent
+
+	// The namespace struct attribute is unexported to avoid cases
+	// where a developer might change this, thinking that it will
+	// apply to all api interactions. RESTClientGetter has an immutable
+	// copy of the value, so change this won't impact those requests.
 	namespace string
 }
 
+// Namespace returns the configured namespace
 func (a *Agent) Namespace() string {
 	return a.namespace
 }

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -32,7 +32,7 @@ import (
 type Agent struct {
 	ActionConfig *action.Configuration
 	K8sAgent     *kubernetes.Agent
-	namespace    string
+	namespace string
 }
 
 func (a *Agent) Namespace() string {
@@ -200,7 +200,7 @@ func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
 	labelSelectors = append(labelSelectors, "owner in (helm)")
 	labelSelectors = append(labelSelectors, "status in (%s)", strings.Join(helmStatuses, ","))
 	listOptions := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("name=%s", name),
+		LabelSelector: strings.Join(labelSelectors, ","),
 	}
 
 	client, _ := a.ActionConfig.KubernetesClientSet()

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -132,6 +132,7 @@ func (a *Agent) GetRelease(
 
 	if version == 0 && a.Namespace() != "" {
 		version = a.getLatestVersion(ctx, name)
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "version-override", Value: version})
 	}
 
 	// Namespace is already known by the RESTClientGetter.

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -131,8 +131,8 @@ func (a *Agent) GetRelease(
 	)
 
 	if version == 0 && a.Namespace() != "" {
-		version = a.getLatestVersion(ctx, name)
-		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "version-override", Value: version})
+		version = a.getLatestReleaseVersion(ctx, name)
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "computed-version", Value: version})
 	}
 
 	// Namespace is already known by the RESTClientGetter.
@@ -175,7 +175,7 @@ func (a *Agent) GetRelease(
 	return release, err
 }
 
-// getLatestVersion retrieves the actual number for the last helm release
+// getLatestReleaseVersion retrieves the actual number for the last helm release
 // for a given name.
 //
 // If we use helm's built-in method of retrieving the last
@@ -190,8 +190,8 @@ func (a *Agent) GetRelease(
 // The ideal case would be if we could sort on the server side, in which case
 // we could Limit results by 1 and not worry about the helm release status label,
 // but Kubernetes only supports ordering results client-side.
-func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
-	ctx, span := telemetry.NewSpan(ctx, "helm-get-latest-version")
+func (a *Agent) getLatestReleaseVersion(ctx context.Context, name string) int {
+	ctx, span := telemetry.NewSpan(ctx, "helm-get-latest-release-version")
 	defer span.End() // This span is one of most frequent spans. We need to sample this.
 
 	telemetry.WithAttributes(span,

--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -212,13 +212,14 @@ func (a *Agent) getLatestVersion(ctx context.Context, name string) int {
 	var labelSelectors []string
 	labelSelectors = append(labelSelectors, fmt.Sprintf("name in (%s)", name))
 	labelSelectors = append(labelSelectors, "owner in (helm)")
-	labelSelectors = append(labelSelectors, "status in (%s)", strings.Join(helmStatuses, ","))
+	labelSelectors = append(labelSelectors, fmt.Sprintf("status in (%s)", strings.Join(helmStatuses, ",")))
 	listOptions := v1.ListOptions{
 		LabelSelector: strings.Join(labelSelectors, ","),
 	}
 
 	client, _ := a.ActionConfig.KubernetesClientSet()
 	secretListResp, err := client.CoreV1().Secrets(a.Namespace()).List(ctx, listOptions)
+
 	version := 0
 	if err == nil {
 		for _, secret := range secretListResp.Items {

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -77,6 +77,7 @@ func GetAgentFromK8sAgent(stg string, ns string, l *logger.Logger, k8sAgent *kub
 	return &Agent{
 		ActionConfig: actionConf,
 		K8sAgent:     k8sAgent,
+		namespace:    ns,
 	}, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

If we use helm's built-in method of retrieving the last release, it will retrieve _all_ releases and then only return the last one. That works ~fine except in cases where you have hundreds of releases, in which case any api calls will take significantly longer.

Instead, we retrieve all non-supersceded versions, then grab the highest version in that list. In the worst case, this would also retrieve every release. In the best case, it only retrieves a single release (the latest).

The ideal case would be if we could sort on the server side, in which case we could Limit results by 1 and not worry about the helm release status label, but Kubernetes only supports ordering results client-side.
