### PR TITLE
chore: update to latest heroku/procfile buildpack

### DIFF
--- a/cli/cmd/pack/pack.go
+++ b/cli/cmd/pack/pack.go
@@ -152,7 +152,7 @@ func (a *Agent) Build(ctx context.Context, opts *docker.BuildOpts, buildConfig *
 	}
 
 	if len(buildOpts.Buildpacks) > 0 && strings.HasPrefix(buildOpts.Builder, "heroku") {
-		buildOpts.Buildpacks = append(buildOpts.Buildpacks, "heroku/procfile@1.0.1")
+		buildOpts.Buildpacks = append(buildOpts.Buildpacks, "heroku/procfile@2.0.1")
 	}
 
 	return sharedPackClient.Build(ctx, buildOpts)


### PR DESCRIPTION
## What does this PR do?

The older version uses a deprecated buildpack api, causing warnings to output when building apps.

See the changelog for more details: https://github.com/heroku/procfile-cnb/blob/main/CHANGELOG.md