### PR TITLE
parse image tag correctly for predeploy on front end

### DIFF
--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/DeployEventCard.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/DeployEventCard.tsx
@@ -38,7 +38,6 @@ type Props = {
   clusterId: number;
   gitCommitUrl: string;
   displayCommitSha: string;
-  isMostRecentDeployEvent: boolean;
 };
 
 const DeployEventCard: React.FC<Props> = ({

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/EventCard.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/cards/EventCard.tsx
@@ -33,25 +33,30 @@ const EventCard: React.FC<Props> = ({
       return "";
     }
 
-    return match(event)
-      .with({ type: "APP_EVENT" }, () => "")
-      .with({ type: "NOTIFICATION" }, () => "")
-      .with({ type: "BUILD" }, (event) =>
-        event.metadata.commit_sha
-          ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.commit_sha}`
-          : ""
-      )
-      .with({ type: "PRE_DEPLOY" }, (event) =>
-        event.metadata.commit_sha
-          ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.commit_sha}`
-          : ""
-      )
-      .with({ type: "DEPLOY" }, (event) =>
-        event.metadata.image_tag
-          ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.image_tag}`
-          : ""
-      )
-      .exhaustive();
+    return (
+      match(event)
+        .with({ type: "APP_EVENT" }, () => "")
+        .with({ type: "NOTIFICATION" }, () => "")
+        .with({ type: "BUILD" }, (event) =>
+          event.metadata.commit_sha
+            ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.commit_sha}`
+            : ""
+        )
+        // TODO: remove check for commit_sha when update flow is GA'd
+        .with({ type: "PRE_DEPLOY" }, (event) =>
+          event.metadata.commit_sha
+            ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.commit_sha}`
+            : event.metadata.image_tag
+            ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.image_tag}`
+            : ""
+        )
+        .with({ type: "DEPLOY" }, (event) =>
+          event.metadata.image_tag
+            ? `https://www.github.com/${porterApp.repo_name}/commit/${event.metadata.image_tag}`
+            : ""
+        )
+        .exhaustive()
+    );
   }, [JSON.stringify(event), porterApp]);
 
   const displayCommitSha = useMemo(() => {
@@ -59,19 +64,26 @@ const EventCard: React.FC<Props> = ({
       return "";
     }
 
-    return match(event)
-      .with({ type: "APP_EVENT" }, () => "")
-      .with({ type: "NOTIFICATION" }, () => "")
-      .with({ type: "BUILD" }, (event) =>
-        event.metadata.commit_sha ? event.metadata.commit_sha.slice(0, 7) : ""
-      )
-      .with({ type: "PRE_DEPLOY" }, (event) =>
-        event.metadata.commit_sha ? event.metadata.commit_sha.slice(0, 7) : ""
-      )
-      .with({ type: "DEPLOY" }, (event) =>
-        event.metadata.image_tag ? event.metadata.image_tag.slice(0, 7) : ""
-      )
-      .exhaustive();
+    return (
+      match(event)
+        .with({ type: "APP_EVENT" }, () => "")
+        .with({ type: "NOTIFICATION" }, () => "")
+        .with({ type: "BUILD" }, (event) =>
+          event.metadata.commit_sha ? event.metadata.commit_sha.slice(0, 7) : ""
+        )
+        // TODO: remove check for commit_sha when update flow is GA'd
+        .with({ type: "PRE_DEPLOY" }, (event) =>
+          event.metadata.commit_sha
+            ? event.metadata.commit_sha.slice(0, 7)
+            : event.metadata.image_tag
+            ? event.metadata.image_tag.slice(0, 7)
+            : ""
+        )
+        .with({ type: "DEPLOY" }, (event) =>
+          event.metadata.image_tag ? event.metadata.image_tag.slice(0, 7) : ""
+        )
+        .exhaustive()
+    );
   }, [JSON.stringify(event), porterApp]);
 
   return match(event)

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/types.ts
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/types.ts
@@ -41,7 +41,8 @@ const porterAppPreDeployEventMetadataValidator = z.object({
   start_time: z.string(),
   end_time: z.string().optional(),
   app_revision_id: z.string(),
-  commit_sha: z.string().optional(),
+  image_tag: z.string().optional(), // used by the update flow
+  commit_sha: z.string().optional(), // used by the apply flow. TODO: remove this field
 });
 
 const serviceNoticationValidator = z.object({


### PR DESCRIPTION
commit_sha has been renamed to image_tag for predeploy events, this updates the parsing logic on the frontend to match