### PR TITLE
fix: load env groups on create crashing

### DIFF
--- a/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroupModal.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroupModal.tsx
@@ -44,6 +44,9 @@ const EnvGroupModal: React.FC<Props> = ({ append, setOpen, baseEnvGroups }) => {
   }, [selectedEnvGroup]);
 
   const remainingEnvGroupOptions = useMemo(() => {
+    if (!envGroups) {
+      return baseEnvGroups;
+    }
     return baseEnvGroups.filter((eg) => {
       return !envGroups.some((eg2) => eg2.name === eg.name);
     });

--- a/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroupModal.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/app-settings/EnvGroupModal.tsx
@@ -31,7 +31,7 @@ const EnvGroupModal: React.FC<Props> = ({ append, setOpen, baseEnvGroups }) => {
   ] = useState<PopulatedEnvGroup | null>(null);
 
   const { watch } = useFormContext<PorterAppFormData>();
-  const envGroups = watch("app.envGroups");
+  const envGroups = watch("app.envGroups", []);
 
   const onSubmit = useCallback(() => {
     if (selectedEnvGroup) {
@@ -44,9 +44,6 @@ const EnvGroupModal: React.FC<Props> = ({ append, setOpen, baseEnvGroups }) => {
   }, [selectedEnvGroup]);
 
   const remainingEnvGroupOptions = useMemo(() => {
-    if (!envGroups) {
-      return baseEnvGroups;
-    }
     return baseEnvGroups.filter((eg) => {
       return !envGroups.some((eg2) => eg2.name === eg.name);
     });


### PR DESCRIPTION
This fix adds a default value to `watch()` to handle undefined env groups.