### PR TITLE
Fix bug where custom helm values for services were being wiped when deployed from the frontend

### DIFF
--- a/api/server/handlers/porter_app/create.go
+++ b/api/server/handlers/porter_app/create.go
@@ -106,33 +106,8 @@ func (c *CreatePorterAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	var releaseValues map[string]interface{}
 	var releaseDependencies []*chart.Dependency
-	// if shouldCreate || request.OverrideRelease {
-	// 	releaseValues = nil
-	// 	releaseDependencies = nil
-
-	// 	// this is required because when the front-end sends an update request with overrideRelease=true, it is unable to
-	// 	// get the image info from the release. unless it is explicitly provided in the request, we avoid overwriting it
-	// 	// by attempting to get the image info from the release or the provided helm values
-	// 	if helmRelease != nil && (imageInfo.Repository == "" || imageInfo.Tag == "") {
-	// 		if request.FullHelmValues != "" {
-	// 			imageInfo, err = attemptToGetImageInfoFromFullHelmValues(request.FullHelmValues)
-	// 			if err != nil {
-	// 				err = telemetry.Error(ctx, span, err, "error getting image info from full helm values")
-	// 				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-yaml-base64", Value: porterYamlBase64})
-	// 				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-	// 				return
-	// 			}
-	// 		} else {
-	// 			imageInfo = attemptToGetImageInfoFromRelease(helmRelease.Config)
-	// 		}
-	// 	}
-	// } else {
-	// 	releaseValues = helmRelease.Config
-	// 	releaseDependencies = helmRelease.Chart.Metadata.Dependencies
-	// }
-	// this is required because when the front-end sends an update request with overrideRelease=true, it is unable to
-	// get the image info from the release. unless it is explicitly provided in the request, we avoid overwriting it
-	// by attempting to get the image info from the release or the provided helm values
+	// unless it is explicitly provided in the request, we avoid overwriting the image info
+	// by attempting to get it from the release or the provided helm values
 	if helmRelease != nil && (imageInfo.Repository == "" || imageInfo.Tag == "") {
 		if request.FullHelmValues != "" {
 			imageInfo, err = attemptToGetImageInfoFromFullHelmValues(request.FullHelmValues)

--- a/api/server/handlers/porter_app/create.go
+++ b/api/server/handlers/porter_app/create.go
@@ -106,30 +106,54 @@ func (c *CreatePorterAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	var releaseValues map[string]interface{}
 	var releaseDependencies []*chart.Dependency
-	if shouldCreate || request.OverrideRelease {
+	// if shouldCreate || request.OverrideRelease {
+	// 	releaseValues = nil
+	// 	releaseDependencies = nil
+
+	// 	// this is required because when the front-end sends an update request with overrideRelease=true, it is unable to
+	// 	// get the image info from the release. unless it is explicitly provided in the request, we avoid overwriting it
+	// 	// by attempting to get the image info from the release or the provided helm values
+	// 	if helmRelease != nil && (imageInfo.Repository == "" || imageInfo.Tag == "") {
+	// 		if request.FullHelmValues != "" {
+	// 			imageInfo, err = attemptToGetImageInfoFromFullHelmValues(request.FullHelmValues)
+	// 			if err != nil {
+	// 				err = telemetry.Error(ctx, span, err, "error getting image info from full helm values")
+	// 				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-yaml-base64", Value: porterYamlBase64})
+	// 				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+	// 				return
+	// 			}
+	// 		} else {
+	// 			imageInfo = attemptToGetImageInfoFromRelease(helmRelease.Config)
+	// 		}
+	// 	}
+	// } else {
+	// 	releaseValues = helmRelease.Config
+	// 	releaseDependencies = helmRelease.Chart.Metadata.Dependencies
+	// }
+	// this is required because when the front-end sends an update request with overrideRelease=true, it is unable to
+	// get the image info from the release. unless it is explicitly provided in the request, we avoid overwriting it
+	// by attempting to get the image info from the release or the provided helm values
+	if helmRelease != nil && (imageInfo.Repository == "" || imageInfo.Tag == "") {
+		if request.FullHelmValues != "" {
+			imageInfo, err = attemptToGetImageInfoFromFullHelmValues(request.FullHelmValues)
+			if err != nil {
+				err = telemetry.Error(ctx, span, err, "error getting image info from full helm values")
+				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-yaml-base64", Value: porterYamlBase64})
+				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+				return
+			}
+		} else {
+			imageInfo = attemptToGetImageInfoFromRelease(helmRelease.Config)
+		}
+	}
+	if shouldCreate {
 		releaseValues = nil
 		releaseDependencies = nil
-
-		// this is required because when the front-end sends an update request with overrideRelease=true, it is unable to
-		// get the image info from the release. unless it is explicitly provided in the request, we avoid overwriting it
-		// by attempting to get the image info from the release or the provided helm values
-		if helmRelease != nil && (imageInfo.Repository == "" || imageInfo.Tag == "") {
-			if request.FullHelmValues != "" {
-				imageInfo, err = attemptToGetImageInfoFromFullHelmValues(request.FullHelmValues)
-				if err != nil {
-					err = telemetry.Error(ctx, span, err, "error getting image info from full helm values")
-					telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "porter-yaml-base64", Value: porterYamlBase64})
-					c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-					return
-				}
-			} else {
-				imageInfo = attemptToGetImageInfoFromRelease(helmRelease.Config)
-			}
-		}
 	} else {
 		releaseValues = helmRelease.Config
 		releaseDependencies = helmRelease.Chart.Metadata.Dependencies
 	}
+
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "image-repo", Value: imageInfo.Repository}, telemetry.AttributeKV{Key: "image-tag", Value: imageInfo.Tag})
 
 	if request.Builder == "" {
@@ -192,6 +216,7 @@ func (c *CreatePorterAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			ShouldValidateHelmValues:     shouldCreate,
 			FullHelmValues:               request.FullHelmValues,
 			AddCustomNodeSelector:        addCustomNodeSelector,
+			RemoveDeletedServices:        request.OverrideRelease,
 		},
 	)
 	if err != nil {

--- a/api/server/handlers/porter_app/parse.go
+++ b/api/server/handlers/porter_app/parse.go
@@ -111,6 +111,8 @@ type ParseConf struct {
 	FullHelmValues string
 	// AddCustomNodeSelector is a flag to determine whether to add porter.run/workload-kind: application to the nodeselector attribute of the helm values
 	AddCustomNodeSelector bool
+	// RemoveDeletedServices is a flag to determine whether to remove values and dependencies for services that are not defined in the porter.yaml
+	RemoveDeletedServices bool
 }
 
 func parse(ctx context.Context, conf ParseConf) (*chart.Chart, map[string]interface{}, map[string]interface{}, error) {
@@ -199,7 +201,7 @@ func parse(ctx context.Context, conf ParseConf) (*chart.Chart, map[string]interf
 		Release:  parsed.Release,
 	}
 
-	values, err := buildUmbrellaChartValues(ctx, application, synced_env, conf.ImageInfo, conf.ExistingHelmValues, conf.SubdomainCreateOpts, conf.InjectLauncherToStartCommand, conf.ShouldValidateHelmValues, conf.UserUpdate, conf.Namespace, conf.AddCustomNodeSelector)
+	values, err := buildUmbrellaChartValues(ctx, application, synced_env, conf.ImageInfo, conf.ExistingHelmValues, conf.SubdomainCreateOpts, conf.InjectLauncherToStartCommand, conf.ShouldValidateHelmValues, conf.UserUpdate, conf.Namespace, conf.AddCustomNodeSelector, conf.RemoveDeletedServices)
 	if err != nil {
 		err = telemetry.Error(ctx, span, err, "error building values")
 		return nil, nil, nil, err
@@ -210,7 +212,7 @@ func parse(ctx context.Context, conf ParseConf) (*chart.Chart, map[string]interf
 		return nil, nil, nil, err
 	}
 
-	umbrellaChart, err := buildUmbrellaChart(application, conf.ServerConfig, conf.ProjectID, conf.ExistingChartDependencies)
+	umbrellaChart, err := buildUmbrellaChart(application, conf.ServerConfig, conf.ProjectID, conf.ExistingChartDependencies, conf.RemoveDeletedServices)
 	if err != nil {
 		err = telemetry.Error(ctx, span, err, "error building umbrella chart")
 		return nil, nil, nil, err
@@ -238,6 +240,7 @@ func buildUmbrellaChartValues(
 	userUpdate bool,
 	namespace string,
 	addCustomNodeSelector bool,
+	removeDeletedValues bool,
 ) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 
@@ -290,10 +293,12 @@ func buildUmbrellaChartValues(
 		values[helmName] = helm_values
 	}
 
-	// add back in the existing services that were not overwritten
-	for k, v := range existingValues {
-		if values[k] == nil {
-			values[k] = v
+	if !removeDeletedValues {
+		// add back in the existing services that were not overwritten
+		for k, v := range existingValues {
+			if values[k] == nil {
+				values[k] = v
+			}
 		}
 	}
 
@@ -505,7 +510,7 @@ func deconstructSyncedEnvs(synced_env []*SyncedEnvSection, env map[string]string
 	return synced
 }
 
-func buildUmbrellaChart(application *Application, config *config.Config, projectID uint, existingDependencies []*chart.Dependency) (*chart.Chart, error) {
+func buildUmbrellaChart(application *Application, config *config.Config, projectID uint, existingDependencies []*chart.Dependency, removeDeletedDependencies bool) (*chart.Chart, error) {
 	deps := make([]*chart.Dependency, 0)
 	for alias, service := range application.Services {
 		var serviceType string
@@ -540,22 +545,24 @@ func buildUmbrellaChart(application *Application, config *config.Config, project
 		})
 	}
 
-	// add in the existing dependencies that were not overwritten
-	for _, dep := range existingDependencies {
-		if !dependencyExists(deps, dep) {
-			// have to repair the dependency name because of https://github.com/helm/helm/issues/9214
-			if strings.HasSuffix(dep.Name, "-web") || strings.HasSuffix(dep.Name, "-wkr") || strings.HasSuffix(dep.Name, "-job") {
-				dep.Name = getChartTypeFromHelmName(dep.Name)
-				if dep.Name == "" {
-					return nil, fmt.Errorf("unable to determine type of existing dependency")
+	if !removeDeletedDependencies {
+		// add in the existing dependencies that were not overwritten
+		for _, dep := range existingDependencies {
+			if !dependencyExists(deps, dep) {
+				// have to repair the dependency name because of https://github.com/helm/helm/issues/9214
+				if strings.HasSuffix(dep.Name, "-web") || strings.HasSuffix(dep.Name, "-wkr") || strings.HasSuffix(dep.Name, "-job") {
+					dep.Name = getChartTypeFromHelmName(dep.Name)
+					if dep.Name == "" {
+						return nil, fmt.Errorf("unable to determine type of existing dependency")
+					}
+					version, err := getLatestTemplateVersion(dep.Name, config, projectID)
+					if err != nil {
+						return nil, err
+					}
+					dep.Version = version
 				}
-				version, err := getLatestTemplateVersion(dep.Name, config, projectID)
-				if err != nil {
-					return nil, err
-				}
-				dep.Version = version
+				deps = append(deps, dep)
 			}
-			deps = append(deps, dep)
 		}
 	}
 


### PR DESCRIPTION
How things were done previously:
- releaseValues and releaseDependencies are two objects passed to parse.go. They determine what 'base' to start with before we start overriding with the config in porter.yaml.
- The front-end passes nil releaseValues and releaseDependencies, since it is expected to provide a full porter.yaml, with the current state of the world.
- The CLI passes releaseValues and releaseDependencies from the latest helm release, because if the porter.yaml that it sends to parse is missing services, they will be supplemented with releaseValues and releaseDependencies

The problem:
- If a user adds custom helm values to an existing service of the release, next time the front-end hits deploy, only the front-end-specified values for that service will be propagated to the next release
- This wipes away the custom helm values

The solution:
- Both front-end and CLI will pass releaseValues and releaseDependencies to parse
- Front-end will just 'cut out' the releaseValues and releaseDependencies for services that are not defined in the front-end (effectively acting as deletions)
- Since front-end is using non-nil releaseValues as its base now, it will simply override the releaseValues with the values specified in the front-end, keeping values that already existed which the front-end has no control over (the custom helm values)

Things I tested:
- Adding custom helm values, updating an env variable, and ensuring that the custom helm values still exist in the new revision
- Deleting services from front-end still works
- Building the image and deploying from the CLI still works (does not wipe out existing services not defined in porter.yaml)
