### PR TITLE
Set default builders to be Ubuntu 22.04 based

### DIFF
--- a/api/server/handlers/gitinstallation/get_buildpack.go
+++ b/api/server/handlers/gitinstallation/get_buildpack.go
@@ -22,12 +22,14 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 	builders[buildpacks.PaketoBuilder] = &buildpacks.BuilderInfo{
 		Name: "Paketo",
 		Builders: []string{
+			"paketobuildpacks/builder-jammy-full:latest",
 			"paketobuildpacks/builder:full",
 		},
 	}
 	builders[buildpacks.HerokuBuilder] = &buildpacks.BuilderInfo{
 		Name: "Heroku",
 		Builders: []string{
+			"heroku/buildpacks:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},

--- a/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
+++ b/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
@@ -130,12 +130,14 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 	builders[buildpacks.PaketoBuilder] = &buildpacks.BuilderInfo{
 		Name: "Paketo",
 		Builders: []string{
+			"paketobuildpacks/builder-jammy-full:latest",
 			"paketobuildpacks/builder:full",
 		},
 	}
 	builders[buildpacks.HerokuBuilder] = &buildpacks.BuilderInfo{
 		Name: "Heroku",
 		Builders: []string{
+			"heroku/buildpacks:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},

--- a/dashboard/src/components/repo-selector/BuildpackSelection.tsx
+++ b/dashboard/src/components/repo-selector/BuildpackSelection.tsx
@@ -10,8 +10,8 @@ import { ActionConfigType } from "shared/types";
 import styled, { keyframes } from "styled-components";
 
 const DEFAULT_BUILDER_NAME = "heroku";
-const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder:full";
-const DEFAULT_HEROKU_STACK = "heroku/buildpacks:20";
+const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
+const DEFAULT_HEROKU_STACK = "heroku/buildpacks:22";
 
 type BuildConfig = {
   builder: string;

--- a/dashboard/src/main/home/app-dashboard/types/buildpack.ts
+++ b/dashboard/src/main/home/app-dashboard/types/buildpack.ts
@@ -24,8 +24,8 @@ export const detectedBuildpackSchema = z.object({
 export type DetectedBuildpack = z.infer<typeof detectedBuildpackSchema>;
 
 export const DEFAULT_BUILDER_NAME = "heroku";
-export const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder:full";
-export const DEFAULT_HEROKU_STACK = "heroku/buildpacks:20";
+export const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
+export const DEFAULT_HEROKU_STACK = "heroku/buildpacks:22";
 
 export const BUILDPACK_TO_NAME: { [key: string]: string } = {
   "heroku/nodejs": "NodeJS",


### PR DESCRIPTION
## What does this PR do?

The previous defaults used Ubuntu 20 (for heroku) and Ubuntu 18 (for packeto). This PR switches us to Ubuntu 22.04 by default, adding the respective builders to each CNB distro.