### PR TITLE
improve handling of missing porter.yaml in preview envs

### DIFF
--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -76,7 +76,7 @@ func Apply(ctx context.Context, inp ApplyInput) error {
 	}
 
 	// overrides incorporated into the app contract baed on the deployment target
-	var b64AppOverrides string
+	var overrides *porter_app.EncodedAppWithEnv
 
 	appName := inp.AppName
 	if porterYamlExists {
@@ -97,6 +97,8 @@ func Apply(ctx context.Context, inp ApplyInput) error {
 			return errors.New("b64 app proto is empty")
 		}
 		b64AppProto = parseResp.B64AppProto
+
+		overrides = parseResp.PreviewApp
 
 		// override app name if provided
 		appName, err = appNameFromB64AppProto(parseResp.B64AppProto)
@@ -128,21 +130,32 @@ func Apply(ctx context.Context, inp ApplyInput) error {
 			return fmt.Errorf("error updating app env group in proto: %w", err)
 		}
 
-		if inp.PreviewApply && parseResp.PreviewApp != nil {
-			b64AppOverrides = parseResp.PreviewApp.B64AppProto
+		color.New(color.FgGreen).Printf("Successfully parsed Porter YAML: applying app \"%s\"\n", appName) // nolint:errcheck,gosec
+	}
 
-			envGroupResp, err := client.CreateOrUpdateAppEnvironment(ctx, cliConf.Project, cliConf.Cluster, appName, deploymentTargetID, parseResp.PreviewApp.EnvVariables, parseResp.PreviewApp.EnvSecrets, parseResp.PreviewApp.B64AppProto)
-			if err != nil {
-				return fmt.Errorf("error calling create or update app environment group endpoint: %w", err)
-			}
+	// b64AppOverrides is the base64-encoded app proto with preview environment specific overrides and env groups
+	var b64AppOverrides string
 
-			b64AppOverrides, err = updateEnvGroupsInProto(ctx, b64AppOverrides, envGroupResp.EnvGroups)
-			if err != nil {
-				return fmt.Errorf("error updating app env group in proto: %w", err)
-			}
+	if inp.PreviewApply {
+		var previewEnvVariables map[string]string
+		var previewEnvSecrets map[string]string
+
+		if overrides != nil {
+			b64AppOverrides = overrides.B64AppProto
+			previewEnvVariables = overrides.EnvVariables
+			previewEnvSecrets = overrides.EnvSecrets
 		}
 
-		color.New(color.FgGreen).Printf("Successfully parsed Porter YAML: applying app \"%s\"\n", appName) // nolint:errcheck,gosec
+		envGroupResp, err := client.CreateOrUpdateAppEnvironment(ctx, cliConf.Project, cliConf.Cluster, appName, deploymentTargetID, previewEnvVariables, previewEnvSecrets, b64AppOverrides)
+		if err != nil {
+			return fmt.Errorf("error calling create or update app environment group endpoint: %w", err)
+		}
+		b64AppOverrides = envGroupResp.Base64AppProto
+
+		b64AppOverrides, err = updateEnvGroupsInProto(ctx, b64AppOverrides, envGroupResp.EnvGroups)
+		if err != nil {
+			return fmt.Errorf("error updating app env group in proto: %w", err)
+		}
 	}
 
 	if appName == "" {

--- a/dashboard/src/lib/porter-apps/index.ts
+++ b/dashboard/src/lib/porter-apps/index.ts
@@ -485,14 +485,10 @@ export function applyPreviewOverrides({
   overrides,
 }: {
   app: ClientPorterApp;
-  overrides: DetectedServices["previews"];
+  overrides?: DetectedServices["previews"];
 }): ClientPorterApp {
-  if (!overrides) {
-    return app;
-  }
-
   const services = app.services.map((svc) => {
-    const override = overrides.services.find(
+    const override = overrides?.services.find(
       (s) => s.name.value === svc.name.value
     );
     if (override) {
@@ -502,24 +498,41 @@ export function applyPreviewOverrides({
       });
 
       if (ds.config.type == "web") {
-        ds.config.domains = [];
+        return {
+          ...ds,
+          config: {
+            ...ds.config,
+            domains: [],
+          },
+        };
       }
       return ds;
     }
 
     if (svc.config.type == "web") {
-      svc.config.domains = [];
+      return {
+        ...svc,
+        config: {
+          ...svc.config,
+          domains: [],
+        },
+      };
     }
+
     return svc;
   });
-  const additionalServices = overrides.services
-    .filter((s) => !app.services.find((svc) => svc.name.value === s.name.value))
-    .map((svc) => deserializeService({ service: serializeService(svc) }));
+  const additionalServices =
+    overrides?.services
+      .filter(
+        (s) => !app.services.find((svc) => svc.name.value === s.name.value)
+      )
+      .map((svc) => deserializeService({ service: serializeService(svc) })) ??
+    [];
 
   app.services = [...services, ...additionalServices];
 
   if (app.predeploy) {
-    const predeployOverride = overrides.predeploy;
+    const predeployOverride = overrides?.predeploy;
     if (predeployOverride) {
       app.predeploy = [
         deserializeService({
@@ -530,33 +543,32 @@ export function applyPreviewOverrides({
     }
   }
 
-  const envOverrides = overrides.variables;
-  if (envOverrides) {
-    const env = app.env.map((e) => {
-      const override = envOverrides[e.key];
-      if (override) {
-        return {
-          ...e,
-          locked: true,
-          value: override,
-        };
-      }
+  const envOverrides = overrides?.variables;
 
-      return e;
-    });
-
-    const additionalEnv = Object.entries(envOverrides)
-      .filter(([key]) => !app.env.find((e) => e.key === key))
-      .map(([key, value]) => ({
-        key,
-        value,
-        hidden: false,
+  const env = app.env.map((e) => {
+    const override = envOverrides?.[e.key];
+    if (override) {
+      return {
+        ...e,
         locked: true,
-        deleted: false,
-      }));
+        value: override,
+      };
+    }
 
-    app.env = [...env, ...additionalEnv];
-  }
+    return e;
+  });
+
+  const additionalEnv = Object.entries(envOverrides ?? {})
+    .filter(([key]) => !app.env.find((e) => e.key === key))
+    .map(([key, value]) => ({
+      key,
+      value,
+      hidden: false,
+      locked: true,
+      deleted: false,
+    }));
+
+  app.env = [...env, ...additionalEnv];
 
   return app;
 }


### PR DESCRIPTION
## What does this PR do?

- Makes sure that overrides are not required on the frontend when creating an app template
- If overrides are not set in porter.yaml, still create the default app env on first apply