### PR TITLE
Forbid users from using old get pods endpoint

### DIFF
--- a/api/server/handlers/release/get_all_pods.go
+++ b/api/server/handlers/release/get_all_pods.go
@@ -46,7 +46,7 @@ func (c *GetAllPodsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if project.GetFeatureFlag(models.ValidateApplyV2, c.Config().LaunchDarklyClient) {
 		err := telemetry.Error(ctx, span, nil, "unable to get pods: please upgrade the CLI and try again")
-		c.HandleAPIError(w, r, apierrors.NewErrForbidden(err))
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusForbidden))
 		return
 	}
 

--- a/api/server/handlers/release/get_all_pods.go
+++ b/api/server/handlers/release/get_all_pods.go
@@ -42,6 +42,13 @@ func (c *GetAllPodsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	helmRelease, _ := ctx.Value(types.ReleaseScope).(*release.Release)
 	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+
+	if project.GetFeatureFlag(models.ValidateApplyV2, c.Config().LaunchDarklyClient) {
+		err := telemetry.Error(ctx, span, nil, "unable to get pods: please upgrade the CLI and try again")
+		c.HandleAPIError(w, r, apierrors.NewErrForbidden(err))
+		return
+	}
 
 	agent, err := c.GetAgent(r, cluster, "")
 	if err != nil {


### PR DESCRIPTION
The problem is that users with outdated CLIs will not hit the branching logic that separates app v1 from app v2 users.

I've checked where these endpoints are called and ensured that if they were called from a v2 project setting, they must have been called from the CLI. I would have liked to add the "please upgrade CLI" error message to CLI code itself, but unfortunately they would have to upgrade the CLI anyway to see it.