### PR TITLE
use new update call and remove cli actions in cli apply

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -703,3 +703,24 @@ func (c *Client) RollbackRevision(
 
 	return resp, err
 }
+
+// UseNewApplyLogic checks whether the CLI should use the new apply logic
+func (c *Client) UseNewApplyLogic(
+	ctx context.Context,
+	projectID, clusterID uint,
+) (*porter_app.UseNewApplyLogicResponse, error) {
+	resp := &porter_app.UseNewApplyLogicResponse{}
+
+	req := &porter_app.UseNewApplyLogicRequest{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/use-new-apply-logic",
+			projectID, clusterID,
+		),
+		req,
+		resp,
+	)
+
+	return resp, err
+}

--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -455,6 +455,26 @@ func (c *Client) PredeployStatus(
 	return resp, err
 }
 
+// GetRevision returns an app revision
+func (c *Client) GetRevision(
+	ctx context.Context,
+	projectID uint, clusterID uint,
+	appName string, appRevisionId string,
+) (*porter_app.GetAppRevisionResponse, error) {
+	resp := &porter_app.GetAppRevisionResponse{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/%s/revisions/%s",
+			projectID, clusterID, appName, appRevisionId,
+		),
+		nil,
+		resp,
+	)
+
+	return resp, err
+}
+
 // UpdateRevisionStatus updates the status of an app revision
 func (c *Client) UpdateRevisionStatus(
 	ctx context.Context,

--- a/api/server/handlers/porter_app/update_app.go
+++ b/api/server/handlers/porter_app/update_app.go
@@ -149,9 +149,12 @@ func (c *UpdateAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if appProto.Name == "" {
-		err := telemetry.Error(ctx, span, nil, "app name is empty")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
+		if request.Name == "" {
+			err := telemetry.Error(ctx, span, nil, "app name is empty")
+			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+			return
+		}
+		appProto.Name = request.Name
 	}
 
 	sourceType, image := sourceFromAppAndGitSource(appProto, request.GitSource)

--- a/api/server/handlers/porter_app/update_app.go
+++ b/api/server/handlers/porter_app/update_app.go
@@ -38,21 +38,6 @@ func NewUpdateAppHandler(
 	}
 }
 
-// CLIAction is an enum for actions the CLI should take after calling applyWithRevisionID
-type CLIAction int
-
-// Actions for the CLI to take after applying the porter yaml
-const (
-	// CLIAction_Missing is the zero value that indicates an action was not assigned. This should never be returned.
-	CLIAction_Missing CLIAction = iota
-	// CLIAction_NoAction indicates that no action should be taken by the CLI.
-	CLIAction_NoAction
-	// CLIAction_Build indicates that the CLI should build the app.
-	CLIAction_Build
-	// CLIAction_TrackPredeploy indicates that the CLI should track the predeploy job.
-	CLIAction_TrackPredeploy
-)
-
 // UpdateAppRequest is the request object for the POST /apps/update endpoint
 type UpdateAppRequest struct {
 	// Name is the name of the app to update. If not specified, the name will be inferred from the porter yaml
@@ -85,9 +70,8 @@ type UpdateAppRequest struct {
 
 // UpdateAppResponse is the response object for the POST /apps/update endpoint
 type UpdateAppResponse struct {
-	AppName       string    `json:"app_name"`
-	AppRevisionId string    `json:"app_revision_id"`
-	CLIAction     CLIAction `json:"cli_action"`
+	AppName       string `json:"app_name"`
+	AppRevisionId string `json:"app_revision_id"`
 }
 
 // ServeHTTP translates the request into an UpdateApp request, forwards to the cluster control plane, and returns the response
@@ -311,33 +295,8 @@ func (c *UpdateAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "resp-app-revision-id", Value: ccpResp.Msg.AppRevisionId})
 
-	if ccpResp.Msg.CliAction == porterv1.EnumCLIAction_ENUM_CLI_ACTION_UNSPECIFIED {
-		err := telemetry.Error(ctx, span, err, "ccp resp cli action is nil")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-		return
-	}
-
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "cli-action", Value: ccpResp.Msg.CliAction.String()})
-
-	var cliAction CLIAction
-	switch ccpResp.Msg.CliAction {
-	case porterv1.EnumCLIAction_ENUM_CLI_ACTION_UNSPECIFIED:
-		cliAction = CLIAction_Missing
-	case porterv1.EnumCLIAction_ENUM_CLI_ACTION_NONE:
-		cliAction = CLIAction_NoAction
-	case porterv1.EnumCLIAction_ENUM_CLI_ACTION_BUILD:
-		cliAction = CLIAction_Build
-	case porterv1.EnumCLIAction_ENUM_CLI_ACTION_TRACK_PREDEPLOY:
-		cliAction = CLIAction_TrackPredeploy
-	default:
-		err := telemetry.Error(ctx, span, err, "ccp resp cli action is invalid")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-		return
-	}
-
 	response := &UpdateAppResponse{
 		AppRevisionId: ccpResp.Msg.AppRevisionId,
-		CLIAction:     cliAction,
 		AppName:       appProto.Name,
 	}
 

--- a/api/server/handlers/porter_app/update_app_revision_status.go
+++ b/api/server/handlers/porter_app/update_app_revision_status.go
@@ -82,6 +82,8 @@ func (c *UpdateAppRevisionStatusHandler) ServeHTTP(w http.ResponseWriter, r *htt
 		statusProto = porterv1.EnumRevisionStatus_ENUM_REVISION_STATUS_DEPLOY_FAILED
 	case models.AppRevisionStatus_PredeployFailed:
 		statusProto = porterv1.EnumRevisionStatus_ENUM_REVISION_STATUS_PREDEPLOY_FAILED
+	case models.AppRevisionStatus_BuildSuccessful:
+		statusProto = porterv1.EnumRevisionStatus_ENUM_REVISION_STATUS_BUILD_SUCCESSFUL
 	default:
 		err := telemetry.Error(ctx, span, nil, "invalid status")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))

--- a/api/server/handlers/porter_app/use_new_apply_logic.go
+++ b/api/server/handlers/porter_app/use_new_apply_logic.go
@@ -1,0 +1,63 @@
+package porter_app
+
+import (
+	"net/http"
+
+	"github.com/porter-dev/porter/api/server/authz"
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+// UseNewApplyLogicHandler returns whether the CLI should use the new apply logic or not
+type UseNewApplyLogicHandler struct {
+	handlers.PorterHandlerReadWriter
+	authz.KubernetesAgentGetter
+}
+
+// NewUseNewApplyLogicHandler returns a new UseNewApplyLogicHandler
+func NewUseNewApplyLogicHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *UseNewApplyLogicHandler {
+	return &UseNewApplyLogicHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
+	}
+}
+
+// UseNewApplyLogicRequest is the request body for the /apps/use-new-apply-logic endpoint
+type UseNewApplyLogicRequest struct{}
+
+// UseNewApplyLogicResponse is the response body for the /apps/use-new-apply-logic endpoint
+type UseNewApplyLogicResponse struct {
+	UseNewApplyLogic bool `json:"use_new_apply_logic"`
+}
+
+// ServeHTTP handles the request on the /apps/use-new-apply-logic endpoint, allowing the server to tell the CLI whether to use the new apply logic or not
+func (c *UseNewApplyLogicHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-use-new-apply-logic")
+	defer span.End()
+
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "project_id", Value: project.ID},
+		telemetry.AttributeKV{Key: "cluster_id", Value: cluster.ID},
+	)
+
+	betaFeaturesEnabled := project.GetFeatureFlag(models.BetaFeaturesEnabled, c.Config().LaunchDarklyClient)
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "beta_features_enabled", Value: betaFeaturesEnabled},
+	)
+
+	c.WriteResult(w, r, &UseNewApplyLogicResponse{
+		UseNewApplyLogic: betaFeaturesEnabled,
+	})
+}

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -1473,5 +1473,34 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/use-new-apply-logic -> porter_app.NewUseNewApplyLogicHandler
+	useNewApplyLogicEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("%s/use-new-apply-logic", relPathV2),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	useNewApplyLogicHandler := porter_app.NewUseNewApplyLogicHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: useNewApplyLogicEndpoint,
+		Handler:  useNewApplyLogicHandler,
+		Router:   r,
+	})
+
 	return routes, newPath
 }

--- a/api/types/project.go
+++ b/api/types/project.go
@@ -44,6 +44,7 @@ type Project struct {
 	EnableReprovision      bool    `json:"enable_reprovision"`
 	ValidateApplyV2        bool    `json:"validate_apply_v2"`
 	QuotaIncrease          bool    `json:"quota_increase"`
+	BetaFeaturesEnabled    bool    `json:"beta_features_enabled"`
 }
 
 type FeatureFlags struct {

--- a/cli/cmd/v2/apply.go
+++ b/cli/cmd/v2/apply.go
@@ -51,13 +51,7 @@ func Apply(ctx context.Context, inp ApplyInput) error {
 	}
 
 	if useNewApplyResp.UseNewApplyLogic {
-		return Update(ctx, UpdateInput{
-			CLIConfig:      inp.CLIConfig,
-			Client:         inp.Client,
-			PorterYamlPath: inp.PorterYamlPath,
-			AppName:        inp.AppName,
-			PreviewApply:   inp.PreviewApply,
-		})
+		return Update(ctx, UpdateInput(inp))
 	}
 
 	deploymentTargetID, err := deploymentTargetFromConfig(ctx, client, cliConf.Project, cliConf.Cluster, inp.PreviewApply)

--- a/cli/cmd/v2/update.go
+++ b/cli/cmd/v2/update.go
@@ -1,0 +1,264 @@
+package v2
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/porter-dev/porter/api/server/handlers/porter_app"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+
+	"github.com/fatih/color"
+	api "github.com/porter-dev/porter/api/client"
+	"github.com/porter-dev/porter/cli/cmd/config"
+)
+
+// UpdateInput is the input for the Update function
+type UpdateInput struct {
+	// CLIConfig is the CLI configuration
+	CLIConfig config.CLIConfig
+	// Client is the Porter API client
+	Client api.Client
+	// PorterYamlPath is the path to the porter.yaml file
+	PorterYamlPath string
+	// AppName is the name of the app
+	AppName string
+	// PreviewApply is true when Update should create a new deployment target matching current git branch and apply to that target
+	PreviewApply bool
+}
+
+// Update implements the functionality of the `porter apply` command for validate apply v2 projects
+func Update(ctx context.Context, inp UpdateInput) error {
+	cliConf := inp.CLIConfig
+	client := inp.Client
+
+	deploymentTargetID, err := deploymentTargetFromConfig(ctx, client, cliConf.Project, cliConf.Cluster, inp.PreviewApply)
+	if err != nil {
+		return fmt.Errorf("error getting deployment target from config: %w", err)
+	}
+
+	var prNumber int
+	prNumberEnv := os.Getenv("PORTER_PR_NUMBER")
+	if prNumberEnv != "" {
+		prNumber, err = strconv.Atoi(prNumberEnv)
+		if err != nil {
+			return fmt.Errorf("error parsing PORTER_PR_NUMBER to int: %w", err)
+		}
+	}
+
+	porterYamlExists := len(inp.PorterYamlPath) != 0
+
+	if porterYamlExists {
+		_, err := os.Stat(filepath.Clean(inp.PorterYamlPath))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("error checking if porter yaml exists at path %s: %w", inp.PorterYamlPath, err)
+			}
+			// If a path was specified but the file does not exist, we will not immediately error out.
+			// This supports users migrated from v1 who use a workflow file that always specifies a porter yaml path
+			// in the apply command.
+			porterYamlExists = false
+		}
+	}
+
+	var b64YAML string
+	if porterYamlExists {
+		porterYaml, err := os.ReadFile(filepath.Clean(inp.PorterYamlPath))
+		if err != nil {
+			return fmt.Errorf("could not read porter yaml file: %w", err)
+		}
+
+		b64YAML = base64.StdEncoding.EncodeToString(porterYaml)
+		color.New(color.FgGreen).Printf("Using Porter YAML at path: %s\n", inp.PorterYamlPath) // nolint:errcheck,gosec
+	}
+
+	commitSHA := commitSHAFromEnv()
+	gitSource, err := gitSourceFromEnv()
+	if err != nil {
+		return fmt.Errorf("error getting git source from env: %w", err)
+	}
+
+	updateInput := api.UpdateAppInput{
+		ProjectID:          cliConf.Project,
+		ClusterID:          cliConf.Cluster,
+		Name:               inp.AppName,
+		GitSource:          gitSource,
+		DeploymentTargetId: deploymentTargetID,
+		Base64PorterYAML:   b64YAML,
+		CommitSHA:          commitSHA,
+	}
+
+	updateResp, err := client.UpdateApp(ctx, updateInput)
+	if err != nil {
+		return fmt.Errorf("error calling update app endpoint: %w", err)
+	}
+
+	if updateResp.AppRevisionId == "" {
+		return errors.New("app revision id is empty")
+	}
+
+	appName := updateResp.AppName
+
+	buildSettings, err := client.GetBuildFromRevision(ctx, cliConf.Project, cliConf.Cluster, appName, updateResp.AppRevisionId)
+	if err != nil {
+		return fmt.Errorf("error getting build from revision: %w", err)
+	}
+
+	if buildSettings != nil && buildSettings.Build.Method != "" {
+		eventID, _ := createBuildEvent(ctx, client, appName, cliConf.Project, cliConf.Cluster, deploymentTargetID, commitSHA)
+
+		reportBuildFailureInput := reportBuildFailureInput{
+			client:             client,
+			appName:            appName,
+			cliConf:            cliConf,
+			deploymentTargetID: deploymentTargetID,
+			appRevisionID:      updateResp.AppRevisionId,
+			eventID:            eventID,
+			commitSHA:          commitSHA,
+			prNumber:           prNumber,
+		}
+
+		if commitSHA == "" {
+			return errors.New("build is required but commit SHA cannot be identified. Please set the PORTER_COMMIT_SHA environment variable or run apply in git repository with access to the git CLI")
+		}
+
+		color.New(color.FgGreen).Printf("Building new image with tag %s...\n", commitSHA) // nolint:errcheck,gosec
+
+		buildInput, err := buildInputFromBuildSettings(cliConf.Project, appName, commitSHA, buildSettings.Image, buildSettings.Build)
+		if err != nil {
+			err := fmt.Errorf("error creating build input from build settings: %w", err)
+			reportBuildFailureInput.buildError = err
+			_ = reportBuildFailure(ctx, reportBuildFailureInput)
+			return err
+		}
+
+		buildOutput := build(ctx, client, buildInput)
+		if buildOutput.Error != nil {
+			err := fmt.Errorf("error building app: %w", buildOutput.Error)
+			reportBuildFailureInput.buildLogs = buildOutput.Logs
+			reportBuildFailureInput.buildError = buildOutput.Error
+			_ = reportBuildFailure(ctx, reportBuildFailureInput)
+			return err
+		}
+
+		_, err = client.UpdateRevisionStatus(ctx, cliConf.Project, cliConf.Cluster, appName, updateResp.AppRevisionId, models.AppRevisionStatus_BuildSuccessful)
+		if err != nil {
+			err := fmt.Errorf("error updating revision status post build: %w", err)
+			reportBuildFailureInput.buildError = err
+			_ = reportBuildFailure(ctx, reportBuildFailureInput)
+			return err
+		}
+
+		color.New(color.FgGreen).Printf("Successfully built image (tag: %s)\n", buildSettings.Image.Tag) // nolint:errcheck,gosec
+
+		buildMetadata := make(map[string]interface{})
+		buildMetadata["end_time"] = time.Now().UTC()
+		_ = updateExistingEvent(ctx, client, appName, cliConf.Project, cliConf.Cluster, deploymentTargetID, types.PorterAppEventType_Build, eventID, types.PorterAppEventStatus_Success, buildMetadata)
+	}
+
+	color.New(color.FgGreen).Printf("Deploying new revision %s for app %s...\n", updateResp.AppRevisionId, appName) // nolint:errcheck,gosec
+
+	now := time.Now().UTC()
+
+	var status models.AppRevisionStatus
+
+	for {
+		if time.Since(now) > checkDeployTimeout {
+			return errors.New("timed out waiting for app to deploy")
+		}
+
+		revision, err := client.GetRevision(ctx, cliConf.Project, cliConf.Cluster, appName, updateResp.AppRevisionId)
+		if err != nil {
+			return fmt.Errorf("error getting app revision status: %w", err)
+		}
+		status = revision.AppRevision.Status
+
+		if status == models.AppRevisionStatus_DeployFailed || status == models.AppRevisionStatus_PredeployFailed || status == models.AppRevisionStatus_Deployed {
+			break
+		}
+		if status == models.AppRevisionStatus_AwaitingPredeploy {
+			color.New(color.FgGreen).Printf("Waiting for predeploy to complete..\n") // nolint:errcheck,gosec
+		}
+
+		time.Sleep(checkDeployFrequency)
+	}
+
+	_, _ = client.ReportRevisionStatus(ctx, api.ReportRevisionStatusInput{
+		ProjectID:     cliConf.Project,
+		ClusterID:     cliConf.Cluster,
+		AppName:       appName,
+		AppRevisionID: updateResp.AppRevisionId,
+		PRNumber:      prNumber,
+		CommitSHA:     commitSHA,
+	})
+
+	if status == models.AppRevisionStatus_DeployFailed {
+		return errors.New("app failed to deploy")
+	}
+	if status == models.AppRevisionStatus_PredeployFailed {
+		return errors.New("predeploy failed for new revision")
+	}
+
+	color.New(color.FgGreen).Printf("Successfully applied new revision %s\n", updateResp.AppRevisionId) // nolint:errcheck,gosec
+	return nil
+}
+
+// checkDeployTimeout is the timeout for checking if an app has been deployed
+const checkDeployTimeout = 15 * time.Minute
+
+// checkDeployFrequency is the frequency for checking if an app has been deployed
+const checkDeployFrequency = 10 * time.Second
+
+func gitSourceFromEnv() (porter_app.GitSource, error) {
+	var source porter_app.GitSource
+
+	var repoID uint
+	if os.Getenv("GITHUB_REPOSITORY_ID") != "" {
+		id, err := strconv.Atoi(os.Getenv("GITHUB_REPOSITORY_ID"))
+		if err != nil {
+			return source, fmt.Errorf("unable to parse GITHUB_REPOSITORY_ID to int: %w", err)
+		}
+		repoID = uint(id)
+	}
+
+	return porter_app.GitSource{
+		GitBranch:   os.Getenv("GITHUB_REF_NAME"),
+		GitRepoID:   repoID,
+		GitRepoName: os.Getenv("GITHUB_REPOSITORY"),
+	}, nil
+}
+
+func buildInputFromBuildSettings(projectID uint, appName string, commitSHA string, image porter_app.Image, build porter_app.BuildSettings) (buildInput, error) {
+	var buildSettings buildInput
+
+	if appName == "" {
+		return buildSettings, errors.New("app name is empty")
+	}
+	if image.Repository == "" {
+		return buildSettings, errors.New("image repository is empty")
+	}
+	if build.Method == "" {
+		return buildSettings, errors.New("build method is empty")
+	}
+	if commitSHA == "" {
+		return buildSettings, errors.New("commit SHA is empty")
+	}
+
+	return buildInput{
+		ProjectID:     projectID,
+		AppName:       appName,
+		BuildContext:  build.Context,
+		Dockerfile:    build.Dockerfile,
+		BuildMethod:   build.Method,
+		Builder:       build.Builder,
+		BuildPacks:    build.Buildpacks,
+		ImageTag:      commitSHA,
+		RepositoryURL: image.Repository,
+	}, nil
+}

--- a/dashboard/src/lib/revisions/types.ts
+++ b/dashboard/src/lib/revisions/types.ts
@@ -3,14 +3,20 @@ import { z } from "zod";
 export const appRevisionValidator = z.object({
   status: z.enum([
     "CREATED",
+    "IMAGE_AVAILABLE",
     "AWAITING_BUILD_ARTIFACT",
     "AWAITING_PREDEPLOY",
-    "READY_TO_APPLY",
+    "AWAITING_DEPLOY",
+    "PREDEPLOY_PROGRESSING",
     "DEPLOYED",
-    "BUILD_FAILED",
+    "DEPLOYING",
     "BUILD_CANCELED",
+    "BUILD_FAILED",
+    "BUILD_SUCCESSFUL",
+    "PREDEPLOY_FAILED",
+    "PREDEPLOY_SUCCESSFUL",
     "DEPLOY_FAILED",
-    "PREDEPLOY_FAILED"
+    "APPLY_FAILED",
   ]),
   b64_app_proto: z.string(),
   revision_number: z.number(),

--- a/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/revisions-list/RevisionTableContents.tsx
@@ -1,12 +1,14 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React, { type Dispatch, type SetStateAction } from "react";
 import { PorterApp } from "@porter-dev/api-contracts";
-import { AppRevision } from "lib/revisions/types";
-import { match } from "ts-pattern";
-import { useLatestRevision } from "../../app-view/LatestRevisionContext";
 import styled from "styled-components";
-import { readableDate } from "shared/string_utils";
+import { match } from "ts-pattern";
+
 import Text from "components/porter/Text";
 import { SourceOptions } from "lib/porter-apps";
+import { type AppRevision } from "lib/revisions/types";
+
+import { readableDate } from "shared/string_utils";
+import { useLatestRevision } from "../../app-view/LatestRevisionContext";
 
 type RevisionTableContentsProps = {
   latestRevisionNumber: number;
@@ -53,21 +55,19 @@ const RevisionTableContents: React.FC<RevisionTableContentsProps> = ({
     match(status)
       .with("CREATED", () => "Created")
       .with("AWAITING_BUILD_ARTIFACT", () => "Awaiting Build")
-      .with("READY_TO_APPLY", () => "Deploying")
       .with("AWAITING_PREDEPLOY", () => "Awaiting Pre-Deploy")
       .with("BUILD_CANCELED", () => "Build Canceled")
       .with("BUILD_FAILED", () => "Build Failed")
       .with("DEPLOY_FAILED", () => "Deploy Failed")
       .with("DEPLOYED", () => "Deployed")
       .with("PREDEPLOY_FAILED", () => "Pre-Deploy Failed")
-      .exhaustive();
+      .otherwise(() => "Deploying"); // fine to do this for now because this component is about to be deprecated
 
   const getDotColor = (status: AppRevision["status"]) =>
     match(status)
       .with(
         "CREATED",
         "AWAITING_BUILD_ARTIFACT",
-        "READY_TO_APPLY",
         "AWAITING_PREDEPLOY",
         () => YELLOW
       )

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.37
+	github.com/porter-dev/api-contracts v0.2.39
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.37 h1:tt3gh6wGEpmeFUMCUwgN/SRfj6zeHNPYHnZI2I0e/Rw=
-github.com/porter-dev/api-contracts v0.2.37/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.39 h1:0adXmIdyLYcJAcCXWlL5PYozoCLU70WRTX3Bl9VIXg4=
+github.com/porter-dev/api-contracts v0.2.39/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/models/app_revision.go
+++ b/internal/models/app_revision.go
@@ -11,21 +11,36 @@ type AppRevisionStatus string
 const (
 	// AppRevisionStatus_Created is the initial status for a revision when first inserted in database
 	AppRevisionStatus_Created AppRevisionStatus = "CREATED"
+	// AppRevisionStatus_ImageAvailable is the status for a revision that has an image available
+	AppRevisionStatus_ImageAvailable AppRevisionStatus = "IMAGE_AVAILABLE"
 	// AppRevisionStatus_AwaitingBuild is the status for a revision that still needs to be built
 	AppRevisionStatus_AwaitingBuild AppRevisionStatus = "AWAITING_BUILD_ARTIFACT"
-	// AppRevisionStatus_AwaitingPredeploy is the status for a revision that is waiting for a predeploy to complete.
+	// AppRevisionStatus_AwaitingPredeploy is the status for a revision that is waiting for a predeploy to be run
 	AppRevisionStatus_AwaitingPredeploy AppRevisionStatus = "AWAITING_PREDEPLOY"
+	// AppRevisionStatus_AwaitingDeploy is the status for a revision that is waiting to be deployed
+	AppRevisionStatus_AwaitingDeploy AppRevisionStatus = "AWAITING_DEPLOY"
+	// AppRevisionStatus_PredeployProgressing is the status for a revision that is currently running a predeploy
+	AppRevisionStatus_PredeployProgressing AppRevisionStatus = "PREDEPLOY_PROGRESSING"
 	// AppRevisionStatus_Deployed is the status for a revision that has been deployed
 	AppRevisionStatus_Deployed AppRevisionStatus = "DEPLOYED"
+	// AppRevisionStatus_Deploying is the status for a revision that is currently deploying
+	AppRevisionStatus_Deploying AppRevisionStatus = "DEPLOYING"
 
 	// AppRevisionStatus_BuildCanceled is the status for a revision that was canceled during the build process
 	AppRevisionStatus_BuildCanceled AppRevisionStatus = "BUILD_CANCELED"
 	// AppRevisionStatus_BuildFailed is the status for a revision that failed to build
 	AppRevisionStatus_BuildFailed AppRevisionStatus = "BUILD_FAILED"
+	// AppRevisionStatus_BuildSuccessful is the status for a revision that successfully built
+	AppRevisionStatus_BuildSuccessful AppRevisionStatus = "BUILD_SUCCESSFUL"
 	// AppRevisionStatus_PredeployFailed is the status for a revision that failed to predeploy
 	AppRevisionStatus_PredeployFailed AppRevisionStatus = "PREDEPLOY_FAILED"
+	// AppRevisionStatus_PredeploySuccessful is the status for a revision that successfully ran a predeploy
+	AppRevisionStatus_PredeploySuccessful AppRevisionStatus = "PREDEPLOY_SUCCESSFUL"
 	// AppRevisionStatus_DeployFailed is the status for a revision that failed to deploy
 	AppRevisionStatus_DeployFailed AppRevisionStatus = "DEPLOY_FAILED"
+
+	// AppRevisionStatus_ApplyFailed is the status for a revision that failed due to an internal system error
+	AppRevisionStatus_ApplyFailed AppRevisionStatus = "APPLY_FAILED"
 )
 
 // AppRevision represents the full spec for a revision of a porter app

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -63,6 +63,9 @@ const (
 
 	// ValidateApplyV2 controls whether apps deploys use a porter app revision contract vs helm
 	ValidateApplyV2 FeatureFlagLabel = "validate_apply_v2"
+
+	// BetaFeaturesEnabled controls whether a project uses beta features
+	BetaFeaturesEnabled FeatureFlagLabel = "beta_features_enabled"
 )
 
 // ProjectFeatureFlags keeps track of all project-related feature flags
@@ -83,6 +86,7 @@ var ProjectFeatureFlags = map[FeatureFlagLabel]bool{
 	SimplifiedViewEnabled:  true,
 	StacksEnabled:          false,
 	ValidateApplyV2:        true,
+	BetaFeaturesEnabled:    false,
 }
 
 type ProjectPlan string
@@ -258,6 +262,7 @@ func (p *Project) ToProjectType(launchDarklyClient *features.Client) types.Proje
 		FullAddOns:             p.GetFeatureFlag(FullAddOns, launchDarklyClient),
 		QuotaIncrease:          p.GetFeatureFlag(QuotaIncrease, launchDarklyClient),
 		EFSEnabled:             p.GetFeatureFlag(EFSEnabled, launchDarklyClient),
+		BetaFeaturesEnabled:    p.GetFeatureFlag(BetaFeaturesEnabled, launchDarklyClient),
 	}
 }
 

--- a/internal/porter_app/revisions.go
+++ b/internal/porter_app/revisions.go
@@ -195,22 +195,37 @@ func AttachEnvToRevision(ctx context.Context, inp AttachEnvToRevisionInput) (Rev
 func appRevisionStatusFromProto(status string) (models.AppRevisionStatus, error) {
 	var appRevisionStatus models.AppRevisionStatus
 	switch status {
+	case string(models.AppRevisionStatus_ImageAvailable):
+		appRevisionStatus = models.AppRevisionStatus_ImageAvailable
 	case string(models.AppRevisionStatus_AwaitingBuild):
 		appRevisionStatus = models.AppRevisionStatus_AwaitingBuild
 	case string(models.AppRevisionStatus_AwaitingPredeploy):
 		appRevisionStatus = models.AppRevisionStatus_AwaitingPredeploy
 	case string(models.AppRevisionStatus_Deployed):
 		appRevisionStatus = models.AppRevisionStatus_Deployed
+	case string(models.AppRevisionStatus_Deploying):
+		appRevisionStatus = models.AppRevisionStatus_Deploying
+	case string(models.AppRevisionStatus_AwaitingDeploy):
+		appRevisionStatus = models.AppRevisionStatus_AwaitingDeploy
 	case string(models.AppRevisionStatus_BuildCanceled):
 		appRevisionStatus = models.AppRevisionStatus_BuildCanceled
 	case string(models.AppRevisionStatus_BuildFailed):
 		appRevisionStatus = models.AppRevisionStatus_BuildFailed
 	case string(models.AppRevisionStatus_PredeployFailed):
 		appRevisionStatus = models.AppRevisionStatus_PredeployFailed
+	case string(models.AppRevisionStatus_PredeploySuccessful):
+		appRevisionStatus = models.AppRevisionStatus_PredeploySuccessful
+	case string(models.AppRevisionStatus_PredeployProgressing):
+		appRevisionStatus = models.AppRevisionStatus_PredeployProgressing
 	case string(models.AppRevisionStatus_DeployFailed):
 		appRevisionStatus = models.AppRevisionStatus_DeployFailed
 	case string(models.AppRevisionStatus_Created):
 		appRevisionStatus = models.AppRevisionStatus_Created
+	case string(models.AppRevisionStatus_BuildSuccessful):
+		appRevisionStatus = models.AppRevisionStatus_BuildSuccessful
+	case string(models.AppRevisionStatus_ApplyFailed):
+		appRevisionStatus = models.AppRevisionStatus_ApplyFailed
+
 	default:
 		return appRevisionStatus, fmt.Errorf("unknown app revision status")
 	}


### PR DESCRIPTION
## What does this PR do?

- Removes CLI action from apply flow
- Instead, assumes that build is needed if build has been set in hydration step
- Awaiting predeploy is also now run in the background and no longer needed on the CLI
- We only wait for revision to reach a terminal state - either deployed or any of the remaining failure states