### PR TITLE
POR-1874 cancel pending workflows when pr is closed or merged

### DIFF
--- a/api/server/handlers/webhook/app_v2_github.go
+++ b/api/server/handlers/webhook/app_v2_github.go
@@ -100,7 +100,7 @@ func (c *GithubWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		telemetry.AttributeKV{Key: "project-id", Value: webhook.ProjectID},
 	)
 
-	porterApp, err := c.Repo().PorterApp().ReadPorterApp(ctx, uint(webhook.PorterAppID))
+	porterApp, err := c.Repo().PorterApp().ReadPorterAppByID(ctx, uint(webhook.PorterAppID))
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "error getting porter app")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))

--- a/internal/repository/gorm/porter_app.go
+++ b/internal/repository/gorm/porter_app.go
@@ -36,7 +36,8 @@ func (repo *PorterAppRepository) ListPorterAppByClusterID(clusterID uint) ([]*mo
 	return apps, nil
 }
 
-func (repo *PorterAppRepository) ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error) {
+// ReadPorterAppByID returns a PorterApp by its ID
+func (repo *PorterAppRepository) ReadPorterAppByID(ctx context.Context, id uint) (*models.PorterApp, error) {
 	app := &models.PorterApp{}
 
 	if err := repo.db.Where("id = ?", id).Limit(1).Find(&app).Error; err != nil {

--- a/internal/repository/gorm/porter_app.go
+++ b/internal/repository/gorm/porter_app.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/porter-dev/porter/internal/models"
 	"github.com/porter-dev/porter/internal/repository"
 	"gorm.io/gorm"
@@ -32,6 +34,16 @@ func (repo *PorterAppRepository) ListPorterAppByClusterID(clusterID uint) ([]*mo
 	}
 
 	return apps, nil
+}
+
+func (repo *PorterAppRepository) ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error) {
+	app := &models.PorterApp{}
+
+	if err := repo.db.Where("id = ?", id).Limit(1).Find(&app).Error; err != nil {
+		return nil, err
+	}
+
+	return app, nil
 }
 
 func (repo *PorterAppRepository) ReadPorterAppByName(clusterID uint, name string) (*models.PorterApp, error) {

--- a/internal/repository/porter_app.go
+++ b/internal/repository/porter_app.go
@@ -1,11 +1,14 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/porter-dev/porter/internal/models"
 )
 
 // PorterAppRepository represents the set of queries on the PorterApp model
 type PorterAppRepository interface {
+	ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error)
 	ReadPorterAppByName(clusterID uint, name string) (*models.PorterApp, error)
 	ReadPorterAppsByProjectIDAndName(projectID uint, name string) ([]*models.PorterApp, error)
 	CreatePorterApp(app *models.PorterApp) (*models.PorterApp, error)

--- a/internal/repository/porter_app.go
+++ b/internal/repository/porter_app.go
@@ -8,7 +8,7 @@ import (
 
 // PorterAppRepository represents the set of queries on the PorterApp model
 type PorterAppRepository interface {
-	ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error)
+	ReadPorterAppByID(ctx context.Context, id uint) (*models.PorterApp, error)
 	ReadPorterAppByName(clusterID uint, name string) (*models.PorterApp, error)
 	ReadPorterAppsByProjectIDAndName(projectID uint, name string) ([]*models.PorterApp, error)
 	CreatePorterApp(app *models.PorterApp) (*models.PorterApp, error)

--- a/internal/repository/test/porter_app.go
+++ b/internal/repository/test/porter_app.go
@@ -44,6 +44,7 @@ func (repo *PorterAppRepository) DeletePorterApp(app *models.PorterApp) (*models
 	return nil, errors.New("cannot write database")
 }
 
-func (repo *PorterAppRepository) ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error) {
+// ReadPorterAppByID is a test method that is not implemented
+func (repo *PorterAppRepository) ReadPorterAppByID(ctx context.Context, id uint) (*models.PorterApp, error) {
 	return nil, errors.New("cannot read database")
 }

--- a/internal/repository/test/porter_app.go
+++ b/internal/repository/test/porter_app.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -41,4 +42,8 @@ func (repo *PorterAppRepository) ListPorterAppByClusterID(clusterID uint) ([]*mo
 
 func (repo *PorterAppRepository) DeletePorterApp(app *models.PorterApp) (*models.PorterApp, error) {
 	return nil, errors.New("cannot write database")
+}
+
+func (repo *PorterAppRepository) ReadPorterApp(ctx context.Context, id uint) (*models.PorterApp, error) {
+	return nil, errors.New("cannot read database")
 }


### PR DESCRIPTION
## POR-1874
## What does this PR do?

- If someone were to quickly close a PR or merged before a preview deploy finished, currently we'd continue to build and create a new revision
- This is also error prone as we delete the deployment target / a new deployment target will potentially be created, or applying the new revision will just error out
