### PR TITLE
add is default flag to deployment target

### DIFF
--- a/internal/models/deployment_target.go
+++ b/internal/models/deployment_target.go
@@ -41,6 +41,9 @@ type DeploymentTarget struct {
 
 	// Metadata is a JSONB column that stores arbitrary metadata about the deployment target
 	Metadata JSONB `json:"metadata" sql:"type:jsonb" gorm:"type:jsonb;default:'{}'"`
+
+	// IsDefault indicates whether this is the default deployment target for the cluster
+	IsDefault bool `gorm:"default:true" json:"is_default"`
 }
 
 // ToDeploymentTargetType generates an external types.PorterApp to be shared over REST

--- a/internal/models/deployment_target.go
+++ b/internal/models/deployment_target.go
@@ -43,7 +43,7 @@ type DeploymentTarget struct {
 	Metadata JSONB `json:"metadata" sql:"type:jsonb" gorm:"type:jsonb;default:'{}'"`
 
 	// IsDefault indicates whether this is the default deployment target for the cluster
-	IsDefault bool `gorm:"default:true" json:"is_default"`
+	IsDefault bool `gorm:"default:false" json:"is_default"`
 }
 
 // ToDeploymentTargetType generates an external types.PorterApp to be shared over REST


### PR DESCRIPTION
## What does this PR do?

- Adding flag indicating whether or not a deployment target is the default for a given cluster
- each cluster can have only one default deployment target
- This is useful for identifying the default deployment target for a given cluster, since names are unique across projects
