### PR TITLE
POR-1781 associated attached env versions with revision

### DIFF
--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -67,15 +67,9 @@ type UpdateAppEnvironmentRequest struct {
 	HardUpdate bool `json:"remove_missing"`
 }
 
-// EnvGroup is a struct containing metadata about an environment group
-type EnvGroup struct {
-	EnvGroupName    string `json:"env_group_name"`
-	EnvGroupVersion int    `json:"env_group_version"`
-}
-
 // UpdateAppEnvironmentResponse represents the fields on the response object from the /apps/{porter_app_name}/environment-group endpoint
 type UpdateAppEnvironmentResponse struct {
-	EnvGroups []EnvGroup `json:"env_groups"`
+	EnvGroups []environment_groups.EnvironmentGroup `json:"env_groups"`
 }
 
 // ServeHTTP updates or creates the environment group for an app
@@ -237,9 +231,9 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 				return
 			}
 
-			latestEnvGroups = append(latestEnvGroups, EnvGroup{
-				EnvGroupName:    latestEnvironmentGroup.Name,
-				EnvGroupVersion: int(latestEnvironmentGroup.Version),
+			latestEnvGroups = append(latestEnvGroups, environment_groups.EnvironmentGroup{
+				Name:    latestEnvironmentGroup.Name,
+				Version: int(latestEnvironmentGroup.Version),
 			})
 
 			res := &UpdateAppEnvironmentResponse{
@@ -333,9 +327,9 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	latestEnvGroups = append(latestEnvGroups, EnvGroup{
-		EnvGroupName:    split[0],
-		EnvGroupVersion: version,
+	latestEnvGroups = append(latestEnvGroups, environment_groups.EnvironmentGroup{
+		Name:    split[0],
+		Version: version,
 	})
 
 	res := &UpdateAppEnvironmentResponse{
@@ -361,11 +355,11 @@ type syncLatestEnvGroupVersionsInput struct {
 }
 
 // syncLatestEnvGroupVersions syncs the latest versions of the env groups to the namespace where an app is deployed
-func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersionsInput) ([]EnvGroup, error) {
+func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersionsInput) ([]environment_groups.EnvironmentGroup, error) {
 	ctx, span := telemetry.NewSpan(ctx, "sync-latest-env-group-versions")
 	defer span.End()
 
-	var envGroups []EnvGroup
+	var envGroups []environment_groups.EnvironmentGroup
 
 	if inp.deploymentTargetID == "" {
 		return envGroups, telemetry.Error(ctx, span, nil, "deployment target id is empty")
@@ -387,7 +381,7 @@ func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersi
 		if envGroup == nil {
 			continue
 		}
-		if envGroup.GetName() == inp.appEnvName { 
+		if envGroup.GetName() == inp.appEnvName {
 			continue
 		}
 
@@ -416,9 +410,9 @@ func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersi
 			return envGroups, telemetry.Error(ctx, span, err, "error converting environment group version to int")
 		}
 
-		envGroups = append(envGroups, EnvGroup{
-			EnvGroupName:    split[0],
-			EnvGroupVersion: version,
+		envGroups = append(envGroups, environment_groups.EnvironmentGroup{
+			Name:    split[0],
+			Version: version,
 		})
 	}
 

--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -67,10 +67,15 @@ type UpdateAppEnvironmentRequest struct {
 	HardUpdate bool `json:"remove_missing"`
 }
 
-// UpdateAppEnvironmentResponse represents the fields on the response object from the /apps/{porter_app_name}/environment-group endpoint
-type UpdateAppEnvironmentResponse struct {
+// EnvGroup is a struct containing metadata about an environment group
+type EnvGroup struct {
 	EnvGroupName    string `json:"env_group_name"`
 	EnvGroupVersion int    `json:"env_group_version"`
+}
+
+// UpdateAppEnvironmentResponse represents the fields on the response object from the /apps/{porter_app_name}/environment-group endpoint
+type UpdateAppEnvironmentResponse struct {
+	EnvGroups []EnvGroup `json:"env_groups"`
 }
 
 // ServeHTTP updates or creates the environment group for an app
@@ -221,21 +226,24 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 				envGroups:          appProto.EnvGroups,
 				appName:            appName,
 				appEnvName:         appEnvGroupName,
-				sameAppEnv:         true,
 				namespace:          namespace,
 				deploymentTargetID: request.DeploymentTargetID,
 				k8sAgent:           agent,
 			}
-			err = syncLatestEnvGroupVersions(ctx, syncInp)
+			latestEnvGroups, err := syncLatestEnvGroupVersions(ctx, syncInp)
 			if err != nil {
 				err := telemetry.Error(ctx, span, err, "error syncing latest env group versions")
 				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 				return
 			}
 
-			res := &UpdateAppEnvironmentResponse{
+			latestEnvGroups = append(latestEnvGroups, EnvGroup{
 				EnvGroupName:    latestEnvironmentGroup.Name,
-				EnvGroupVersion: latestEnvironmentGroup.Version,
+				EnvGroupVersion: int(latestEnvironmentGroup.Version),
+			})
+
+			res := &UpdateAppEnvironmentResponse{
+				EnvGroups: latestEnvGroups,
 			}
 
 			c.WriteResult(w, r, res)
@@ -288,15 +296,30 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		TargetNamespace:          namespace,
 	}
 
-	syncedEnvironment, err := environment_groups.SyncLatestVersionToNamespace(ctx, agent, inp, additionalEnvGroupLabels)
+	syncedAppEnvironment, err := environment_groups.SyncLatestVersionToNamespace(ctx, agent, inp, additionalEnvGroupLabels)
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "unable to create or update synced environment group")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
 		return
 	}
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "env-group-versioned-name", Value: syncedEnvironment.EnvironmentGroupVersionedName})
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "env-group-versioned-name", Value: syncedAppEnvironment.EnvironmentGroupVersionedName})
 
-	split := strings.Split(syncedEnvironment.EnvironmentGroupVersionedName, ".")
+	syncInp := syncLatestEnvGroupVersionsInput{
+		envGroups:          appProto.EnvGroups,
+		appName:            appName,
+		appEnvName:         appEnvGroupName,
+		namespace:          namespace,
+		deploymentTargetID: request.DeploymentTargetID,
+		k8sAgent:           agent,
+	}
+	latestEnvGroups, err := syncLatestEnvGroupVersions(ctx, syncInp)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error syncing latest env group versions")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	split := strings.Split(syncedAppEnvironment.EnvironmentGroupVersionedName, ".")
 	if len(split) != 2 {
 		err := telemetry.Error(ctx, span, err, "unexpected environment group versioned name")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
@@ -310,25 +333,13 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	syncInp := syncLatestEnvGroupVersionsInput{
-		envGroups:          appProto.EnvGroups,
-		appName:            appName,
-		appEnvName:         appEnvGroupName,
-		sameAppEnv:         false,
-		namespace:          namespace,
-		deploymentTargetID: request.DeploymentTargetID,
-		k8sAgent:           agent,
-	}
-	err = syncLatestEnvGroupVersions(ctx, syncInp)
-	if err != nil {
-		err := telemetry.Error(ctx, span, err, "error syncing latest env group versions")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-		return
-	}
-
-	res := &UpdateAppEnvironmentResponse{
+	latestEnvGroups = append(latestEnvGroups, EnvGroup{
 		EnvGroupName:    split[0],
 		EnvGroupVersion: version,
+	})
+
+	res := &UpdateAppEnvironmentResponse{
+		EnvGroups: latestEnvGroups,
 	}
 
 	c.WriteResult(w, r, res)
@@ -341,8 +352,6 @@ type syncLatestEnvGroupVersionsInput struct {
 	appName string
 	// appEnvName is the name of the app env. This is the env group created when the app is created for storing app-specific variables
 	appEnvName string
-	// sameAppEnv is true if the app env group variables are unchanged. If true, we do not need to sync the latest version of the app env group
-	sameAppEnv bool
 	// namespace is the namespace to sync the latest versions to
 	namespace string
 	// deploymentTargetID is the id of the deployment target
@@ -352,28 +361,33 @@ type syncLatestEnvGroupVersionsInput struct {
 }
 
 // syncLatestEnvGroupVersions syncs the latest versions of the env groups to the namespace where an app is deployed
-func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersionsInput) error {
+func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersionsInput) ([]EnvGroup, error) {
 	ctx, span := telemetry.NewSpan(ctx, "sync-latest-env-group-versions")
 	defer span.End()
 
+	var envGroups []EnvGroup
+
 	if inp.deploymentTargetID == "" {
-		return telemetry.Error(ctx, span, nil, "deployment target id is empty")
+		return envGroups, telemetry.Error(ctx, span, nil, "deployment target id is empty")
 	}
 	if inp.appName == "" {
-		return telemetry.Error(ctx, span, nil, "app name is empty")
+		return envGroups, telemetry.Error(ctx, span, nil, "app name is empty")
 	}
 	if inp.appEnvName == "" {
-		return telemetry.Error(ctx, span, nil, "app env name is empty")
+		return envGroups, telemetry.Error(ctx, span, nil, "app env name is empty")
 	}
 	if inp.namespace == "" {
-		return telemetry.Error(ctx, span, nil, "namespace is empty")
+		return envGroups, telemetry.Error(ctx, span, nil, "namespace is empty")
 	}
 	if inp.k8sAgent == nil {
-		return telemetry.Error(ctx, span, nil, "k8s agent is nil")
+		return envGroups, telemetry.Error(ctx, span, nil, "k8s agent is nil")
 	}
 
 	for _, envGroup := range inp.envGroups {
 		if envGroup == nil {
+			continue
+		}
+		if envGroup.GetName() == inp.appEnvName { 
 			continue
 		}
 
@@ -383,23 +397,30 @@ func syncLatestEnvGroupVersions(ctx context.Context, inp syncLatestEnvGroupVersi
 			LabelKey_PorterManaged:      "true",
 		}
 
-		if envGroup.GetName() == inp.appEnvName {
-			if inp.sameAppEnv {
-				continue
-			}
-
-			additionalEnvGroupLabels[environment_groups.LabelKey_DefaultAppEnvironment] = "true"
-		}
-
-		_, err := environment_groups.SyncLatestVersionToNamespace(ctx, inp.k8sAgent, environment_groups.SyncLatestVersionToNamespaceInput{
+		syncedEnvironment, err := environment_groups.SyncLatestVersionToNamespace(ctx, inp.k8sAgent, environment_groups.SyncLatestVersionToNamespaceInput{
 			TargetNamespace:          inp.namespace,
 			BaseEnvironmentGroupName: envGroup.GetName(),
 		}, additionalEnvGroupLabels)
 		if err != nil {
 			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "env-group-name", Value: envGroup.GetName()})
-			return telemetry.Error(ctx, span, err, "error syncing latest version to namespace")
+			return envGroups, telemetry.Error(ctx, span, err, "error syncing latest version to namespace")
 		}
+
+		split := strings.Split(syncedEnvironment.EnvironmentGroupVersionedName, ".")
+		if len(split) != 2 {
+			return envGroups, telemetry.Error(ctx, span, err, "unexpected environment group versioned name")
+		}
+
+		version, err := strconv.Atoi(split[1])
+		if err != nil {
+			return envGroups, telemetry.Error(ctx, span, err, "error converting environment group version to int")
+		}
+
+		envGroups = append(envGroups, EnvGroup{
+			EnvGroupName:    split[0],
+			EnvGroupVersion: version,
+		})
 	}
 
-	return nil
+	return envGroups, nil
 }

--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -233,7 +233,7 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 			latestEnvGroups = append(latestEnvGroups, environment_groups.EnvironmentGroup{
 				Name:    latestEnvironmentGroup.Name,
-				Version: int(latestEnvironmentGroup.Version),
+				Version: latestEnvironmentGroup.Version,
 			})
 
 			res := &UpdateAppEnvironmentResponse{

--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -185,8 +185,8 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
         .object({
           env_groups: z
             .object({
-              env_group_name: z.string(),
-              env_group_version: z.coerce.bigint(),
+              name: z.string(),
+              latest_version: z.coerce.bigint(),
             })
             .array(),
         })
@@ -195,8 +195,8 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
       const protoWithUpdatedEnv = new PorterApp({
         ...validatedAppProto,
         envGroups: updatedEnvGroups.env_groups.map((eg) => ({
-          name: eg.env_group_name,
-          version: eg.env_group_version,
+          name: eg.name,
+          version: eg.latest_version,
         })),
       });
 

--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -181,25 +181,23 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
         }
       );
 
-      const updatedEnvGroup = z
+      const updatedEnvGroups = z
         .object({
-          env_group_name: z.string(),
-          env_group_version: z.coerce.bigint(),
+          env_groups: z
+            .object({
+              env_group_name: z.string(),
+              env_group_version: z.coerce.bigint(),
+            })
+            .array(),
         })
         .parse(res.data);
 
       const protoWithUpdatedEnv = new PorterApp({
         ...validatedAppProto,
-        envGroups: validatedAppProto.envGroups.map((envGroup) => {
-          if (envGroup.name === updatedEnvGroup.env_group_name) {
-            return {
-              ...envGroup,
-              version: updatedEnvGroup.env_group_version,
-            };
-          }
-
-          return envGroup;
-        }),
+        envGroups: updatedEnvGroups.env_groups.map((eg) => ({
+          name: eg.env_group_name,
+          version: eg.env_group_version,
+        })),
       });
 
       await api.applyApp(

--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -279,8 +279,8 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
           .object({
             env_groups: z
               .object({
-                env_group_name: z.string(),
-                env_group_version: z.coerce.bigint(),
+                name: z.string(),
+                latest_version: z.coerce.bigint(),
               })
               .array(),
           })
@@ -289,8 +289,8 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
         const protoWithUpdatedEnv = new PorterApp({
           ...app,
           envGroups: updatedEnvGroups.env_groups.map((eg) => ({
-            name: eg.env_group_name,
-            version: eg.env_group_version,
+            name: eg.name,
+            version: eg.latest_version,
           })),
         });
 

--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -183,7 +183,10 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
     porterYamlFound,
     detectedName,
     loading: isLoadingPorterYaml,
-  } = usePorterYaml({ source: source?.type === "github" ? source : null, appName: name.value });
+  } = usePorterYaml({
+    source: source?.type === "github" ? source : null,
+    appName: name.value,
+  });
   const deploymentTarget = useDefaultDeploymentTarget();
   const { updateAppStep } = useAppAnalytics(name.value);
   const { validateApp } = useAppValidation({
@@ -257,7 +260,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
           }
         );
 
-        const envGroupResponse = await api.updateEnvironmentGroupV2(
+        const res = await api.updateEnvironmentGroupV2(
           "<token>",
           {
             deployment_target_id: deploymentTarget.deployment_target_id,
@@ -272,31 +275,29 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
           }
         );
 
-        const addedEnvGroup = await z
+        const updatedEnvGroups = z
           .object({
-            env_group_name: z.string(),
-            env_group_version: z.coerce.bigint(),
+            env_groups: z
+              .object({
+                env_group_name: z.string(),
+                env_group_version: z.coerce.bigint(),
+              })
+              .array(),
           })
-          .parseAsync(envGroupResponse.data);
+          .parse(res.data);
 
-        const envGroups = [
-          ...app.envGroups.filter(
-            (group) => group.name !== addedEnvGroup.env_group_name
-          ),
-          {
-            name: addedEnvGroup.env_group_name,
-            version: addedEnvGroup.env_group_version,
-          },
-        ];
-        const appWithSeededEnv = new PorterApp({
+        const protoWithUpdatedEnv = new PorterApp({
           ...app,
-          envGroups,
+          envGroups: updatedEnvGroups.env_groups.map((eg) => ({
+            name: eg.env_group_name,
+            version: eg.env_group_version,
+          })),
         });
 
         await api.applyApp(
           "<token>",
           {
-            b64_app_proto: btoa(appWithSeededEnv.toJsonString()),
+            b64_app_proto: btoa(protoWithUpdatedEnv.toJsonString()),
             deployment_target_id: deploymentTarget.deployment_target_id,
           },
           {

--- a/internal/kubernetes/environment_groups/list.go
+++ b/internal/kubernetes/environment_groups/list.go
@@ -35,7 +35,7 @@ type EnvironmentGroup struct {
 	// SecretVariables are secret values for the EnvironmentGroup. This usually will be a Secret on the kubernetes cluster
 	SecretVariables map[string]string `json:"secret_variables,omitempty"`
 	// CreatedAt is only used for display purposes and is in UTC Unix time
-	CreatedAtUTC time.Time `json:"created_at"`
+	CreatedAtUTC time.Time `json:"created_at,omitempty"`
 }
 
 type environmentGroupOptions struct {


### PR DESCRIPTION
## POR-1781
## What does this PR do?

- Previously, the latest version of env groups associated with a revision were being moved to the namespace specified by a deployment target, but the revision was not accounting for the version incrementing
- This PR returns all env groups that were updated so that the new versions can be accounted for on an upcoming revision