### PR TITLE
fix passing validate apply v2 flag to segment

### DIFF
--- a/api/server/handlers/porter_app/analytics.go
+++ b/api/server/handlers/porter_app/analytics.go
@@ -110,6 +110,7 @@ func TrackStackBuildStatus(
 	stackName string,
 	errorMessage string,
 	status types.PorterAppEventStatus,
+	validateApplyV2 bool,
 ) error {
 	_, span := telemetry.NewSpan(ctx, "track-build-status")
 	defer span.End()
@@ -126,7 +127,7 @@ func TrackStackBuildStatus(
 			FirstName:              user.FirstName,
 			LastName:               user.LastName,
 			CompanyName:            user.CompanyName,
-			ValidateApplyV2:        project.ValidateApplyV2,
+			ValidateApplyV2:        validateApplyV2,
 		}))
 	}
 
@@ -138,7 +139,7 @@ func TrackStackBuildStatus(
 			FirstName:              user.FirstName,
 			LastName:               user.LastName,
 			CompanyName:            user.CompanyName,
-			ValidateApplyV2:        project.ValidateApplyV2,
+			ValidateApplyV2:        validateApplyV2,
 		}))
 	}
 
@@ -151,7 +152,7 @@ func TrackStackBuildStatus(
 			FirstName:              user.FirstName,
 			LastName:               user.LastName,
 			CompanyName:            user.CompanyName,
-			ValidateApplyV2:        project.ValidateApplyV2,
+			ValidateApplyV2:        validateApplyV2,
 		}))
 	}
 

--- a/api/server/handlers/porter_app/list_events.go
+++ b/api/server/handlers/porter_app/list_events.go
@@ -132,7 +132,8 @@ func (p *PorterAppEventListHandler) updateExistingAppEvent(
 
 	// TODO: get rid of this block and related methods if still here after 08-04-2023
 	if appEvent.Type == string(types.PorterAppEventType_Build) && appEvent.TypeExternalSource == "GITHUB" {
-		err = p.updateBuildEvent_Github(ctx, &event, user, project, stackName)
+		validateApplyV2 := project.GetFeatureFlag(models.ValidateApplyV2, p.Config().LaunchDarklyClient)
+		err = p.updateBuildEvent_Github(ctx, &event, user, project, stackName, validateApplyV2)
 		if err != nil {
 			return appEvent, telemetry.Error(ctx, span, err, "error updating porter app event for github build")
 		}
@@ -158,6 +159,7 @@ func (p *PorterAppEventListHandler) updateBuildEvent_Github(
 	user *models.User,
 	project *models.Project,
 	stackName string,
+	validateApplyV2 bool,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "update-porter-app-build-event")
 	defer span.End()
@@ -220,10 +222,10 @@ func (p *PorterAppEventListHandler) updateBuildEvent_Github(
 	if *actionRun.Status == "completed" {
 		if *actionRun.Conclusion == "success" {
 			event.Status = string(types.PorterAppEventStatus_Success)
-			_ = TrackStackBuildStatus(ctx, p.Config(), user, project, stackName, "", types.PorterAppEventStatus_Success)
+			_ = TrackStackBuildStatus(ctx, p.Config(), user, project, stackName, "", types.PorterAppEventStatus_Success, validateApplyV2)
 		} else {
 			event.Status = string(types.PorterAppEventStatus_Failed)
-			_ = TrackStackBuildStatus(ctx, p.Config(), user, project, stackName, "", types.PorterAppEventStatus_Failed)
+			_ = TrackStackBuildStatus(ctx, p.Config(), user, project, stackName, "", types.PorterAppEventStatus_Failed, validateApplyV2)
 		}
 		event.Metadata["end_time"] = actionRun.GetUpdatedAt().Time
 	}


### PR DESCRIPTION
ValidateApplyV2 was always false because it was pulling from the project db model, but now that we have launch darkly we have to pull the feature flag value from the client
