### PR TITLE
feat: add namespace to helm-get-release telemetry

### DIFF
--- a/internal/helm/agent.go
+++ b/internal/helm/agent.go
@@ -126,6 +126,7 @@ func (a *Agent) GetRelease(
 
 	telemetry.WithAttributes(span,
 		telemetry.AttributeKV{Key: "name", Value: name},
+		telemetry.AttributeKV{Key: "namespace", Value: a.Namespace()},
 		telemetry.AttributeKV{Key: "version", Value: version},
 		telemetry.AttributeKV{Key: "getDeps", Value: getDeps},
 	)


### PR DESCRIPTION
## What does this PR do?

The logic for fetching the latest release depends on a namespace being set, and doesn't seem to be triggered when looking at telemetry atm. This will make it more clear as to whether we should be hitting the 'latest' logic or not.