### PR TITLE
feat: overwrite the extracted porter binary

### DIFF
--- a/services/cli_install_script_container/install.sh
+++ b/services/cli_install_script_container/install.sh
@@ -16,7 +16,7 @@ download_and_install() {
     echo "[INFO] Please make sure /usr/local/bin is included in your PATH."
 
     curl -L https://github.com/porter-dev/porter/releases/download/{{ .TagName }}/porter_{{ .TagName }}_${osname}_x86_64.zip --output porter.zip
-    unzip -a porter.zip
+    unzip -o -a porter.zip
     rm porter.zip
 
     chmod +x ./porter


### PR DESCRIPTION
## What does this PR do?

Some github runner implementations reuse the environment for caching purposes, causing the porter binary to potentially already exist. This overwrites the extracted file, ensuring it is available for the mv later.
