### PR TITLE
POR-1788 fix linked apps

### DIFF
--- a/api/server/handlers/environment_groups/list.go
+++ b/api/server/handlers/environment_groups/list.go
@@ -49,6 +49,7 @@ func (c *ListEnvironmentGroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	ctx, span := telemetry.NewSpan(r.Context(), "serve-list-env-groups")
 	defer span.End()
 
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
 	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
 
 	agent, err := c.GetAgent(r, cluster, "")
@@ -84,26 +85,39 @@ func (c *ListEnvironmentGroupsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 			return
 		}
 
-		applications, err := environmentgroups.LinkedApplications(ctx, agent, latestVersion.Name)
-		if err != nil {
-			err = telemetry.Error(ctx, span, err, "unable to get linked applications")
-			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-			return
-		}
-
-		applicationSetForEnvGroup := make(map[string]struct{})
-		for _, app := range applications {
-			if app.Namespace == "" {
-				continue
-			}
-			if _, ok := applicationSetForEnvGroup[app.Namespace]; !ok {
-				applicationSetForEnvGroup[app.Namespace] = struct{}{}
-			}
-		}
 		var linkedApplications []string
-		for appNamespace := range applicationSetForEnvGroup {
-			porterAppName := strings.TrimPrefix(appNamespace, "porter-stack-")
-			linkedApplications = append(linkedApplications, porterAppName)
+		if !project.GetFeatureFlag(models.ValidateApplyV2, c.Config().LaunchDarklyClient) {
+			applications, err := environmentgroups.LinkedApplications(ctx, agent, latestVersion.Name, true)
+			if err != nil {
+				err = telemetry.Error(ctx, span, err, "unable to get linked applications")
+				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+				return
+			}
+
+			applicationSetForEnvGroup := make(map[string]struct{})
+			for _, app := range applications {
+				if app.Namespace == "" {
+					continue
+				}
+				if _, ok := applicationSetForEnvGroup[app.Namespace]; !ok {
+					applicationSetForEnvGroup[app.Namespace] = struct{}{}
+				}
+			}
+			for appNamespace := range applicationSetForEnvGroup {
+				porterAppName := strings.TrimPrefix(appNamespace, "porter-stack-")
+				linkedApplications = append(linkedApplications, porterAppName)
+			}
+		} else {
+			applications, err := environmentgroups.LinkedApplications(ctx, agent, latestVersion.Name, false)
+			if err != nil {
+				err = telemetry.Error(ctx, span, err, "unable to get linked applications")
+				c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+				return
+			}
+
+			for _, app := range applications {
+				linkedApplications = append(linkedApplications, app.Name)
+			}
 		}
 
 		secrets := make(map[string]string)

--- a/dashboard/src/main/home/app-dashboard/app-view/LatestRevisionContext.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/LatestRevisionContext.tsx
@@ -27,8 +27,8 @@ export const LatestRevisionContext = createContext<{
   clusterId: number;
   projectId: number;
   deploymentTargetId: string;
-  previewRevision: number | null;
-  setPreviewRevision: Dispatch<SetStateAction<number | null>>;
+  previewRevision: AppRevision | null;
+  setPreviewRevision: Dispatch<SetStateAction<AppRevision | null>>;
 } | null>(null);
 
 export const useLatestRevision = () => {
@@ -48,7 +48,7 @@ export const LatestRevisionProvider = ({
   appName?: string;
   children: JSX.Element;
 }) => {
-  const [previewRevision, setPreviewRevision] = useState<number | null>(null);
+  const [previewRevision, setPreviewRevision] = useState<AppRevision | null>(null);
   const { currentCluster, currentProject } = useContext(Context);
   const deploymentTarget = useDefaultDeploymentTarget();
 

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
@@ -19,6 +19,7 @@ const Environment: React.FC = () => {
     latestProto,
     clusterId,
     projectId,
+    previewRevision,
   } = useLatestRevision();
   const {
     formState: { isSubmitting, errors },
@@ -68,7 +69,7 @@ const Environment: React.FC = () => {
       <EnvVariables />
       <EnvGroups
         appName={latestProto.name}
-        revisionId={latestRevision.id}
+        revisionId={previewRevision ? previewRevision.id : latestRevision.id} // get versions of env groups attached to preview revision if set
         baseEnvGroups={baseEnvGroups}
         existingEnvGroupNames={envGroupNames}
       />

--- a/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroups.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroups.tsx
@@ -153,7 +153,7 @@ const EnvGroups: React.FC<Props> = ({
           Max 4 Env Groups allowed
         </TooltipText>
       </TooltipWrapper>
-      {envGroups.length > 0 && (
+      {populatedEnvWithFallback.length > 0 && (
         <>
           <Spacer y={0.5} />
           <Text size={16}>Synced environment groups</Text>

--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
@@ -102,7 +102,7 @@ const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
     const { numDeployed, latestRevision } = args;
 
     if (previewRevision) {
-      return previewRevision;
+      return previewRevision.revision_number;
     }
 
     if (latestRevision && latestRevision.revision_number !== 0) {
@@ -181,7 +181,8 @@ const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
                     key={revision.revision_number}
                     selected={
                       previewRevision
-                        ? revision.revision_number === previewRevision
+                        ? revision.revision_number ===
+                          previewRevision.revision_number
                         : isLatestDeployedRevision
                     }
                     onClick={() => {
@@ -198,10 +199,9 @@ const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
                           envGroupNames: [],
                         },
                       });
+
                       setPreviewRevision(
-                        isLatestDeployedRevision
-                          ? null
-                          : revision.revision_number
+                        isLatestDeployedRevision ? null : revision
                       );
                     }}
                   >

--- a/internal/kubernetes/environment_groups/delete.go
+++ b/internal/kubernetes/environment_groups/delete.go
@@ -27,7 +27,7 @@ func DeleteEnvironmentGroup(ctx context.Context, a *kubernetes.Agent, name strin
 	}
 
 	for _, environmentGroup := range environmentGroups {
-		applications, err := LinkedApplications(ctx, a, environmentGroup.Name)
+		applications, err := LinkedApplications(ctx, a, environmentGroup.Name, true)
 		if err != nil {
 			return telemetry.Error(ctx, span, err, "unable to list linked applications")
 		}


### PR DESCRIPTION
## POR-1788
## What does this PR do?

- Previously, linked apps were determined by finding the unique set of namespaces containing deployments that have the env group attached by label
- for validate/apply v2, we set an app name label that we can use instead, since many apps can now be deployed in the same namespace
