### PR TITLE
[POR-1911] misc log refactors in v2

### DIFF
--- a/api/server/handlers/porter_app/create_and_update_events.go
+++ b/api/server/handlers/porter_app/create_and_update_events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/porter-dev/porter/api/server/authz"
@@ -468,6 +469,7 @@ func (p *CreateUpdatePorterAppEventHandler) updateDeployEvent(ctx context.Contex
 			}
 		}
 		if allServicesDone {
+			matchEvent.Metadata["end_time"] = time.Now().UTC()
 			if anyServicesFailed {
 				matchEvent.Status = string(types.PorterAppEventStatus_Failed)
 			} else {

--- a/dashboard/src/components/LogQueryModeSelectionToggle.tsx
+++ b/dashboard/src/components/LogQueryModeSelectionToggle.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 interface LogQueryModeSelectionToggleProps {
   selectedDate?: Date;
   setSelectedDate: (date?: Date) => void;
-  resetSearch: () => void;
 }
 
 const LogQueryModeSelectionToggle = (
@@ -25,11 +24,10 @@ const LogQueryModeSelectionToggle = (
         <ToggleOption
           onClick={() => {
             props.setSelectedDate(undefined);
-            props.resetSearch();
           }}
           selected={!props.selectedDate}
         >
-          <Dot selected={!props.selectedDate} />
+          <StatusDot selected={!props.selectedDate} />
           Live
         </ToggleOption>
         <ToggleOption
@@ -65,7 +63,7 @@ const ToggleOption = styled.div<{ selected: boolean; nudgeLeft?: boolean }>`
   :hover {
     border: 1px solid #7a7b80;
     z-index: 2;
-  }
+  };
 `;
 
 const ToggleButton = styled.div`
@@ -85,14 +83,30 @@ const TimeIcon = styled.img<{ selected?: boolean }>`
   opacity: ${(props) => (props.selected ? "" : "50%")};
 `;
 
-const Dot = styled.div<{ selected?: boolean }>`
-  display: inline-black;
+const StatusDot = styled.div<{ selected?: boolean }>`
   width: 8px;
   height: 8px;
   margin-right: 9px;
   border-radius: 20px;
   background: ${(props) => (props.selected ? "#ed5f85" : "#ffffff22")};
-  border: 0px;
-  outline: none;
-  box-shadow: ${(props) => (props.selected ? "0px 0px 5px 1px #ed5f85" : "")};
+
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 1);
+  transform: scale(1);
+  animation: pulse 2s infinite;
+  @keyframes pulse {
+    0% {
+      transform: scale(0.95);
+      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.9);
+    }
+
+    70% {
+      transform: scale(1);
+      box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
+    }
+
+    100% {
+      transform: scale(0.95);
+      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    }
+  }
 `;

--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -497,9 +497,7 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
           projectId={projectId}
           clusterId={clusterId}
           appName={porterAppRecord.name}
-          latestSource={latestSource}
           onSubmit={onSubmit}
-          porterAppRecord={porterAppRecord}
         />
         <AnimateHeight height={isDirty && !onlyExpandedChanged ? "auto" : 0}>
           <Banner

--- a/dashboard/src/main/home/app-dashboard/expanded-app/logs/LogSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/logs/LogSection.tsx
@@ -184,16 +184,6 @@ const LogSection: React.FC<Props> = ({
     }
   }, [isLoading, logs, scrollToBottomRef, scrollToBottomEnabled]);
 
-
-  const resetFilters = () => {
-    setSelectedFilterValues({
-      revision: filterOpts?.revision ?? GenericLogFilter.getDefaultOption("revision").value,
-      output_stream: filterOpts?.output_stream ?? GenericLogFilter.getDefaultOption("output_stream").value,
-      pod_name: getPodSelectorFromServiceName(filterOpts?.service, services) ?? GenericLogFilter.getDefaultOption("pod_name").value,
-      service_name: filterOpts?.service ?? GenericLogFilter.getDefaultOption("service_name").value,
-    });
-  };
-
   const onLoadPrevious = useCallback(() => {
     if (!selectedDate) {
       setSelectedDate(dayjs(logs[0].timestamp).toDate());
@@ -202,12 +192,6 @@ const LogSection: React.FC<Props> = ({
 
     moveCursor(Direction.backward);
   }, [logs, selectedDate]);
-
-  const resetSearch = () => {
-    setSearchText("");
-    setEnteredSearchText("");
-    resetFilters();
-  };
 
   const setSelectedDateIfUndefined = () => {
     if (selectedDate == null) {
@@ -246,7 +230,6 @@ const LogSection: React.FC<Props> = ({
             <LogQueryModeSelectionToggle
               selectedDate={selectedDate}
               setSelectedDate={setSelectedDate}
-              resetSearch={resetSearch}
             />
           </Flex>
           <Flex>

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -263,16 +263,6 @@ const Logs: React.FC<Props> = ({
         }
     }, [isLoading, logs, scrollToBottomRef, scrollToBottomEnabled]);
 
-
-    const resetFilters = () => {
-        setSelectedFilterValues({
-            service_name: logQueryParamOpts?.service ?? GenericLogFilter.getDefaultOption("service_name").value,
-            pod_name: "", // not supported in v2
-            revision: logQueryParamOpts.revision ?? GenericLogFilter.getDefaultOption("revision").value,
-            output_stream: logQueryParamOpts.output_stream ?? GenericLogFilter.getDefaultOption("output_stream").value,
-        });
-    };
-
     const onLoadPrevious = useCallback(() => {
         if (!selectedDate) {
             setSelectedDate(dayjs(logs[0].timestamp).toDate());
@@ -281,12 +271,6 @@ const Logs: React.FC<Props> = ({
 
         moveCursor(Direction.backward);
     }, [logs, selectedDate]);
-
-    const resetSearch = () => {
-        setSearchText("");
-        setEnteredSearchText("");
-        resetFilters();
-    };
 
     const setSelectedDateIfUndefined = () => {
         if (selectedDate == null) {
@@ -323,7 +307,6 @@ const Logs: React.FC<Props> = ({
                         <LogQueryModeSelectionToggle
                             selectedDate={selectedDate ?? timeRange?.endTime?.toDate()}
                             setSelectedDate={setSelectedDate}
-                            resetSearch={resetSearch}
                         />
                     </Flex>
                     <Flex>

--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
@@ -11,7 +11,6 @@ import { SourceOptions } from "lib/porter-apps";
 type RevisionTableContentsProps = {
   latestRevisionNumber: number;
   revisions: AppRevision[];
-  latestSource: SourceOptions;
   expandRevisions: boolean;
   setExpandRevisions: Dispatch<SetStateAction<boolean>>;
   setRevertData: Dispatch<
@@ -29,7 +28,6 @@ const YELLOW = "#FFA500";
 const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
   latestRevisionNumber,
   revisions,
-  latestSource,
   expandRevisions,
   setExpandRevisions,
   setRevertData,

--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionsList.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionsList.tsx
@@ -7,7 +7,6 @@ import { match } from "ts-pattern";
 import loading from "assets/loading.gif";
 import {
   PorterAppFormData,
-  SourceOptions,
   clientAppFromProto,
 } from "lib/porter-apps";
 import { z } from "zod";
@@ -18,17 +17,14 @@ import { useLatestRevision } from "../../app-view/LatestRevisionContext";
 import RevisionTableContents from "./RevisionTableContents";
 import GHStatusBanner from "./GHStatusBanner";
 import Spacer from "components/porter/Spacer";
-import { PorterAppRecord } from "../../app-view/AppView";
 
 type Props = {
   deploymentTargetId: string;
   projectId: number;
   clusterId: number;
   appName: string;
-  latestSource: SourceOptions;
   latestRevisionNumber: number;
   onSubmit: () => Promise<void>;
-  porterAppRecord: PorterAppRecord;
 };
 
 const RevisionsList: React.FC<Props> = ({
@@ -37,9 +33,7 @@ const RevisionsList: React.FC<Props> = ({
   projectId,
   clusterId,
   appName,
-  latestSource,
   onSubmit,
-  porterAppRecord,
 }) => {
   const { servicesFromYaml } = useLatestRevision();
   const { setValue } = useFormContext<PorterAppFormData>();
@@ -137,11 +131,9 @@ const RevisionsList: React.FC<Props> = ({
             <RevisionTableContents
               latestRevisionNumber={latestRevisionNumber}
               revisions={data.app_revisions}
-              latestSource={latestSource}
               expandRevisions={expandRevisions}
               setExpandRevisions={setExpandRevisions}
               setRevertData={setRevertData}
-              porterAppRecord={porterAppRecord}
             />
           ))
           .otherwise(() => null)}


### PR DESCRIPTION
1. do not reset log filters when going from live to historical (or vice-versa)
2. add end time to deploy events so we can start tracking their durations
3. removing unused imports