### PR TITLE
fix: write an empty Procfile to force detection to work for all buildpacks

### DIFF
--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -42,8 +42,9 @@ func (a *Agent) Build(ctx context.Context, opts *docker.BuildOpts, buildConfig *
 		return err
 	}
 
-	mode := os.FileMode(0600)
-	file, err := os.OpenFile(filepath.Join(absPath, "Procfile"), os.O_RDONLY|os.O_CREATE, mode)
+	mode := os.FileMode(0o600)
+	procfilePath := filepath.Clean(filepath.Join(absPath, "Procfile"))
+	file, err := os.OpenFile(procfilePath, os.O_RDONLY|os.O_CREATE, mode)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -47,7 +47,9 @@ func (a *Agent) Build(ctx context.Context, opts *docker.BuildOpts, buildConfig *
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	if err := file.Close(); err != nil {
+		return err
+	}
 
 	buildOpts := packclient.BuildOptions{
 		RelativeBaseDir: filepath.Dir(absPath),

--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -40,6 +41,13 @@ func (a *Agent) Build(ctx context.Context, opts *docker.BuildOpts, buildConfig *
 	if err != nil {
 		return err
 	}
+
+	mode := os.FileMode(0600)
+	file, err := os.OpenFile(filepath.Join(absPath, "Procfile"), os.O_RDONLY|os.O_CREATE, mode)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 
 	buildOpts := packclient.BuildOptions{
 		RelativeBaseDir: filepath.Dir(absPath),


### PR DESCRIPTION
## What does this PR do?

Some buildpack groups fail to detect because of a missing Procfile, such as the heroku/python buildpack.