### PR TITLE
fix issue with old predeploy job logs not showing up because they were being filtered out

### DIFF
--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/BuildEventCard.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/BuildEventCard.tsx
@@ -62,7 +62,7 @@ const BuildEventCard: React.FC<Props> = ({
               <Container row>
                 <Icon src={document} height="10px" />
                 <Spacer inline width="5px" />
-                View build logs
+                View logs
               </Container>
             </Link>
             <Spacer inline x={1} />

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/PreDeployEventCard.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/PreDeployEventCard.tsx
@@ -82,11 +82,11 @@ const PreDeployEventCard: React.FC<Props> = ({
           {renderStatusText(event)}
           <Spacer inline x={1} />
           <Wrapper>
-            <Link to={`/apps/${appName}/events?event_id=${event.id}&service=predeploy`} hasunderline>
+            <Link to={`/apps/${appName}/events?event_id=${event.id}&service=predeploy&revision_id=${event.metadata.app_revision_id}`} hasunderline>
               <Container row>
                 <Icon src={document} height="10px" />
                 <Spacer inline width="5px" />
-                View pre-deploy logs
+                View logs
               </Container>
             </Link>
             {(event.status !== "SUCCESS") &&

--- a/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
@@ -53,7 +53,7 @@ export const GenericFilterOption = {
         return { label, value };
     }
 }
-export type FilterName = 'revision' | 'output_stream' | 'pod_name' | 'service_name';
+export type FilterName = 'revision' | 'output_stream' | 'pod_name' | 'service_name' | 'revision_id';
 export interface GenericFilter {
     name: FilterName;
     displayName: string;
@@ -70,7 +70,9 @@ export const GenericFilter = {
         switch (filterName) {
             case 'service_name':
                 return GenericFilterOption.of('All', 'all');
-            case 'revision':
+            case 'revision': // refers to number
+                return GenericFilterOption.of('All', 'all');
+            case 'revision_id':
                 return GenericFilterOption.of('All', 'all');
             case 'output_stream':
                 return GenericFilterOption.of('All', 'all');

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -52,7 +52,7 @@ const Logs: React.FC<Props> = ({
     deploymentTargetId,
     appRevisionId,
     timeRange,
-    logFilterNames = ["service_name", "revision", "output_stream"],
+    logFilterNames = ["service_name", "revision", "output_stream"], // these are the names of filters that will be displayed in the UI
     filterPredeploy = false,
     appId,
 }) => {
@@ -62,6 +62,7 @@ const Logs: React.FC<Props> = ({
         revision: queryParams.get('version'),
         output_stream: queryParams.get('output_stream'),
         service: queryParams.get('service'),
+        revision_id: queryParams.get('revision_id'),
     }
 
     const scrollToBottomRef = useRef<HTMLDivElement | undefined>(undefined);
@@ -81,6 +82,7 @@ const Logs: React.FC<Props> = ({
         pod_name: "", // not supported in v2
         revision: logQueryParamOpts.revision ?? GenericFilter.getDefaultOption("revision").value,
         output_stream: logQueryParamOpts.output_stream ?? GenericFilter.getDefaultOption("output_stream").value,
+        revision_id: logQueryParamOpts.revision_id ?? GenericFilter.getDefaultOption("revision_id").value,
     });
 
     const { revisionIdToNumber } = useRevisionList({ appName, deploymentTargetId, projectId, clusterId });
@@ -185,7 +187,6 @@ const Logs: React.FC<Props> = ({
         clusterID: clusterId,
         selectedFilterValues,
         appName,
-        serviceName: selectedFilterValues.service_name,
         deploymentTargetId,
         searchParam: enteredSearchText,
         notify,
@@ -243,7 +244,7 @@ const Logs: React.FC<Props> = ({
             } as GenericFilter,
         ].filter((f: GenericFilter) => logFilterNames.includes(f.name)))
 
-        if (latestRevisionNumber && !logQueryParamOpts.revision) {
+        if (latestRevisionNumber && !logQueryParamOpts.revision && !logQueryParamOpts.revision_id) { // default to filter by latest revision number if no query params supplied
             setSelectedFilterValues({
                 ...selectedFilterValues,
                 revision: latestRevisionNumber.toString(),

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -80,7 +80,7 @@ const Logs: React.FC<Props> = ({
     const [selectedFilterValues, setSelectedFilterValues] = useState<Record<FilterName, string>>({
         service_name: logQueryParamOpts?.service ?? GenericFilter.getDefaultOption("service_name").value,
         pod_name: "", // not supported in v2
-        revision: logQueryParamOpts.revision ?? GenericFilter.getDefaultOption("revision").value,
+        revision: logQueryParamOpts.revision ?? GenericFilter.getDefaultOption("revision").value, // refers to revision number
         output_stream: logQueryParamOpts.output_stream ?? GenericFilter.getDefaultOption("output_stream").value,
         revision_id: logQueryParamOpts.revision_id ?? GenericFilter.getDefaultOption("revision_id").value,
     });
@@ -244,7 +244,7 @@ const Logs: React.FC<Props> = ({
             } as GenericFilter,
         ].filter((f: GenericFilter) => logFilterNames.includes(f.name)))
 
-        if (latestRevisionNumber && !logQueryParamOpts.revision && !logQueryParamOpts.revision_id) { // default to filter by latest revision number if no query params supplied
+        if (latestRevisionNumber && !logQueryParamOpts.revision && !logQueryParamOpts.revision_id) { // default to filter by latest revision number if no revision-related query params supplied
             setSelectedFilterValues({
                 ...selectedFilterValues,
                 revision: latestRevisionNumber.toString(),

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/utils.ts
@@ -46,7 +46,6 @@ export const useLogs = ({
   clusterID,
   selectedFilterValues,
   appName,
-  serviceName,
   deploymentTargetId,
   searchParam,
   notify,
@@ -62,7 +61,6 @@ export const useLogs = ({
   clusterID: number,
   selectedFilterValues: Record<FilterName, string>,
   appName: string,
-  serviceName: string,
   deploymentTargetId: string,
   searchParam: string,
   notify: (message: string) => void,
@@ -182,7 +180,7 @@ export const useLogs = ({
     const websocketBaseURL = `/api/projects/${projectID}/clusters/${clusterID}/apps/${appName}/logs/loki`;
 
     const searchParams = {
-      service_name: serviceName,
+      service_name: selectedFilterValues.service_name,
       deployment_target_id: deploymentTargetId,
       search_param: searchParam,
       app_revision_id: appRevisionId,
@@ -258,6 +256,11 @@ export const useLogs = ({
         return false;
       }
 
+      if (selectedFilterValues.revision_id !== GenericFilter.getDefaultOption("revision_id").value &&
+        log.metadata.raw_labels?.porter_run_app_revision_id !== selectedFilterValues.revision_id) {
+        return false;
+      }
+
       return true;
     });
   };
@@ -275,7 +278,7 @@ export const useLogs = ({
     try {
       const getLogsReq = {
         app_id: appID,
-        service_name: serviceName,
+        service_name: selectedFilterValues.service_name,
         deployment_target_id: deploymentTargetId,
         search_param: searchParam,
         start_range: startDate,
@@ -367,7 +370,7 @@ export const useLogs = ({
 
     closeAllWebsockets();
     const suffix = Math.random().toString(36).substring(2, 15);
-    const websocketKey = `${appName}-${serviceName}-websocket-${suffix}`;
+    const websocketKey = `${appName}-${selectedFilterValues.service_name}-websocket-${suffix}`;
 
     setLoading(false);
 
@@ -471,7 +474,6 @@ export const useLogs = ({
     }
   }, [
     appName,
-    serviceName,
     deploymentTargetId,
     searchParam,
     setDate,


### PR DESCRIPTION
Ever since we started defaulting to showing the latest revision number logs, historical predeploy logs became broken because they don't necessarily match the latest revision number. This work allows logs to be filtered by revision_id as well as number, so they aren't filtered out.
