### PR TITLE
fix parsing of custom buildpack urls

### DIFF
--- a/dashboard/src/main/home/app-dashboard/build-settings/buildpacks/AddCustomBuildpackComponent.tsx
+++ b/dashboard/src/main/home/app-dashboard/build-settings/buildpacks/AddCustomBuildpackComponent.tsx
@@ -8,9 +8,12 @@ function isValidBuildpack(url: string): boolean {
   if (url.startsWith(urnPrefix)) {
     return true;
   }
-
-  const pattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(:\d{2,5})?([\/\w.-]*)*\/?$/i;
-  return pattern.test(url);
+  try {
+    new URL(url);
+    return true;
+  } catch (error) {
+    return false;
+  }
 }
 
 const AddCustomBuildpackComponent: React.FC<{

--- a/dashboard/src/main/home/app-dashboard/validate-apply/build-settings/buildpacks/AddCustomBuildpack.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/build-settings/buildpacks/AddCustomBuildpack.tsx
@@ -8,9 +8,12 @@ function isValidBuildpack(url: string): boolean {
   if (url.startsWith(urnPrefix)) {
     return true;
   }
-
-  const pattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(:\d{2,5})?([\/\w.-]*)*\/?$/i;
-  return pattern.test(url);
+  try {
+    new URL(url);
+    return true;
+  } catch (error) {
+    return false;
+  }
 }
 
 const AddCustomBuildpack: React.FC<{
@@ -53,7 +56,7 @@ const AddCustomBuildpack: React.FC<{
         </EventInformation>
       </ContentContainer>
       <ActionContainer>
-        <ActionButton onClick={() => handleAddCustomBuildpack()}>
+        <ActionButton onClick={() => handleAddCustomBuildpack()} type="button">
           <span className="material-icons-outlined">add</span>
         </ActionButton>
       </ActionContainer>


### PR DESCRIPTION
Previous regex parsing runs into a crashloop for some URLs; this PR simplifies the implementation to remove the regex entirely
