### PR TITLE
feat: add support for buildpack urns

### DIFF
--- a/dashboard/src/main/home/app-dashboard/build-settings/buildpacks/AddCustomBuildpackComponent.tsx
+++ b/dashboard/src/main/home/app-dashboard/build-settings/buildpacks/AddCustomBuildpackComponent.tsx
@@ -3,7 +3,12 @@ import React, { useState } from "react";
 import styled, { keyframes } from "styled-components";
 import { Buildpack } from "../../types/buildpack";
 
-function isValidURL(url: string): boolean {
+function isValidBuildpack(url: string): boolean {
+  const urnPrefix = "urn:cnb:registry:";
+  if (url.startsWith(urnPrefix)) {
+    return true;
+  }
+
   const pattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(:\d{2,5})?([\/\w.-]*)*\/?$/i;
   return pattern.test(url);
 }
@@ -15,7 +20,7 @@ const AddCustomBuildpackComponent: React.FC<{
   const [error, setError] = useState(false);
 
   const handleAddCustomBuildpack = () => {
-    if (buildpackUrl === "" || !isValidURL(buildpackUrl)) {
+    if (buildpackUrl === "" || !isValidBuildpack(buildpackUrl)) {
       setError(true);
       return;
     }

--- a/dashboard/src/main/home/app-dashboard/validate-apply/build-settings/buildpacks/AddCustomBuildpack.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/build-settings/buildpacks/AddCustomBuildpack.tsx
@@ -3,7 +3,12 @@ import { Buildpack } from "main/home/app-dashboard/types/buildpack";
 import React, { useState } from "react";
 import styled, { keyframes } from "styled-components";
 
-function isValidURL(url: string): boolean {
+function isValidBuildpack(url: string): boolean {
+  const urnPrefix = "urn:cnb:registry:";
+  if (url.startsWith(urnPrefix)) {
+    return true;
+  }
+
   const pattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(:\d{2,5})?([\/\w.-]*)*\/?$/i;
   return pattern.test(url);
 }
@@ -15,7 +20,7 @@ const AddCustomBuildpack: React.FC<{
   const [error, setError] = useState(false);
 
   const handleAddCustomBuildpack = () => {
-    if (buildpackUrl === "" || !isValidURL(buildpackUrl)) {
+    if (buildpackUrl === "" || !isValidBuildpack(buildpackUrl)) {
       setError(true);
       return;
     }


### PR DESCRIPTION
## What does this PR do?

URNs pull directly from the CNB registry, and should be fine to reference as is. We previously only supported git/https urls for referencing buildpacks, which aren't always available for various reasons.