### PR TITLE
env group parsing hotfix

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupArrayStacks.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/env-groups/EnvGroupArrayStacks.tsx
@@ -45,9 +45,10 @@ const EnvGroupArray = ({
   }, [values]);
   const isKeyOverriding = (key: string) => {
     if (!syncedEnvGroups || !values) return false;
-    return syncedEnvGroups?.some(envGroup =>
-      (envGroup?.variables) && key in envGroup?.variables || key in envGroup?.secret_variables
-    );
+    return syncedEnvGroups?.some(envGroup => {
+      if (!envGroup || !envGroup.variables) return false;
+      return key in envGroup.variables || (envGroup.secret_variables && key in envGroup.secret_variables);
+    });
   };
 
   const readFile = (env: string) => {


### PR DESCRIPTION
stack trace: 
```
dex.js:103 TypeError: Cannot use 'in' operator to search for 'PORT' in undefined
    at EnvGroupArrayStacks.tsx:49:62
    at Array.some (<anonymous>)
    at I (EnvGroupArrayStacks.tsx:48:29)
    at EnvGroupArrayStacks.tsx:107:31
    at Array.map (<anonymous>)
    at t.a (EnvGroupArrayStacks.tsx:92:18)
    at Sa (react-dom.production.min.js:167:137)
    at Ss (react-dom.production.min.js:290:337)
    at wl (react-dom.production.min.js:280:389)
    at yl (react-dom.production.min.js:280:320)
(
```