### PR TITLE
add back variable

### DIFF
--- a/dashboard/src/main/home/app-dashboard/new-app-flow/tabs/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/tabs/utils.ts
@@ -85,3 +85,4 @@ export const AWS_INSTANCE_LIMITS: InstanceTypes = {
 
 
 export const UPPER_BOUND_SMART = .5;
+export const RESOURCE_ALLOCATION_RAM = 1;


### PR DESCRIPTION
deleted a const that was used in v1 in https://github.com/porter-dev/porter/commit/531a2504c7f0ef160cf877fe488289d0980049a6, adding it back here