### PR TITLE
[POR-1987] fix: remove escaping from log search term

### DIFF
--- a/dashboard/src/components/LogSearchBar.tsx
+++ b/dashboard/src/components/LogSearchBar.tsx
@@ -29,7 +29,7 @@ const LogSearchBar: React.FC<Props> = ({
         setSearchText(x);
       }}
       onEnter={() => {
-        setEnteredSearchText(escapeRegExp(searchText));
+        setEnteredSearchText(searchText);
         setSelectedDate();
       }}
       placeholder="Search logs . . ."

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/logs-section/LogsSection.tsx
@@ -209,7 +209,7 @@ const LogsSection: React.FC<Props> = ({
                   }}
                   onKeyPress={(event) => {
                     if (event.key === "Enter") {
-                      setEnteredSearchText(escapeRegExp(searchText));
+                      setEnteredSearchText(searchText);
                       if (selectedDate == null) {
                         setSelectedDate(dayjs().toDate());
                       }


### PR DESCRIPTION
Fixes invalid search parameter format sent from frontend to agent.