### PR TITLE
add basic app rollback command

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -551,3 +551,29 @@ func (c *Client) UpdateImage(
 
 	return resp, err
 }
+
+// ListAppRevisions lists the last ten app revisions for a given app
+func (c *Client) ListAppRevisions(
+	ctx context.Context,
+	projectID, clusterID uint,
+	appName string,
+	deploymentTargetID string,
+) (*porter_app.ListAppRevisionsResponse, error) {
+	resp := &porter_app.ListAppRevisionsResponse{}
+
+	req := &porter_app.ListAppRevisionsRequest{
+		DeploymentTargetID: deploymentTargetID,
+	}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/%s/revisions",
+			projectID, clusterID,
+			appName,
+		),
+		req,
+		resp,
+	)
+
+	return resp, err
+}

--- a/cli/cmd/commands/app.go
+++ b/cli/cmd/commands/app.go
@@ -108,6 +108,20 @@ func registerCommand_App(cliConf config.CLIConfig) *cobra.Command {
 	)
 	appCmd.AddCommand(appUpdateTagCmd)
 
+	// appRollback represents the "porter app rollback" subcommand
+	appRollbackCmd := &cobra.Command{
+		Use:   "rollback [application]",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Rolls back an application to the last successful revision.",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := checkLoginAndRunWithConfig(cmd, cliConf, args, appRollback)
+			if err != nil {
+				os.Exit(1)
+			}
+		},
+	}
+	appCmd.AddCommand(appRollbackCmd)
+
 	return appCmd
 }
 
@@ -158,6 +172,33 @@ func appRunFlags(appRunCmd *cobra.Command) {
 		"",
 		"name of the container inside pod to run the command in",
 	)
+}
+
+func appRollback(ctx context.Context, _ *types.GetAuthenticatedUserResponse, client api.Client, cliConfig config.CLIConfig, _ config.FeatureFlags, _ *cobra.Command, args []string) error {
+	project, err := client.GetProject(ctx, cliConfig.Project)
+	if err != nil {
+		return fmt.Errorf("could not retrieve project from Porter API. Please contact support@porter.run")
+	}
+
+	if !project.ValidateApplyV2 {
+		return fmt.Errorf("rollback command is not enabled for this project")
+	}
+
+	appName := args[0]
+	if appName == "" {
+		return fmt.Errorf("app name must be specified")
+	}
+
+	err = v2.Rollback(ctx, v2.RollbackInput{
+		CLIConfig: cliConfig,
+		Client:    client,
+		AppName:   appName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to rollback app: %w", err)
+	}
+
+	return nil
 }
 
 func appRun(ctx context.Context, _ *types.GetAuthenticatedUserResponse, client api.Client, cliConfig config.CLIConfig, _ config.FeatureFlags, _ *cobra.Command, args []string) error {

--- a/cli/cmd/commands/app.go
+++ b/cli/cmd/commands/app.go
@@ -113,11 +113,8 @@ func registerCommand_App(cliConf config.CLIConfig) *cobra.Command {
 		Use:   "rollback [application]",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Rolls back an application to the last successful revision.",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := checkLoginAndRunWithConfig(cmd, cliConf, args, appRollback)
-			if err != nil {
-				os.Exit(1)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return checkLoginAndRunWithConfig(cmd, cliConf, args, appRollback)
 		},
 	}
 	appCmd.AddCommand(appRollbackCmd)

--- a/cli/cmd/v2/rollback.go
+++ b/cli/cmd/v2/rollback.go
@@ -47,8 +47,11 @@ func Rollback(ctx context.Context, inp RollbackInput) error {
 			break
 		}
 	}
+	if rollbackTarget.ID == "" {
+		return fmt.Errorf("no previous successful revisions found for app %s", inp.AppName)
+	}
 
-	color.New(color.FgGreen).Printf("Rolling back to revision %d...\n", rollbackTarget.RevisionNumber)
+	color.New(color.FgGreen).Printf("Rolling back to revision %d...\n", rollbackTarget.RevisionNumber) // nolint:errcheck,gosec
 
 	applyResp, err := inp.Client.ApplyPorterApp(ctx, inp.CLIConfig.Project, inp.CLIConfig.Cluster, rollbackTarget.B64AppProto, deploymentTargetID, "", false)
 	if err != nil {
@@ -59,6 +62,6 @@ func Rollback(ctx context.Context, inp RollbackInput) error {
 		return fmt.Errorf("unexpected CLI action: %s", applyResp.CLIAction)
 	}
 
-	color.New(color.FgGreen).Printf("Successfully rolled back to revision %d\n", rollbackTarget.RevisionNumber)
+	color.New(color.FgGreen).Printf("Successfully rolled back to revision %d\n", rollbackTarget.RevisionNumber) // nolint:errcheck,gosec
 	return nil
 }

--- a/cli/cmd/v2/rollback.go
+++ b/cli/cmd/v2/rollback.go
@@ -1,0 +1,64 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fatih/color"
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/cli/cmd/config"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/porter_app"
+)
+
+// RollbackInput is the input for the Rollback function
+type RollbackInput struct {
+	// CLIConfig is the CLI configuration
+	CLIConfig config.CLIConfig
+	// Client is the Porter API client
+	Client api.Client
+	// AppName is the name of the app to rollback
+	AppName string
+}
+
+// Rollback deploys the previous successful revision of an app
+func Rollback(ctx context.Context, inp RollbackInput) error {
+	targetResp, err := inp.Client.DefaultDeploymentTarget(ctx, inp.CLIConfig.Project, inp.CLIConfig.Cluster)
+	if err != nil {
+		return fmt.Errorf("error calling default deployment target endpoint: %w", err)
+	}
+	deploymentTargetID := targetResp.DeploymentTargetID
+
+	listResp, err := inp.Client.ListAppRevisions(ctx, inp.CLIConfig.Project, inp.CLIConfig.Cluster, inp.AppName, deploymentTargetID)
+	if err != nil {
+		return fmt.Errorf("error calling current app revision endpoint: %w", err)
+	}
+	if len(listResp.AppRevisions) <= 1 {
+		return fmt.Errorf("no previous successful revisions found for app %s", inp.AppName)
+	}
+
+	revisions := listResp.AppRevisions
+	var rollbackTarget porter_app.Revision
+
+	for _, rev := range revisions[1:] {
+		if rev.RevisionNumber != 0 && rev.Status == models.AppRevisionStatus_Deployed {
+			rollbackTarget = rev
+			break
+		}
+	}
+
+	color.New(color.FgGreen).Printf("Rolling back to revision %d...\n", rollbackTarget.RevisionNumber)
+
+	applyResp, err := inp.Client.ApplyPorterApp(ctx, inp.CLIConfig.Project, inp.CLIConfig.Cluster, rollbackTarget.B64AppProto, deploymentTargetID, "", false)
+	if err != nil {
+		return fmt.Errorf("error calling apply endpoint: %w", err)
+	}
+
+	if applyResp.CLIAction != porterv1.EnumCLIAction_ENUM_CLI_ACTION_NONE {
+		return fmt.Errorf("unexpected CLI action: %s", applyResp.CLIAction)
+	}
+
+	color.New(color.FgGreen).Printf("Successfully rolled back to revision %d\n", rollbackTarget.RevisionNumber)
+	return nil
+}


### PR DESCRIPTION
## What does this PR do?

- Deploys the latest previous successful revision of an app
- Basic implementation to unblock custom workflows, but in the future the explicit version number could be included