### PR TITLE
POR-1732 Get app env

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -418,20 +418,16 @@ func (c *Client) UpdateRevisionStatus(
 func (c *Client) GetBuildEnv(
 	ctx context.Context,
 	projectID uint, clusterID uint,
-	base64AppProto string,
+	appName string, appRevisionId string,
 ) (*porter_app.GetBuildEnvResponse, error) {
 	resp := &porter_app.GetBuildEnvResponse{}
 
-	req := &porter_app.GetBuildEnvRequest{
-		Base64AppProto: base64AppProto,
-	}
-
-	err := c.postRequest(
+	err := c.getRequest(
 		fmt.Sprintf(
-			"/projects/%d/clusters/%d/apps/build-env",
-			projectID, clusterID,
+			"/projects/%d/clusters/%d/apps/%s/revisions/%s/build-env",
+			projectID, clusterID, appName, appRevisionId,
 		),
-		req,
+		nil,
 		resp,
 	)
 

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -978,14 +978,14 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
-	// POST /api/projects/{project_id}/clusters/{cluster_id}/apps/build-env -> porter_app.NewGetBuildEnvHandler
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/revisions/{app_revision_id}/build-env -> porter_app.NewGetBuildEnvHandler
 	getBuildEnvEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
-			Verb:   types.APIVerbUpdate,
-			Method: types.HTTPVerbPost,
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
 			Path: &types.Path{
 				Parent:       basePath,
-				RelativePath: "/apps/build-env",
+				RelativePath: fmt.Sprintf("/apps/{%s}/revisions/{%s}/build-env", types.URLParamPorterAppName, types.URLParamAppRevisionID),
 			},
 			Scopes: []types.PermissionScope{
 				types.UserScope,
@@ -1004,6 +1004,35 @@ func getPorterAppRoutes(
 	routes = append(routes, &router.Route{
 		Endpoint: getBuildEnvEndpoint,
 		Handler:  getBuildEnvHandler,
+		Router:   r,
+	})
+
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/revisions/{app_revision_id}/env -> porter_app.NewGetAppEnvHandler
+	getAppEnvEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("/apps/{%s}/revisions/{%s}/env", types.URLParamPorterAppName, types.URLParamAppRevisionID),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	getAppEnvHandler := porter_app.NewGetAppEnvHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: getAppEnvEndpoint,
+		Handler:  getAppEnvHandler,
 		Router:   r,
 	})
 

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -150,7 +150,7 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		buildSettings.CurrentImageTag = currentImageTag
 		buildSettings.ProjectID = cliConf.Project
 
-		buildEnv, err := client.GetBuildEnv(ctx, cliConf.Project, cliConf.Cluster, base64AppProto)
+		buildEnv, err := client.GetBuildEnv(ctx, cliConf.Project, cliConf.Cluster, appName, targetResp.DeploymentTargetID)
 		if err != nil {
 			return fmt.Errorf("error getting build env: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.1.4
+	github.com/porter-dev/api-contracts v0.1.5
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1512,8 +1512,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.1.4 h1:EOEd+vgR/Jjt4K8NPKQsxpZ8wq/7jKbnN2sabQnuSqY=
-github.com/porter-dev/api-contracts v0.1.4/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.1.5 h1:Nz0bEIXedKHYfC0YzOj579ABXHxDaH4DXjKcstvWR8A=
+github.com/porter-dev/api-contracts v0.1.5/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/kubernetes/environment_groups/list.go
+++ b/internal/kubernetes/environment_groups/list.go
@@ -31,7 +31,7 @@ type EnvironmentGroup struct {
 	// Variables are non-secret values for the EnvironmentGroup. This usually will be a configmap
 	Variables map[string]string `json:"variables"`
 	// SecretVariables are secret values for the EnvironmentGroup. This usually will be a Secret on the kubernetes cluster
-	SecretVariables map[string][]byte `json:"variables_secrets"`
+	SecretVariables map[string][]byte `json:"variables_secrets,omitempty"`
 	// CreatedAt is only used for display purposes and is in UTC Unix time
 	CreatedAtUTC time.Time `json:"created_at"`
 }

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -12,6 +12,7 @@ import (
 
 type envVariarableOptions struct {
 	includeSecrets bool
+	envGroups      []string
 }
 
 // EnvVariableOption is a function that modifies AppEnvironmentFromProto
@@ -21,6 +22,12 @@ type EnvVariableOption func(*envVariarableOptions)
 func WithSecrets() EnvVariableOption {
 	return func(opts *envVariarableOptions) {
 		opts.includeSecrets = true
+	}
+}
+
+func WithEnvGroupFilter(envGroups []string) EnvVariableOption {
+	return func(opts *envVariarableOptions) {
+		opts.envGroups = envGroups
 	}
 }
 
@@ -36,7 +43,7 @@ func AppEnvironmentFromProto(ctx context.Context, inp AppEnvironmentFromProtoInp
 	ctx, span := telemetry.NewSpan(ctx, "porter-app-env-from-proto")
 	defer span.End()
 
-	var envGroups []environment_groups.EnvironmentGroup
+	envGroups := []environment_groups.EnvironmentGroup{}
 
 	if inp.DeploymentTarget == nil {
 		return nil, telemetry.Error(ctx, span, nil, "must provide a deployment target")
@@ -61,14 +68,26 @@ func AppEnvironmentFromProto(ctx context.Context, inp AppEnvironmentFromProtoInp
 		return envGroups, telemetry.Error(ctx, span, nil, "deployment target selector type not supported")
 	}
 
-	for _, envGroupRef := range inp.App.EnvGroups {
+	filteredEnvGroups := inp.App.EnvGroups
+	if len(opts.envGroups) > 0 {
+		filteredEnvGroups = []*porterv1.EnvGroup{}
+		for _, envGroup := range inp.App.EnvGroups {
+			for _, envGroupName := range opts.envGroups {
+				if envGroup.GetName() == envGroupName {
+					filteredEnvGroups = append(filteredEnvGroups, envGroup)
+				}
+			}
+		}
+	}
+
+	for _, envGroupRef := range filteredEnvGroups {
 		envGroup, err := environment_groups.EnvironmentGroupInTargetNamespace(ctx, inp.K8SAgent, environment_groups.EnvironmentGroupInTargetNamespaceInput{
 			Name:      envGroupRef.GetName(),
 			Version:   int(envGroupRef.GetVersion()),
 			Namespace: namespace,
 		})
 		if err != nil {
-			return nil, err
+			return nil, telemetry.Error(ctx, span, err, "error getting environment group in target namespace")
 		}
 
 		if !opts.includeSecrets {

--- a/internal/porter_app/environment.go
+++ b/internal/porter_app/environment.go
@@ -27,6 +27,7 @@ func WithSecrets() EnvVariableOption {
 	}
 }
 
+// WithEnvGroupFilter filters the environment groups to only include the ones in this list of names
 func WithEnvGroupFilter(envGroups []string) EnvVariableOption {
 	return func(opts *envVariarableOptions) {
 		opts.envGroups = envGroups

--- a/internal/porter_app/revisions.go
+++ b/internal/porter_app/revisions.go
@@ -29,6 +29,7 @@ type Revision struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// GetAppRevisionsInput is the input struct for GetAppRevisions
 type GetAppRevisionInput struct {
 	ProjectID     uint
 	AppRevisionID uuid.UUID

--- a/internal/porter_app/revisions.go
+++ b/internal/porter_app/revisions.go
@@ -29,7 +29,7 @@ type Revision struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// GetAppRevisionsInput is the input struct for GetAppRevisions
+// GetAppRevisionInput is the input struct for GetAppRevisions
 type GetAppRevisionInput struct {
 	ProjectID     uint
 	AppRevisionID uuid.UUID

--- a/internal/porter_app/revisions.go
+++ b/internal/porter_app/revisions.go
@@ -5,8 +5,11 @@ import (
 	"encoding/base64"
 	"time"
 
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
 	"github.com/porter-dev/api-contracts/generated/go/helpers"
 	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	"github.com/porter-dev/api-contracts/generated/go/porter/v1/porterv1connect"
 	"github.com/porter-dev/porter/internal/telemetry"
 )
 
@@ -24,6 +27,50 @@ type Revision struct {
 	CreatedAt time.Time `json:"created_at"`
 	// UpdatedAt is the time the revision was updated
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type GetAppRevisionInput struct {
+	ProjectID     uint
+	AppRevisionID uuid.UUID
+
+	CCPClient porterv1connect.ClusterControlPlaneServiceClient
+}
+
+// GetAppRevision returns a single app revision by id
+func GetAppRevision(ctx context.Context, inp GetAppRevisionInput) (Revision, error) {
+	ctx, span := telemetry.NewSpan(ctx, "get-app-revision")
+	defer span.End()
+
+	var revision Revision
+
+	if inp.ProjectID == 0 {
+		return revision, telemetry.Error(ctx, span, nil, "must provide a project id")
+	}
+	if inp.AppRevisionID == uuid.Nil {
+		return revision, telemetry.Error(ctx, span, nil, "must provide an app revision id")
+	}
+
+	getRevisionReq := connect.NewRequest(&porterv1.GetAppRevisionRequest{
+		ProjectId:     int64(inp.ProjectID),
+		AppRevisionId: inp.AppRevisionID.String(),
+	})
+
+	ccpResp, err := inp.CCPClient.GetAppRevision(ctx, getRevisionReq)
+	if err != nil {
+		return revision, telemetry.Error(ctx, span, err, "error getting app revision")
+	}
+	if ccpResp == nil || ccpResp.Msg == nil {
+		return revision, telemetry.Error(ctx, span, nil, "get app revision response is nil")
+	}
+
+	appRevisionProto := ccpResp.Msg.AppRevision
+
+	revision, err = EncodedRevisionFromProto(ctx, appRevisionProto)
+	if err != nil {
+		return revision, telemetry.Error(ctx, span, err, "error converting app revision from proto")
+	}
+
+	return revision, nil
 }
 
 // EncodedRevisionFromProto converts an AppRevision proto object into a Revision object


### PR DESCRIPTION
## POR-1732
## What does this PR do?

- Motivation: Right now the only way to get environment groups is to list them out as they're defined in the base namespace
- This endpoint serves to get the env variables as they would have been defined when the latest revision was deployed, based on the name and version of each env group as defined in the app contract.
- The other benefit of this endpoint is that it allows us to not have to list out all the env groups on the FE, get the attached apps, and check if the current app is included in the attached app list.