### PR TITLE
feat: add telemetry for the cluster status endpoint

### DIFF
--- a/api/server/handlers/cluster/cluster_status.go
+++ b/api/server/handlers/cluster/cluster_status.go
@@ -45,11 +45,6 @@ func (c *ClusterStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	defer span.End()
 
 	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
-	telemetry.WithAttributes(span,
-		telemetry.AttributeKV{Key: "project-id", Value: cluster.ProjectID},
-		telemetry.AttributeKV{Key: "cluster-id", Value: cluster.ID},
-	)
-
 	req := connect.NewRequest(&porterv1.ClusterStatusRequest{
 		ProjectId: int64(cluster.ProjectID),
 		ClusterId: int64(cluster.ID),


### PR DESCRIPTION
## What does this PR do?

This PR adds some telemetry to the cluster status endpoint. The endpoint currently just returns an internal service error without any extra context. Without this change, internal service errors get swallowed up, making debugging more difficult.