### PR TITLE
change validate apply default to true

### DIFF
--- a/api/server/handlers/project/create_test.go
+++ b/api/server/handlers/project/create_test.go
@@ -47,6 +47,7 @@ func TestCreateProjectSuccessful(t *testing.T) {
 		HelmValuesEnabled:      false,
 		MultiCluster:           false,
 		EnableReprovision:      false,
+		ValidateApplyV2:        true,
 	}
 
 	gotProject := &types.CreateProjectResponse{}

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -70,7 +70,7 @@ var ProjectFeatureFlags = map[FeatureFlagLabel]bool{
 	RDSDatabasesEnabled:    false,
 	SimplifiedViewEnabled:  true,
 	StacksEnabled:          false,
-	ValidateApplyV2:        false,
+	ValidateApplyV2:        true,
 }
 
 type ProjectPlan string


### PR DESCRIPTION
## What does this PR do?

- This sets the default fallback evaluation of the validate_apply_v2 feature flag to be true in cases where no evaluation can be determined for a given context
- This should only be released after all existing contexts have been assigned the off variation
