### PR TITLE
add defaults to all form items

### DIFF
--- a/dashboard/src/lib/porter-apps/values.ts
+++ b/dashboard/src/lib/porter-apps/values.ts
@@ -120,22 +120,22 @@ export function deserializeAutoscaling({
       enabled: ServiceField.boolean(autoscaling.enabled, override?.enabled),
       minInstances: autoscaling.minInstances
         ? ServiceField.number(autoscaling.minInstances, override?.minInstances)
-        : undefined,
+        : ServiceField.number(1, undefined),
       maxInstances: autoscaling.maxInstances
         ? ServiceField.number(autoscaling.maxInstances, override?.maxInstances)
-        : undefined,
+        : ServiceField.number(10, undefined),
       cpuThresholdPercent: autoscaling.cpuThresholdPercent
         ? ServiceField.number(
             autoscaling.cpuThresholdPercent,
             override?.cpuThresholdPercent
           )
-        : undefined,
+        : ServiceField.number(50, undefined),
       memoryThresholdPercent: autoscaling.memoryThresholdPercent
         ? ServiceField.number(
             autoscaling.memoryThresholdPercent,
             override?.memoryThresholdPercent
           )
-        : undefined,
+        : ServiceField.number(50, undefined),
     }
   );
 }
@@ -175,7 +175,7 @@ export function deserializeHealthCheck({
       enabled: ServiceField.boolean(health.enabled, override?.enabled),
       httpPath: health.httpPath
         ? ServiceField.string(health.httpPath, override?.httpPath)
-        : undefined,
+        :  ServiceField.string("", undefined),
     }
   );
 }


### PR DESCRIPTION
We need defaults for all values: the frontend will try to read the values of fields even if they are undefined. 

Currently, we don't run into this issue because all initial app creations fill default values during the hydration phase. However, the seeding script does not, and rather than fixing that side of things, I figured we should properly support handling undefined.