### PR TITLE
parse addons from porter.yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.53
+	github.com/porter-dev/api-contracts v0.2.55
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.53 h1:dksPN2aPsN/LT97b0pMXqbGt2E/0YKJt0o0XR1ipqNs=
-github.com/porter-dev/api-contracts v0.2.53/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.55 h1:H8RvD004mX4uWrlRVcL8kzo7ZtFQyZDN+X9j+2bW7fc=
+github.com/porter-dev/api-contracts v0.2.55/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/porter_app/v2/addons.go
+++ b/internal/porter_app/v2/addons.go
@@ -1,0 +1,71 @@
+package v2
+
+import (
+	"context"
+
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+func ProtoFromAddon(ctx context.Context, addon Addon) (*porterv1.Addon, error) {
+	ctx, span := telemetry.NewSpan(ctx, "proto-from-addon")
+	defer span.End()
+
+	addonProto := &porterv1.Addon{
+		Name: addon.Name,
+	}
+
+	addonType, err := addonEnumProtoFromType(ctx, addon.Type)
+	if err != nil {
+		return addonProto, telemetry.Error(ctx, span, err, "error getting addon type")
+	}
+
+	switch addonType {
+	case porterv1.AddonType_ADDON_TYPE_POSTGRES:
+		addonProto.Type = addonType
+		postgres := postgresConfigProtoFromAddon(addon)
+
+		addonProto.Config = &porterv1.Addon_Postgres{
+			Postgres: postgres,
+		}
+	default:
+		return addonProto, telemetry.Error(ctx, span, nil, "specified addon type not supported")
+	}
+
+	var envGroups []*porterv1.EnvGroup
+
+	for _, envGroup := range addon.EnvGroups {
+		eg := &porterv1.EnvGroup{
+			Name:    envGroup.Name,
+			Version: int64(envGroup.Version),
+		}
+		envGroups = append(envGroups, eg)
+	}
+	addonProto.EnvGroups = envGroups
+
+	return addonProto, nil
+}
+
+func addonEnumProtoFromType(ctx context.Context, addonType string) (porterv1.AddonType, error) {
+	ctx, span := telemetry.NewSpan(ctx, "addon-enum-proto-from-type")
+	defer span.End()
+
+	var addonTypeEnum porterv1.AddonType
+
+	switch addonType {
+	case "postgres":
+		addonTypeEnum = porterv1.AddonType_ADDON_TYPE_POSTGRES
+	default:
+		return addonTypeEnum, telemetry.Error(ctx, span, nil, "invalid addon type")
+	}
+
+	return addonTypeEnum, nil
+}
+
+func postgresConfigProtoFromAddon(addon Addon) *porterv1.Postgres {
+	return &porterv1.Postgres{
+		RamMegabytes:     int32(addon.RamMegabytes),
+		CpuCores:         float32(addon.CpuCores),
+		StorageGigabytes: int32(addon.StorageGigabytes),
+	}
+}


### PR DESCRIPTION
## POR-1441
## What does this PR do?

- Parse add-on definitions from porter.yaml
- Each add-on is parsed out as its own independent contract. This is because we are assuming that each will be hydrated and deployed indiviudally