### PR TITLE
POR-1435 create app templates and commit preview env workflow

### DIFF
--- a/api/server/handlers/porter_app/create_secret_and_open_pr.go
+++ b/api/server/handlers/porter_app/create_secret_and_open_pr.go
@@ -116,22 +116,35 @@ func (c *OpenStackPRHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		prRequestBody = "Hello 👋 from Porter! Please merge this PR to enable preview environments for your application."
 	}
+
 	if request.OpenPr || request.DeleteWorkflowFilename != "" {
-		pr, err = actions.OpenGithubPR(&actions.GithubPROpts{
-			Client:                  client,
-			GitRepoOwner:            request.GithubRepoOwner,
-			GitRepoName:             request.GithubRepoName,
-			StackName:               appName,
-			ProjectID:               project.ID,
-			ClusterID:               cluster.ID,
-			ServerURL:               c.Config().ServerConf.ServerURL,
-			DefaultBranch:           request.Branch,
-			SecretName:              secretName,
-			PorterYamlPath:          request.PorterYamlPath,
-			Body:                    prRequestBody,
-			DeleteWorkflowFilename:  request.DeleteWorkflowFilename,
-			PreviewWorkflowFilename: request.PreviewsWorkflowFilename,
-		})
+		openPRInput := &actions.GithubPROpts{
+			PRAction:       actions.GithubPRAction_NewAppWorkflow,
+			Client:         client,
+			GitRepoOwner:   request.GithubRepoOwner,
+			GitRepoName:    request.GithubRepoName,
+			StackName:      appName,
+			ProjectID:      project.ID,
+			ClusterID:      cluster.ID,
+			ServerURL:      c.Config().ServerConf.ServerURL,
+			DefaultBranch:  request.Branch,
+			SecretName:     secretName,
+			PorterYamlPath: request.PorterYamlPath,
+			Body:           prRequestBody,
+			PRBranch:       "porter-stack",
+		}
+		if request.DeleteWorkflowFilename != "" {
+			openPRInput.PRAction = actions.GithubPRAction_DeleteAppWorkflow
+			openPRInput.WorkflowFileName = request.DeleteWorkflowFilename
+			openPRInput.PRBranch = "porter-stack-delete"
+		}
+		if request.PreviewsWorkflowFilename != "" {
+			openPRInput.PRAction = actions.GithubPRAction_PreviewAppWorkflow
+			openPRInput.WorkflowFileName = request.PreviewsWorkflowFilename
+			openPRInput.PRBranch = "porter-stack-preview"
+		}
+
+		pr, err = actions.OpenGithubPR(openPRInput)
 	}
 
 	if err != nil {

--- a/api/server/handlers/porter_app/validate.go
+++ b/api/server/handlers/porter_app/validate.go
@@ -99,7 +99,7 @@ func (c *ValidatePorterAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	} else {
 		decoded, err := base64.StdEncoding.DecodeString(request.Base64AppProto)
 		if err != nil {
-			err := telemetry.Error(ctx, span, err, "error decoding base  yaml")
+			err := telemetry.Error(ctx, span, err, "error decoding base yaml")
 			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
 			return
 		}

--- a/api/types/stack.go
+++ b/api/types/stack.go
@@ -12,13 +12,14 @@ type ImageInfo struct {
 }
 
 type CreateSecretAndOpenGHPRRequest struct {
-	GithubAppInstallationID int64  `json:"github_app_installation_id" form:"required"`
-	GithubRepoOwner         string `json:"github_repo_owner" form:"required"`
-	GithubRepoName          string `json:"github_repo_name" form:"required"`
-	OpenPr                  bool   `json:"open_pr"`
-	Branch                  string `json:"branch"`
-	PorterYamlPath          string `json:"porter_yaml_path"`
-	DeleteWorkflowFilename  string `json:"delete_workflow_filename"`
+	GithubAppInstallationID  int64  `json:"github_app_installation_id" form:"required"`
+	GithubRepoOwner          string `json:"github_repo_owner" form:"required"`
+	GithubRepoName           string `json:"github_repo_name" form:"required"`
+	OpenPr                   bool   `json:"open_pr"`
+	Branch                   string `json:"branch"`
+	PorterYamlPath           string `json:"porter_yaml_path"`
+	DeleteWorkflowFilename   string `json:"delete_workflow_filename"`
+	PreviewsWorkflowFilename string `json:"previews_workflow_filename"`
 }
 
 type CreateSecretAndOpenGHPRResponse struct {

--- a/dashboard/src/main/home/app-dashboard/new-app-flow/GithubActionModal.tsx
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/GithubActionModal.tsx
@@ -1,6 +1,6 @@
 import { RouteComponentProps, withRouter } from "react-router";
 import styled from "styled-components";
-import React from "react";
+import React, { useMemo } from "react";
 
 import Modal from "components/porter/Modal";
 import Text from "components/porter/Text";
@@ -9,7 +9,7 @@ import ExpandableSection from "components/porter/ExpandableSection";
 import Button from "components/porter/Button";
 import Select from "components/porter/Select";
 import api from "shared/api";
-import { getGithubAction } from "./utils";
+import { getGithubAction, getPreviewGithubAction } from "./utils";
 import YamlEditor from "components/YamlEditor";
 import Error from "components/porter/Error";
 import Checkbox from "components/porter/Checkbox";
@@ -26,7 +26,8 @@ type Props = RouteComponentProps & {
   deployPorterApp?: () => Promise<boolean>;
   deploymentError?: string;
   porterYamlPath?: string;
-}
+  type?: "create" | "preview";
+};
 
 type Choice = "open_pr" | "copy";
 
@@ -42,16 +43,47 @@ const GithubActionModal: React.FC<Props> = ({
   deployPorterApp,
   deploymentError,
   porterYamlPath,
+  type = "create",
   ...props
 }) => {
   const [choice, setChoice] = React.useState<Choice>("open_pr");
   const [loading, setLoading] = React.useState<boolean>(false);
   const [isChecked, setIsChecked] = React.useState<boolean>(false);
 
+  const actionYamlContents = useMemo(() => {
+    if (!projectId || !clusterId || !stackName || !branch || !porterYamlPath) {
+      return "";
+    }
+    if (type === "preview") {
+      return getPreviewGithubAction(
+        projectId,
+        clusterId,
+        stackName,
+        porterYamlPath
+      );
+    }
+
+    return getGithubAction(
+      projectId,
+      clusterId,
+      stackName,
+      branch,
+      porterYamlPath
+    );
+  }, [type]);
+
   const submit = async () => {
-    if (githubAppInstallationID && githubRepoOwner && githubRepoName && branch && stackName && projectId && clusterId) {
+    if (
+      githubAppInstallationID &&
+      githubRepoOwner &&
+      githubRepoName &&
+      branch &&
+      stackName &&
+      projectId &&
+      clusterId
+    ) {
       try {
-        setLoading(true)
+        setLoading(true);
         // this creates the dummy chart
         var success = true;
         if (deployPorterApp) {
@@ -67,8 +99,11 @@ const GithubActionModal: React.FC<Props> = ({
               github_repo_owner: githubRepoOwner,
               github_repo_name: githubRepoName,
               branch,
-              open_pr: (choice === "open_pr" || isChecked),
+              open_pr: choice === "open_pr" || isChecked,
               porter_yaml_path: porterYamlPath,
+              ...(type === "preview" && {
+                previews_workflow_filename: `.github/workflows/porter_preview_${stackName}.yml`,
+              }),
             },
             {
               project_id: projectId,
@@ -85,37 +120,34 @@ const GithubActionModal: React.FC<Props> = ({
           props.history.push(`/apps/${stackName}`);
         }
       } catch (error) {
-        console.log(error)
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     } else {
       console.log("missing information");
     }
-  }
+  };
   return (
     <Modal closeModal={closeModal}>
-      <Text size={16}>
-        Continuous Integration (CI) with GitHub Actions
-      </Text>
+      <Text size={16}>Continuous Integration (CI) with GitHub Actions</Text>
       <Spacer height="15px" />
       <Text color="helper">
-        In order to automatically update your services every time new code is pushed to your GitHub branch, the following file must exist in your GitHub repository:
+        In order to automatically update your services every time new code is
+        pushed to your GitHub branch, the following file must exist in your
+        GitHub repository:
       </Text>
       <Spacer y={0.5} />
       <ExpandableSection
         noWrapper
         expandText="[+] Show code"
         collapseText="[-] Hide code"
-        Header={
-          <ModalHeader>.github/workflows/porter.yml</ModalHeader>
-        }
+        Header={<ModalHeader>.github/workflows/porter.yml</ModalHeader>}
         isInitiallyExpanded
         spaced
-        copy={getGithubAction(projectId, clusterId, stackName, branch, porterYamlPath)}
+        copy={actionYamlContents}
         ExpandedSection={
           <YamlEditor
-            value={getGithubAction(projectId, clusterId, stackName, branch, porterYamlPath)}
+            value={actionYamlContents}
             readOnly={true}
             height="300px"
           />
@@ -123,15 +155,25 @@ const GithubActionModal: React.FC<Props> = ({
       />
       <Spacer y={1} />
       <Text color="helper">
-        Porter can open a PR for you to approve and merge this file into your repository, or you can add it yourself. If you allow Porter to open a PR, you will be redirected to the PR in a new tab after submitting below.
+        Porter can open a PR for you to approve and merge this file into your
+        repository, or you can add it yourself. If you allow Porter to open a
+        PR, you will be redirected to the PR in a new tab after submitting
+        below.
       </Text>
       <Spacer y={1} />
       {deployPorterApp ? (
         <>
           <Select
             options={[
-              { label: "I authorize Porter to open a PR on my behalf (recommended)", value: "open_pr" },
-              { label: "I will copy the file into my repository myself", value: "copy" },
+              {
+                label:
+                  "I authorize Porter to open a PR on my behalf (recommended)",
+                value: "open_pr",
+              },
+              {
+                label: "I will copy the file into my repository myself",
+                value: "copy",
+              },
             ]}
             setValue={(x: string) => setChoice(x as Choice)}
             width="100%"
@@ -141,9 +183,13 @@ const GithubActionModal: React.FC<Props> = ({
             onClick={submit}
             width={"110px"}
             loadingText={"Submitting..."}
-            status={loading ? "loading" : deploymentError ? (
-              <Error message={deploymentError} />
-            ) : undefined}
+            status={
+              loading ? (
+                "loading"
+              ) : deploymentError ? (
+                <Error message={deploymentError} />
+              ) : undefined
+            }
           >
             Deploy app
           </Button>
@@ -154,26 +200,28 @@ const GithubActionModal: React.FC<Props> = ({
             checked={isChecked}
             toggleChecked={() => setIsChecked(!isChecked)}
           >
-            <Text>
-              I authorize Porter to open a PR on my behalf
-            </Text>
+            <Text>I authorize Porter to open a PR on my behalf</Text>
           </Checkbox>
           <Spacer y={1} />
           <Button
             disabled={!isChecked}
             onClick={submit}
             loadingText={"Submitting..."}
-            status={loading ? "loading" : deploymentError ? (
-              <Error message={deploymentError} />
-            ) : undefined}
+            status={
+              loading ? (
+                "loading"
+              ) : deploymentError ? (
+                <Error message={deploymentError} />
+              ) : undefined
+            }
           >
             Open a PR for me
           </Button>
         </>
       )}
     </Modal>
-  )
-}
+  );
+};
 
 export default withRouter(GithubActionModal);
 

--- a/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
@@ -61,11 +61,12 @@ export const getPreviewGithubAction = (
 ) => {
   return `on:
   pull_request:
+    branches:
+    - '!porter-**'
     types:
     - opened
     - synchronize
-    branches-ignore:
-    - porter-*
+    
 name: Deploy preview environment
 jobs:
   porter-deploy:

--- a/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
@@ -2,7 +2,12 @@ export const overrideObjectValues = (obj1: any, obj2: any) => {
   // Iterate over the keys in obj2
   for (const key in obj2) {
     // Check if the key exists in obj1 and if its value is an object
-    if (key in obj1 && obj1[key] !== null && typeof obj1[key] === 'object' && typeof obj2[key] === 'object') {
+    if (
+      key in obj1 &&
+      obj1[key] !== null &&
+      typeof obj1[key] === "object" &&
+      typeof obj2[key] === "object"
+    ) {
       obj1[key] = overrideObjectValues(obj1[key], obj2[key]);
     } else {
       obj1[key] = obj2[key];
@@ -13,7 +18,13 @@ export const overrideObjectValues = (obj1: any, obj2: any) => {
   return obj1;
 };
 
-export const getGithubAction = (projectID: number, clusterId: number, stackName: string, branchName: string, porterYamlPath: string = "porter.yaml") => {
+export const getGithubAction = (
+  projectID: number,
+  clusterId: number,
+  stackName: string,
+  branchName: string,
+  porterYamlPath: string = "porter.yaml"
+) => {
   return `on:
   push:
     branches:
@@ -40,4 +51,41 @@ jobs:
         PORTER_STACK_NAME: ${stackName}
         PORTER_TAG: \${{ steps.vars.outputs.sha_short }}
         PORTER_TOKEN: \${{ secrets.PORTER_STACK_${projectID}_${clusterId} }}`;
-}
+};
+
+export const getPreviewGithubAction = (
+  projectID: number,
+  clusterId: number,
+  stackName: string,
+  porterYamlPath: string = "porter.yaml"
+) => {
+  return `on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    branches-ignore:
+    - porter-*
+name: Deploy preview environment
+jobs:
+  porter-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Set Github tag
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Build and deploy preview environment
+      timeout-minutes: 30
+      uses: porter-dev/porter-cli-action@v0.1.0
+      with:
+        command: apply -f ${porterYamlPath} --preview
+      env:
+        PORTER_CLUSTER: ${clusterId}
+        PORTER_HOST: https://dashboard.getporter.dev
+        PORTER_PROJECT: ${projectID}
+        PORTER_STACK_NAME: ${stackName}
+        PORTER_TAG: \${{ steps.vars.outputs.sha_short }}
+        PORTER_TOKEN: \${{ secrets.PORTER_STACK_${projectID}_${clusterId} }}`;
+};

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -948,6 +948,20 @@ const createApp = baseApi<
   return `/api/projects/${pathParams.project_id}/clusters/${pathParams.cluster_id}/apps/create`;
 });
 
+const createAppTemplate = baseApi<
+{
+  b64_app_proto: string;
+  variables: Record<string, string>
+  secrets: Record<string, string>
+},
+{
+  project_id: number;
+  cluster_id: number;
+  porter_app_name: string;
+}>("POST", ({ project_id, cluster_id, porter_app_name}) => {
+  return `/api/projects/${project_id}/clusters/${cluster_id}/apps/${porter_app_name}/templates`;
+})
+
 const applyApp = baseApi<
   {
     deployment_target_id: string;
@@ -3013,6 +3027,7 @@ const createSecretAndOpenGitHubPullRequest = baseApi<
     open_pr?: boolean;
     porter_yaml_path?: string;
     delete_workflow_filename?: string;
+    previews_workflow_filename?: string;
   },
   {
     project_id: number;
@@ -3156,6 +3171,7 @@ export default {
   getBranchHead,
   validatePorterApp,
   createApp,
+  createAppTemplate,
   applyApp,
   getAttachedEnvGroups,
   getLatestRevision,

--- a/internal/integrations/ci/actions/actions.go
+++ b/internal/integrations/ci/actions/actions.go
@@ -224,6 +224,17 @@ type GithubActionYAMLOnPush struct {
 	Push GithubActionYAMLOnPushBranches `yaml:"push,omitempty"`
 }
 
+// GithubActionYAMLOnPullRequest is a struct that represents the "on" field of a Github Action YAML file for pull request events
+type GithubActionYAMLOnPullRequest struct {
+	PullRequest GithubActionYAMLOnPullRequestTypes `yaml:"pull_request,omitempty"`
+}
+
+// GithubActionYAMLOnPullRequestTypes is a struct that represents the "types" field of a Github Action YAML file for pull request events
+type GithubActionYAMLOnPullRequestTypes struct {
+	Types []string `yaml:"types,omitempty"`
+	BranchesIgnore []string `yaml:"branches-ignore,omitempty"`
+}
+
 type GithubActionYAMLJob struct {
 	RunsOn      string                 `yaml:"runs-on,omitempty"`
 	Steps       []GithubActionYAMLStep `yaml:"steps,omitempty"`

--- a/internal/integrations/ci/actions/actions.go
+++ b/internal/integrations/ci/actions/actions.go
@@ -231,8 +231,8 @@ type GithubActionYAMLOnPullRequest struct {
 
 // GithubActionYAMLOnPullRequestTypes is a struct that represents the "types" field of a Github Action YAML file for pull request events
 type GithubActionYAMLOnPullRequestTypes struct {
-	Types []string `yaml:"types,omitempty"`
-	BranchesIgnore []string `yaml:"branches-ignore,omitempty"`
+	Branches []string `yaml:"branches,omitempty"`
+	Types    []string `yaml:"types,omitempty"`
 }
 
 type GithubActionYAMLJob struct {

--- a/internal/integrations/ci/actions/steps.go
+++ b/internal/integrations/ci/actions/steps.go
@@ -74,6 +74,7 @@ func getCreatePreviewEnvStep(
 func getDeployStackStep(
 	serverURL, porterTokenSecretName, stackName, actionVersion, porterYamlPath string,
 	projectID, clusterID uint,
+	preview bool,
 ) GithubActionYAMLStep {
 	var path string
 	if porterYamlPath != "" {
@@ -81,11 +82,22 @@ func getDeployStackStep(
 	} else {
 		path = "porter.yaml"
 	}
+
+	command := fmt.Sprintf("apply -f %s", path)
+	if preview {
+		command = fmt.Sprintf("%s --preview", command)
+	}
+
+	name := "Deploy stack"
+	if preview {
+		name = "Build and deploy preview environment"
+	}
+
 	return GithubActionYAMLStep{
-		Name: "Deploy stack",
+		Name: name,
 		Uses: fmt.Sprintf("%s@%s", cliActionName, actionVersion),
 		With: map[string]string{
-			"command": fmt.Sprintf("apply -f %s", path),
+			"command": command,
 		},
 		Env: map[string]string{
 			"PORTER_CLUSTER":    fmt.Sprintf("%d", clusterID),

--- a/internal/kubernetes/environment_groups/list.go
+++ b/internal/kubernetes/environment_groups/list.go
@@ -41,6 +41,8 @@ type EnvironmentGroup struct {
 	SecretVariables map[string]string `json:"secret_variables,omitempty"`
 	// CreatedAt is only used for display purposes and is in UTC Unix time
 	CreatedAtUTC time.Time `json:"created_at,omitempty"`
+	// DefaultAppEnvironment is a boolean value that determines whether or not this environment group is the default environment group for an app
+	DefaultAppEnvironment bool `json:"default_app_environment"`
 }
 
 type environmentGroupOptions struct {
@@ -154,6 +156,7 @@ func listEnvironmentGroups(ctx context.Context, a *kubernetes.Agent, listOpts ..
 			Variables:       cm.Data,
 			SecretVariables: envGroupSet[cm.Name].SecretVariables,
 			CreatedAtUTC:    cm.CreationTimestamp.Time.UTC(),
+			DefaultAppEnvironment: cm.Labels[LabelKey_DefaultAppEnvironment] == "true",
 		}
 	}
 
@@ -192,6 +195,7 @@ func listEnvironmentGroups(ctx context.Context, a *kubernetes.Agent, listOpts ..
 			SecretVariables: stringSecret,
 			Variables:       envGroupSet[secret.Name].Variables,
 			CreatedAtUTC:    secret.CreationTimestamp.Time.UTC(),
+			DefaultAppEnvironment: secret.Labels[LabelKey_DefaultAppEnvironment] == "true",
 		}
 	}
 

--- a/internal/repository/gorm/app_template.go
+++ b/internal/repository/gorm/app_template.go
@@ -57,7 +57,7 @@ func (repo *AppTemplateRepository) CreateAppTemplate(appTemplate *models.AppTemp
 		appTemplate.UpdatedAt = time.Now().UTC()
 	}
 
-	if err := repo.db.Create(appTemplate).Error; err != nil {
+	if err := repo.db.Save(appTemplate).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## POR-1435
## What does this PR do?

- Commit workflow file for preview envs to porter-preview-{app_name}.yml
- Save app template which will be used on initial deploy to a new deployment target
- Filter out any default app env groups when creating the app template (they aren't needed)
