### PR TITLE
fix docker build errors when registry url includes protocol

### DIFF
--- a/cli/cmd/docker/builder.go
+++ b/cli/cmd/docker/builder.go
@@ -53,7 +53,7 @@ func (a *Agent) BuildLocal(ctx context.Context, opts *BuildOpts) (err error) {
 		excludes, err = dockerignore.ReadAll(bytes.NewBuffer(dockerIgnoreBytes))
 
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading .dockerignore: %w", err)
 		}
 	}
 
@@ -63,7 +63,7 @@ func (a *Agent) BuildLocal(ctx context.Context, opts *BuildOpts) (err error) {
 		ExcludePatterns: excludes,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating tar: %w", err)
 	}
 
 	var writer io.Writer = os.Stderr
@@ -74,7 +74,7 @@ func (a *Agent) BuildLocal(ctx context.Context, opts *BuildOpts) (err error) {
 	if !opts.IsDockerfileInCtx {
 		dockerfileCtx, err := os.Open(dockerfilePath)
 		if err != nil {
-			return fmt.Errorf("unable to open Dockerfile: %v", err)
+			return fmt.Errorf("error opening Dockerfile: %w", err)
 		}
 
 		defer dockerfileCtx.Close()
@@ -83,7 +83,7 @@ func (a *Agent) BuildLocal(ctx context.Context, opts *BuildOpts) (err error) {
 		tar, dockerfilePath, err = AddDockerfileToBuildContext(dockerfileCtx, tar)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("error adding Dockerfile to build context: %w", err)
 		}
 	}
 
@@ -111,7 +111,7 @@ func (a *Agent) BuildLocal(ctx context.Context, opts *BuildOpts) (err error) {
 		Platform: "linux/amd64",
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error building image: %w", err)
 	}
 
 	defer out.Body.Close()

--- a/cli/cmd/v2/build.go
+++ b/cli/cmd/v2/build.go
@@ -67,9 +67,9 @@ func build(ctx context.Context, client api.Client, inp buildInput) buildOutput {
 		output.Error = errors.New("must specify a registry url")
 		return output
 	}
-	imageURL := strings.TrimPrefix(inp.RepositoryURL, "https://")
+	repositoryURL := strings.TrimPrefix(inp.RepositoryURL, "https://")
 
-	err := createImageRepositoryIfNotExists(ctx, client, projectID, imageURL)
+	err := createImageRepositoryIfNotExists(ctx, client, projectID, repositoryURL)
 	if err != nil {
 		output.Error = fmt.Errorf("error creating image repository: %w", err)
 		return output
@@ -104,7 +104,7 @@ func build(ctx context.Context, client api.Client, inp buildInput) buildOutput {
 		}
 
 		opts := &docker.BuildOpts{
-			ImageRepo:         inp.RepositoryURL,
+			ImageRepo:         repositoryURL,
 			Tag:               tag,
 			CurrentTag:        inp.CurrentImageTag,
 			BuildContext:      buildCtx,
@@ -136,7 +136,7 @@ func build(ctx context.Context, client api.Client, inp buildInput) buildOutput {
 		packAgent := &pack.Agent{}
 
 		opts := &docker.BuildOpts{
-			ImageRepo:    imageURL,
+			ImageRepo:    repositoryURL,
 			Tag:          tag,
 			BuildContext: inp.BuildContext,
 			Env:          inp.Env,
@@ -168,7 +168,7 @@ func build(ctx context.Context, client api.Client, inp buildInput) buildOutput {
 		return output
 	}
 
-	err = dockerAgent.PushImage(ctx, fmt.Sprintf("%s:%s", imageURL, tag))
+	err = dockerAgent.PushImage(ctx, fmt.Sprintf("%s:%s", repositoryURL, tag))
 	if err != nil {
 		output.Error = fmt.Errorf("error pushing image: %w", err)
 		return output

--- a/cli/cmd/v2/update.go
+++ b/cli/cmd/v2/update.go
@@ -183,7 +183,7 @@ func Update(ctx context.Context, inp UpdateInput) error {
 			return buildError
 		}
 
-		color.New(color.FgGreen).Printf("Successfully built image (tag: %s)\n", buildSettings.Image.Tag) // nolint:errcheck,gosec
+		color.New(color.FgGreen).Printf("Successfully built image (tag: %s)\n", commitSHA) // nolint:errcheck,gosec
 
 		buildMetadata := make(map[string]interface{})
 		buildMetadata["end_time"] = time.Now().UTC()
@@ -280,14 +280,15 @@ func buildInputFromBuildSettings(projectID uint, appName string, commitSHA strin
 	}
 
 	return buildInput{
-		ProjectID:     projectID,
-		AppName:       appName,
-		BuildContext:  build.Context,
-		Dockerfile:    build.Dockerfile,
-		BuildMethod:   build.Method,
-		Builder:       build.Builder,
-		BuildPacks:    build.Buildpacks,
-		ImageTag:      commitSHA,
-		RepositoryURL: image.Repository,
+		ProjectID:       projectID,
+		AppName:         appName,
+		BuildContext:    build.Context,
+		Dockerfile:      build.Dockerfile,
+		BuildMethod:     build.Method,
+		Builder:         build.Builder,
+		BuildPacks:      build.Buildpacks,
+		ImageTag:        commitSHA,
+		RepositoryURL:   image.Repository,
+		CurrentImageTag: image.Tag,
 	}, nil
 }

--- a/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/new-app-flow/utils.ts
@@ -69,7 +69,7 @@ export const getPreviewGithubAction = (
     - synchronize
     paths:
     - '**'
-    - '!./github/workflows/porter_**'
+    - '!.github/workflows/porter_**'
     
 name: Deploy to Preview Environment
 jobs:

--- a/internal/integrations/ci/actions/stack.go
+++ b/internal/integrations/ci/actions/stack.go
@@ -196,7 +196,7 @@ func getStackApplyActionYAML(opts *GetStackApplyActionYAMLOpts) ([]byte, error) 
 				PullRequest: GithubActionYAMLOnPullRequestTypes{
 					Paths: []string{
 						"**",
-						"!./github/workflows/porter_**",
+						"!.github/workflows/porter_**",
 					},
 					Branches: []string{
 						opts.DefaultBranch,


### PR DESCRIPTION
## What does this PR do?

- If the registry URL is set with a protocol, it causes for Docker to throw an `invalid reference format` error
- PR guarantees any provided registry URL has striped the protocol