### PR TITLE
let the porter app creation api call fail if build and image are missing, not cli

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -315,9 +315,6 @@ func (c *Client) CreatePorterAppDBEntry(
 			Tag:        inp.ImageTag,
 		}
 	}
-	if sourceType == "" {
-		return fmt.Errorf("cannot determine source type")
-	}
 
 	req := &porter_app.CreateAppRequest{
 		Name:           inp.AppName,

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -56,21 +56,24 @@ func Apply(ctx context.Context, cliConf config.CLIConfig, client api.Client, por
 		}
 		b64AppProto = parseResp.B64AppProto
 
-		// we only need to create the app if a porter yaml is provided (otherwise it must already exist)
-		createPorterAppDBEntryInp, err := createPorterAppDbEntryInputFromProtoAndEnv(parseResp.B64AppProto)
-		if err != nil {
-			return fmt.Errorf("error creating porter app db entry input from proto: %w", err)
-		}
-
-		err = client.CreatePorterAppDBEntry(ctx, cliConf.Project, cliConf.Cluster, createPorterAppDBEntryInp)
-		if err != nil {
-			return fmt.Errorf("error creating porter app db entry: %w", err)
-		}
-
 		// override app name if provided
 		appName, err = appNameFromB64AppProto(parseResp.B64AppProto)
 		if err != nil {
 			return fmt.Errorf("error getting app name from b64 app proto: %w", err)
+		}
+
+		// we only need to create the app if a porter yaml is provided (otherwise it must already exist)
+		createPorterAppDBEntryInp, err := createPorterAppDbEntryInputFromProtoAndEnv(parseResp.B64AppProto)
+		if err != nil {
+			return fmt.Errorf("unable to form porter app creation input from yaml: %w", err)
+		}
+
+		err = client.CreatePorterAppDBEntry(ctx, cliConf.Project, cliConf.Cluster, createPorterAppDBEntryInp)
+		if err != nil {
+			if err.Error() == porter_app.ErrMissingSourceType.Error() {
+				return fmt.Errorf("cannot find existing Porter app with name %s and no build or image settings were specified in porter.yaml", appName)
+			}
+			return fmt.Errorf("unable to create porter app from yaml: %w", err)
 		}
 
 		envGroupResp, err := client.CreateOrUpdateAppEnvironment(ctx, cliConf.Project, cliConf.Cluster, appName, targetResp.DeploymentTargetID, parseResp.EnvVariables, parseResp.EnvSecrets, parseResp.B64AppProto)
@@ -289,7 +292,7 @@ func createPorterAppDbEntryInputFromProtoAndEnv(base64AppProto string) (api.Crea
 		return input, nil
 	}
 
-	return input, fmt.Errorf("app does not contain build or image settings")
+	return input, nil
 }
 
 func buildSettingsFromBase64AppProto(base64AppProto string) (buildInput, error) {


### PR DESCRIPTION
Previously, the CLI would fail if a porter.yaml was specified and no build/image was included.  This was because it always tries to create a Porter App (though this is a no-op if an app was already created).  However, we should support cases were the app was created with image or build settings in the UI, and the CLI is running with a porter.yaml that excludes these.

This PR lets the Porter App creation logic decide whether to error out on missing image/build info. If the app already exists, it will successfully return it.

Note: if we ever want to support changing the build/image info, this logic will have to change.