### PR TITLE
move gh webhook to standalone table

### DIFF
--- a/internal/models/github_webhook.go
+++ b/internal/models/github_webhook.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type GithhubWebhook struct {
+	gorm.Model
+
+	// ID is a UUID for the Revision
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+
+	// ClusterID is the ID of the cluster that the webhook is associated with.
+	ClusterID int
+
+	// ProjectID is the ID of the project that the webhook is associated with.
+	ProjectID int
+
+	// PorterAppID is the ID of the PorterApp that the webhook is associated with.
+	PorterAppID int
+
+	// GithubWebhookID is the ID of the webhook provided by Github.
+	GithubWebhookID int64
+}

--- a/internal/models/github_webhook.go
+++ b/internal/models/github_webhook.go
@@ -5,10 +5,11 @@ import (
 	"gorm.io/gorm"
 )
 
-type GithhubWebhook struct {
+// GithubWebhook represents a webhook that is created on Github which can trigger actions in Porter for the specified project/cluster
+type GithubWebhook struct {
 	gorm.Model
 
-	// ID is a UUID for the Revision
+	// ID is a UUID for the webhook
 	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
 
 	// ClusterID is the ID of the cluster that the webhook is associated with.

--- a/internal/models/porter_app.go
+++ b/internal/models/porter_app.go
@@ -18,10 +18,9 @@ type PorterApp struct {
 	ImageRepoURI string
 
 	// Git repo information (optional)
-	GitRepoID       uint
-	RepoName        string
-	GitBranch       string
-	GithubWebhookID int64 `gorm:"-"` // do not use in read/writes. this is temporary until migrations are run
+	GitRepoID uint
+	RepoName  string
+	GitBranch string
 
 	BuildContext   string
 	Builder        string

--- a/internal/repository/gorm/migrate.go
+++ b/internal/repository/gorm/migrate.go
@@ -65,7 +65,7 @@ func AutoMigrate(db *gorm.DB, debug bool) error {
 		&models.AppRevision{},
 		&models.DeploymentTarget{},
 		&models.AppTemplate{},
-		&models.GithhubWebhook{},
+		&models.GithubWebhook{},
 		&ints.KubeIntegration{},
 		&ints.BasicIntegration{},
 		&ints.OIDCIntegration{},

--- a/internal/repository/gorm/migrate.go
+++ b/internal/repository/gorm/migrate.go
@@ -65,6 +65,7 @@ func AutoMigrate(db *gorm.DB, debug bool) error {
 		&models.AppRevision{},
 		&models.DeploymentTarget{},
 		&models.AppTemplate{},
+		&models.GithhubWebhook{},
 		&ints.KubeIntegration{},
 		&ints.BasicIntegration{},
 		&ints.OIDCIntegration{},


### PR DESCRIPTION
## What does this PR do?

- Avoiding nullable field in model potentially causing issues
- Instead, github webhook IDs will be stored individually and can take actions upon the project / cluster / porter app that they are associated with
