### PR TITLE
filter predeploys when getting linked apps

### DIFF
--- a/internal/kubernetes/environment_groups/list.go
+++ b/internal/kubernetes/environment_groups/list.go
@@ -255,7 +255,7 @@ func listLinkedAppsByUniqueAppLabel(environmentGroupName string, deployments []a
 		appName := d.Labels[LabelKey_AppName]
 
 		for _, linkedEnvironmentGroup := range applicationsLinkedEnvironmentGroups {
-			if linkedEnvironmentGroup == environmentGroupName && appName != "" {
+			if linkedEnvironmentGroup == environmentGroupName && !strings.HasSuffix(d.Name, "predeploy") && appName != "" {
 				appsByName[appName] = LinkedPorterApplication{
 					Name:      appName,
 					Namespace: d.Namespace,


### PR DESCRIPTION
## What does this PR do?

- predeploy cronjob deployments aren't removed, so a deleted app will still appear to be linked
