### PR TITLE
POR-1887 filter empty secrets

### DIFF
--- a/api/server/handlers/porter_app/update_app_environment_group.go
+++ b/api/server/handlers/porter_app/update_app_environment_group.go
@@ -286,10 +286,14 @@ func (c *UpdateAppEnvironmentHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	}
 
 	for key, value := range request.Variables {
-		variables[key] = value
+		if len(key) > 0 && len(value) > 0 {
+			variables[key] = value
+		}
 	}
 	for key, value := range request.Secrets {
-		secrets[key] = value
+		if len(key) > 0 && len(value) > 0 {
+			secrets[key] = value
+		}
 	}
 
 	envGroup := environment_groups.EnvironmentGroup{

--- a/dashboard/src/lib/hooks/useAppValidation.ts
+++ b/dashboard/src/lib/hooks/useAppValidation.ts
@@ -75,13 +75,16 @@ export const useAppValidation = ({
 
       const { env } = data.app;
       const variables = env
-        .filter((e) => !e.hidden && !e.deleted)
+        .filter(
+          (e) =>
+            !e.hidden && !e.deleted && e.value.length > 0 && e.key.length > 0
+        )
         .reduce((acc: Record<string, string>, item) => {
           acc[item.key] = item.value;
           return acc;
         }, {});
       const secrets = env
-        .filter((e) => !e.deleted)
+        .filter((e) => !e.deleted && e.value.length > 0 && e.key.length > 0)
         .reduce((acc: Record<string, string>, item) => {
           if (item.hidden) {
             acc[item.key] = item.value;


### PR DESCRIPTION
## POR-1887
## What does this PR do?

 - Remove any secrets with empty keys or values
 - Added to avoid K8s level error concerning empty string in config maps
 - 
