### PR TITLE
sort tags alphabetically

### DIFF
--- a/internal/repository/gorm/tag.go
+++ b/internal/repository/gorm/tag.go
@@ -80,7 +80,7 @@ func (repo *TagRepository) ReadTagByNameAndProjectId(tagName string, projectId u
 func (repo *TagRepository) ListTagsByProjectId(projectId uint) ([]*models.Tag, error) {
 	tags := make([]*models.Tag, 0)
 
-	err := repo.db.Preload("Releases").Where("project_id = ?", projectId).Find(&tags).Error
+	err := repo.db.Preload("Releases").Where("project_id = ?", projectId).Order("name asc").Find(&tags).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Sort application tags alphabetically as opposed to in order of creation.