### PR TITLE
feat: add heroku/builder-classic:22 to the builder list

### DIFF
--- a/api/server/handlers/gitinstallation/get_buildpack.go
+++ b/api/server/handlers/gitinstallation/get_buildpack.go
@@ -30,6 +30,7 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 		Name: "Heroku",
 		Builders: []string{
 			"heroku/builder:22",
+			"heroku/builder-classic:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},

--- a/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
+++ b/api/server/handlers/project_integration/get_gitlab_repo_buildpack.go
@@ -138,6 +138,7 @@ func initBuilderInfo() map[string]*buildpacks.BuilderInfo {
 		Name: "Heroku",
 		Builders: []string{
 			"heroku/builder:22",
+			"heroku/builder-classic:22",
 			"heroku/buildpacks:20",
 			"heroku/buildpacks:18",
 		},


### PR DESCRIPTION
## What does this PR do?

While not currently default, adding this should allow builds to use v2a Buildpacks in their apps by default through the use of the built-in shim. Additionally, all the buildpacks are the existing official Heroku v2a Buildpacks, so this will provide maximum compatibility for users migrating from Heroku.

See https://github.com/heroku/builder for more information on the available builders.
