### PR TITLE
[POR-1689] filter out pre-deploy logs from 'all' logs view

### DIFF
--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/LogsTab.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/LogsTab.tsx
@@ -15,6 +15,7 @@ const LogsTab: React.FC = () => {
             appName={appName}
             serviceNames={serviceNames}
             deploymentTargetId={deploymentTargetId}
+            filterPredeploy={true}
         />
     );
 };

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -25,10 +25,8 @@ import Container from "components/porter/Container";
 import Button from "components/porter/Button";
 import LogFilterContainer from "../../expanded-app/logs/LogFilterContainer";
 import StyledLogs from "../../expanded-app/logs/StyledLogs";
-import { AppRevision } from "lib/revisions/types";
 import { useLatestRevisionNumber, useRevisionIdToNumber } from "lib/hooks/useRevisionList";
 import { useLocation } from "react-router";
-import { valueExists } from "shared/util";
 
 type Props = {
     projectId: number;
@@ -38,6 +36,7 @@ type Props = {
     deploymentTargetId: string;
     appRevisionId?: string;
     logFilterNames?: LogFilterName[];
+    filterPredeploy?: boolean;
 };
 
 const Logs: React.FC<Props> = ({
@@ -48,6 +47,7 @@ const Logs: React.FC<Props> = ({
     deploymentTargetId,
     appRevisionId,
     logFilterNames = ["service_name", "revision", "output_stream"],
+    filterPredeploy = false,
 }) => {
     const { search } = useLocation();
     const queryParams = new URLSearchParams(search);
@@ -173,20 +173,21 @@ const Logs: React.FC<Props> = ({
         }, 5000);
     };
 
-    const { logs, refresh, moveCursor, paginationInfo } = useLogs(
-        projectId,
-        clusterId,
+    const { logs, refresh, moveCursor, paginationInfo } = useLogs({
+        projectID: projectId,
+        clusterID: clusterId,
         selectedFilterValues,
         appName,
-        selectedFilterValues.service_name,
+        serviceName: selectedFilterValues.service_name,
         deploymentTargetId,
-        enteredSearchText,
+        searchParam: enteredSearchText,
         notify,
-        setIsLoading,
+        setLoading: setIsLoading,
         revisionIdToNumber,
-        selectedDate,
+        setDate: selectedDate,
         appRevisionId,
-    );
+        filterPredeploy,
+    });
 
     useEffect(() => {
         setFilters([

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
@@ -41,7 +41,22 @@ export const parseLogs = (logs: any[] = []): PorterLog[] => {
   });
 };
 
-export const useLogs = (
+export const useLogs = ({
+  projectID,
+  clusterID,
+  selectedFilterValues,
+  appName,
+  serviceName,
+  deploymentTargetId,
+  searchParam,
+  notify,
+  setLoading,
+  revisionIdToNumber,
+  setDate,
+  appRevisionId = "",
+  timeRange,
+  filterPredeploy,
+}: {
   projectID: number,
   clusterID: number,
   selectedFilterValues: Record<LogFilterName, string>,
@@ -54,11 +69,13 @@ export const useLogs = (
   revisionIdToNumber: Record<string, number>,
   // if setDate is set, results are not live
   setDate?: Date,
-  appRevisionId: string = "",
+  appRevisionId?: string,
   timeRange?: {
     startTime?: Dayjs,
     endTime?: Dayjs,
   },
+  filterPredeploy: boolean,
+}
 ) => {
   const isLive = !setDate;
   const logsBufferRef = useRef<PorterLog[]>([]);
@@ -218,7 +235,7 @@ export const useLogs = (
         return false;
       }
 
-      if ((log.metadata.raw_labels?.porter_run_service_name ?? "").endsWith("predeploy")) {
+      if (filterPredeploy && (log.metadata.raw_labels?.porter_run_service_name ?? "").endsWith("predeploy")) {
         return false;
       }
 

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
@@ -218,6 +218,10 @@ export const useLogs = (
         return false;
       }
 
+      if ((log.metadata.raw_labels?.porter_run_service_name ?? "").endsWith("predeploy")) {
+        return false;
+      }
+
       if (selectedFilterValues.revision !== GenericLogFilter.getDefaultOption("revision").value &&
         log.metadata.revision !== selectedFilterValues.revision) {
         return false;


### PR DESCRIPTION
we don't want to show pre-deploy logs in the main logs page, since they have their own dedicated section in the activity feed
