### PR TITLE
ignore errors when attempting workflow cancellation

### DIFF
--- a/api/server/handlers/webhook/app_v2_github.go
+++ b/api/server/handlers/webhook/app_v2_github.go
@@ -128,7 +128,7 @@ func (c *GithubWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		branch := event.GetPullRequest().GetHead().GetRef()
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "event-branch", Value: branch})
 
-		err = cancelPendingWorkflows(ctx, cancelPendingWorkflowsInput{
+		_ = cancelPendingWorkflows(ctx, cancelPendingWorkflowsInput{
 			appName:         porterApp.Name,
 			repoID:          porterApp.GitRepoID,
 			repoName:        porterApp.RepoName,
@@ -136,11 +136,6 @@ func (c *GithubWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			githubAppID:     c.Config().ServerConf.GithubAppID,
 			event:           event,
 		})
-		if err != nil {
-			err := telemetry.Error(ctx, span, err, "error cancelling pending workflows")
-			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-			return
-		}
 
 		deploymentTarget, err := c.Repo().DeploymentTarget().DeploymentTargetBySelectorAndSelectorType(
 			uint(webhook.ProjectID),

--- a/internal/integrations/ci/actions/stack.go
+++ b/internal/integrations/ci/actions/stack.go
@@ -194,8 +194,8 @@ func getStackApplyActionYAML(opts *GetStackApplyActionYAMLOpts) ([]byte, error) 
 			On: GithubActionYAMLOnPullRequest{
 				PullRequest: GithubActionYAMLOnPullRequestTypes{
 					Paths: []string{
-						"!./github/workflows/porter-**",
 						"**",
+						"!./github/workflows/porter-**",
 					},
 					Branches: []string{
 						opts.DefaultBranch,


### PR DESCRIPTION
## What does this PR do?

- We attempt to cancel any outstanding preview env workflows when PRs are closed.
- However, the workflow runs are looked up by action name and this throws an error if the action can't be found, which could be the case if a user copies the file themselves instead of auto creating the PR
- This is a temporary fix which ignores the error so that other resources can be cleaned up
