### PR TITLE
support ccp image call

### DIFF
--- a/dashboard/src/components/image-selector/TagList.tsx
+++ b/dashboard/src/components/image-selector/TagList.tsx
@@ -86,7 +86,7 @@ export default class TagList extends Component<PropsType, StateType> {
           const [latestImage] = tags.splice(latestImageIndex, 1);
           tags.unshift(latestImage);
         }
-        this.setState({ tags: tags.map((tag) => tag.tag), loading: false });
+        this.setState({ tags: tags.map((tag) => tag.tag), loading: false, error: false });
       })
       .catch((err) => {
         console.log(err);

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.1.5
+	github.com/porter-dev/api-contracts v0.1.6
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1516,8 +1516,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.1.5 h1:Nz0bEIXedKHYfC0YzOj579ABXHxDaH4DXjKcstvWR8A=
-github.com/porter-dev/api-contracts v0.1.5/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.1.6 h1:nMP/+M53Mohwe/1mNq/HYEnfIKEiDHEFItZwjLmPZ+8=
+github.com/porter-dev/api-contracts v0.1.6/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1026,6 +1026,17 @@ func (r *Registry) ListImages(
 	repo repository.Repository,
 	conf *config.Config,
 ) ([]*ptypes.Image, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-repositories")
+	defer span.End()
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "registry-name", Value: r.Name},
+		telemetry.AttributeKV{Key: "registry-id", Value: r.ID},
+		telemetry.AttributeKV{Key: "registry-url", Value: r.URL},
+		telemetry.AttributeKV{Key: "project-id", Value: r.ProjectID},
+		telemetry.AttributeKV{Key: "repo-name", Value: repoName},
+	)
+
 	// switch on the auth mechanism to get a token
 	if r.AWSIntegrationID != 0 {
 		aws, err := repo.AWSIntegration().ReadAWSIntegration(
@@ -1064,6 +1075,39 @@ func (r *Registry) ListImages(
 	}
 
 	if project.GetFeatureFlag(models.CapiProvisionerEnabled, conf.LaunchDarklyClient) {
+
+		if strings.Contains(r.URL, ".azurecr.") || strings.Contains(r.URL, "-docker.pkg.dev") {
+			req := connect.NewRequest(&porterv1.ListImagesForRepositoryRequest{
+				ProjectId:   int64(r.ProjectID),
+				RegistryUri: r.URL,
+				RepoName:    repoName,
+			})
+
+			resp, err := conf.ClusterControlPlaneClient.ListImagesForRepository(ctx, req)
+			if err != nil {
+				return nil, telemetry.Error(ctx, span, err, "error calling ccp list images")
+			}
+
+			res := make([]*ptypes.Image, 0)
+
+			for _, image := range resp.Msg.Images {
+				if image.UpdatedAt == nil {
+					continue
+				}
+				lastUpdateTime := image.UpdatedAt.AsTime()
+
+				res = append(res, &ptypes.Image{
+					Digest:         image.Digest,
+					Tag:            image.Tag,
+					Manifest:       "",
+					RepositoryName: image.RepositoryName,
+					PushedAt:       &lastUpdateTime,
+				})
+			}
+
+			return res, nil
+		}
+
 		uri := strings.TrimPrefix(r.URL, "https://")
 		splits := strings.Split(uri, ".")
 		accountID := splits[0]


### PR DESCRIPTION
This change calls the CCP ListImage endpoint if the registry URL is Azure or GCP.

It also patches a bug where the frontend won't reset `error: true` after an initial error.