### PR TITLE
use shortened commit sha in update flow

### DIFF
--- a/cli/cmd/v2/update.go
+++ b/cli/cmd/v2/update.go
@@ -84,6 +84,16 @@ func Update(ctx context.Context, inp UpdateInput) error {
 		return fmt.Errorf("error getting git source from env: %w", err)
 	}
 
+	if commitSHA != "" {
+		if len(commitSHA) < 7 {
+			return fmt.Errorf("commit SHA %s is not long enough", commitSHA)
+		}
+
+		// shorten commit SHA to 7 characters, which is a way of indicating to our hydration function that
+		// the app is being built and deployed with the new update logic
+		commitSHA = commitSHA[:7]
+	}
+
 	updateInput := api.UpdateAppInput{
 		ProjectID:          cliConf.Project,
 		ClusterID:          cliConf.Cluster,


### PR DESCRIPTION
## What does this PR do?

- Ensure that commit sha is shortened before passing along to update
- This provides a simple way of ensuring backwards compatibility when updating to the new tagging system
- If a values update is made without a new build / tag, identified by a longer tag, then continue to use the longer tag rather than the SHA as the source of truth. 
