### PR TITLE
POR-1778 prevent env from being cleared out on revert

### DIFF
--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionsList.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionsList.tsx
@@ -83,7 +83,8 @@ const RevisionsList: React.FC<Props> = ({
       clientAppFromProto({
         proto: revertData.app,
         overrides: servicesFromYaml,
-        
+        variables: revertData.variables,
+        secrets: revertData.secrets,
       })
     );
     setRevertData(null);


### PR DESCRIPTION
## POR-1778
## What does this PR do?

- include env vars from previous revision in app definition when reverting
