### PR TITLE
fix: use correct builder for heroku-22

### DIFF
--- a/api/server/handlers/gitinstallation/get_buildpack.go
+++ b/api/server/handlers/gitinstallation/get_buildpack.go
@@ -29,7 +29,7 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 	builders[buildpacks.HerokuBuilder] = &buildpacks.BuilderInfo{
 		Name: "Heroku",
 		Builders: []string{
-			"heroku/buildpacks:22",
+			"heroku/builder:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},

--- a/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
+++ b/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
@@ -137,7 +137,7 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 	builders[buildpacks.HerokuBuilder] = &buildpacks.BuilderInfo{
 		Name: "Heroku",
 		Builders: []string{
-			"heroku/buildpacks:22",
+			"heroku/builder:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},

--- a/dashboard/src/components/repo-selector/BuildpackSelection.tsx
+++ b/dashboard/src/components/repo-selector/BuildpackSelection.tsx
@@ -11,7 +11,7 @@ import styled, { keyframes } from "styled-components";
 
 const DEFAULT_BUILDER_NAME = "heroku";
 const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
-const DEFAULT_HEROKU_STACK = "heroku/buildpacks:22";
+const DEFAULT_HEROKU_STACK = "heroku/builder:22";
 
 type BuildConfig = {
   builder: string;

--- a/dashboard/src/main/home/app-dashboard/types/buildpack.ts
+++ b/dashboard/src/main/home/app-dashboard/types/buildpack.ts
@@ -25,7 +25,7 @@ export type DetectedBuildpack = z.infer<typeof detectedBuildpackSchema>;
 
 export const DEFAULT_BUILDER_NAME = "heroku";
 export const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
-export const DEFAULT_HEROKU_STACK = "heroku/buildpacks:22";
+export const DEFAULT_HEROKU_STACK = "heroku/builder:22";
 
 export const BUILDPACK_TO_NAME: { [key: string]: string } = {
   "heroku/nodejs": "NodeJS",


### PR DESCRIPTION
## What does this PR do?

The ubuntu-22 builder is named heroku/builder, not heroku:buildpacks - the buildpacks naming includes shimmed buildpack support.
