### PR TITLE
fix: do not show the ack datastore charts in the addons ui 

### DIFF
--- a/dashboard/src/main/home/add-on-dashboard/NewAddOnFlow.tsx
+++ b/dashboard/src/main/home/add-on-dashboard/NewAddOnFlow.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 const HIDDEN_CHARTS = [
   "agent",
-  "elasticache-chart"
+  "elasticache-chart",
   "loki",
   "porter-agent",
   "rds-chart",

--- a/dashboard/src/main/home/add-on-dashboard/NewAddOnFlow.tsx
+++ b/dashboard/src/main/home/add-on-dashboard/NewAddOnFlow.tsx
@@ -26,7 +26,13 @@ import Select from "components/porter/Select";
 type Props = {
 };
 
-const HIDDEN_CHARTS = ["porter-agent", "loki", "agent"];
+const HIDDEN_CHARTS = [
+  "agent",
+  "elasticache-chart"
+  "loki",
+  "porter-agent",
+  "rds-chart",
+];
 
 //For Charts that don't exist locally we need to add them in manually
 const TAG_MAPPING = {


### PR DESCRIPTION
## What does this PR do?

Currently, these charts are shown to any system super-admins. These charts are system-level charts that shouldn't be shown in the UI at all, regardless of whether the user is on AWS or not.
