### PR TITLE
POR-1714: properly redirect users to their first project if the project they attempt to route to is non-existent

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -140,6 +140,13 @@ const Home: React.FC<Props> = (props) => {
             Number(localStorage.getItem("currentProject")) || projectList[0].id;
         }
 
+        const foundProjectListEntry = projectList.find(
+          (item: ProjectListType) => item.id === id
+        );
+        if (foundProjectListEntry === undefined) {
+          id = projectList[0].id
+        }
+
         const project = await api
           .getProject("<token>", {}, { id: id })
           .then((res) => res.data as ProjectType);


### PR DESCRIPTION
## What does this PR do?

Due to our use of localStorage for storing the current project, it is possible to get into a state where the current project id is set to a non-existent project, resulting in a weird state for the view that is a melange of all features turned off. This page is hard to get out of because the sidebar doesn't show a project selector, so it appears to the user that there are no projects at all.

Currently, the only known way to trigger such a view is to setup a local dev install, create a new project, browse to the new project, then reset the entire dev cluster. On first login on the new install, the user is redirected to a weird page.

The fix is just to verify the project being viewed is in the list of returned projects. If not, we redirect to the first project in the list.

The ideal case is that we show an error pop up of some sort, but there isn't a standard here, so I've left that error state as is.

I was able to replicate this locally by browsing to something like `http://localhost:8081/apps?project_id=404`, where `404` is the ID of a non-existent project. You should be redirected to the first project in your list. If you don't have any projects, the previous project fetch will already perform the redirect to the new project page, so there isn't anything extra we need to do there.