### PR TITLE
fix: switch the default heroku builder to heroku-20

### DIFF
--- a/dashboard/src/components/repo-selector/BuildpackSelection.tsx
+++ b/dashboard/src/components/repo-selector/BuildpackSelection.tsx
@@ -11,7 +11,7 @@ import styled, { keyframes } from "styled-components";
 
 const DEFAULT_BUILDER_NAME = "heroku";
 const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
-const DEFAULT_HEROKU_STACK = "heroku/builder:22";
+const DEFAULT_HEROKU_STACK = "heroku/buildpacks:20";
 
 type BuildConfig = {
   builder: string;

--- a/dashboard/src/main/home/app-dashboard/types/buildpack.ts
+++ b/dashboard/src/main/home/app-dashboard/types/buildpack.ts
@@ -25,7 +25,7 @@ export type DetectedBuildpack = z.infer<typeof detectedBuildpackSchema>;
 
 export const DEFAULT_BUILDER_NAME = "heroku";
 export const DEFAULT_PAKETO_STACK = "paketobuildpacks/builder-jammy-full:latest";
-export const DEFAULT_HEROKU_STACK = "heroku/builder:22";
+export const DEFAULT_HEROKU_STACK = "heroku/buildpacks:20";
 
 export const BUILDPACK_TO_NAME: { [key: string]: string } = {
   "heroku/nodejs": "NodeJS",


### PR DESCRIPTION
## What does this PR do?

The :22 builder requires injecting a Procfile in order for detection to work as all the buildpack groups depend on a Procfile to detect properly, so for now we'll just revert this.
