### PR TITLE
fix throughput query: check for exported_namespace and namespace as the namespace label

### DIFF
--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -275,7 +275,13 @@ func QueryPrometheus(
 }
 
 func getNginxStatusQuery(opts *QueryOpts, selectionRegex string) (string, error) {
-	query := fmt.Sprintf(`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{exported_namespace=~"%s",ingress="%s",service="%s"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`, opts.Namespace, selectionRegex, opts.Name)
+	var queries []string
+
+	namespaceLabels := []string{"exported_namespace", "namespace"}
+	for _, namespaceLabel := range namespaceLabels {
+		queries = append(queries, fmt.Sprintf(`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{%s=~"%s",ingress="%s",service="%s"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`, namespaceLabel, opts.Namespace, selectionRegex, opts.Name)
+	}
+	query := strings.Join(queries, " or ")
 	return query, nil
 }
 

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -279,7 +279,7 @@ func getNginxStatusQuery(opts *QueryOpts, selectionRegex string) (string, error)
 
 	namespaceLabels := []string{"exported_namespace", "namespace"}
 	for _, namespaceLabel := range namespaceLabels {
-		queries = append(queries, fmt.Sprintf(`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{%s=~"%s",ingress="%s",service="%s"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`, namespaceLabel, opts.Namespace, selectionRegex, opts.Name)
+		queries = append(queries, fmt.Sprintf(`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{%s=~"%s",ingress="%s",service="%s"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`, namespaceLabel, opts.Namespace, selectionRegex, opts.Name))
 	}
 	query := strings.Join(queries, " or ")
 	return query, nil

--- a/internal/kubernetes/prometheus/metrics_test.go
+++ b/internal/kubernetes/prometheus/metrics_test.go
@@ -16,7 +16,7 @@ func Test_getNginxStatusQuery(t *testing.T) {
 		err   error
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		input    input
 		expected struct {
@@ -34,7 +34,7 @@ func Test_getNginxStatusQuery(t *testing.T) {
 				"process-app-web",
 			},
 			output{
-				`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{exported_namespace=~"app-namespace",ingress="process-app-web",service="process-app-web"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`,
+				`round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{exported_namespace=~"app-namespace",ingress="process-app-web",service="process-app-web"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001) or round(sum by (status_code, ingress)(label_replace(increase(nginx_ingress_controller_requests{namespace=~"app-namespace",ingress="process-app-web",service="process-app-web"}[2m]), "status_code", "${1}xx", "status", "(.)..")), 0.001)`,
 				nil,
 			},
 		},


### PR DESCRIPTION
This should fix the issue with the throughput graph.  Looks like it is not a v2 issue, but a new prometheus chart issue (possibly rolled out at the same time as v2).