### PR TITLE
separate query notifications into its own handler

### DIFF
--- a/api/server/handlers/porter_app/app_notifications.go
+++ b/api/server/handlers/porter_app/app_notifications.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/porter-dev/porter/internal/porter_app"
+	"github.com/porter-dev/porter/internal/porter_app/notifications"
 	"github.com/porter-dev/porter/internal/telemetry"
 
 	"github.com/porter-dev/porter/api/server/handlers"
@@ -23,48 +24,40 @@ import (
 	"github.com/porter-dev/porter/internal/models"
 )
 
-// LatestAppRevisionHandler handles requests to the /apps/{porter_app_name}/latest endpoint
-type LatestAppRevisionHandler struct {
+// AppNotifications handles requests to the /apps/{porter_app_name}/notifications endpoint
+type AppNotificationsHandler struct {
 	handlers.PorterHandlerReadWriter
 	authz.KubernetesAgentGetter
 }
 
-// NewLatestAppRevisionHandler returns a new LatestAppRevisionHandler
-func NewLatestAppRevisionHandler(
+// NewAppNotificationsHandler returns a new AppNotificationsHandler
+func NewAppNotificationsHandler(
 	config *config.Config,
 	decoderValidator shared.RequestDecoderValidator,
 	writer shared.ResultWriter,
-) *LatestAppRevisionHandler {
-	return &LatestAppRevisionHandler{
+) *AppNotificationsHandler {
+	return &AppNotificationsHandler{
 		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
 		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
 	}
 }
 
-// LatestAppRevisionRequest is the request object for the /apps/{porter_app_name}/latest endpoint
-type LatestAppRevisionRequest struct {
+// AppNotificationsRequest is the request object for the /apps/{porter_app_name}/notifications endpoint
+type AppNotificationsRequest struct {
 	DeploymentTargetID string `schema:"deployment_target_id"`
 }
 
-// LatestAppRevisionResponse is the response object for the /apps/{porter_app_name}/latest endpoint
-type LatestAppRevisionResponse struct {
-	// AppRevision is the latest revision for the app
-	AppRevision porter_app.Revision `json:"app_revision"`
+// AppNotificationsResponse is the response object for the /apps/{porter_app_name}/notifications endpoint
+type AppNotificationsResponse struct {
+	// Notifications are the notifications associated with the app revision
+	Notifications []notifications.Notification `json:"notifications"`
 }
 
-// ServeHTTP translates the request into a CurrentAppRevision grpc request, forwards to the cluster control plane, and returns the response.
-// Multi-cluster projects are not supported, as they may have multiple porter-apps with the same name in the same project.
-func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := telemetry.NewSpan(r.Context(), "serve-latest-app-revision")
+func (c *AppNotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-app-notifications")
 	defer span.End()
 
 	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
-	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
-
-	telemetry.WithAttributes(span,
-		telemetry.AttributeKV{Key: "project-id", Value: project.ID},
-		telemetry.AttributeKV{Key: "cluster-id", Value: cluster.ID},
-	)
 
 	appName, reqErr := requestutils.GetURLParamString(r, types.URLParamPorterAppName)
 	if reqErr != nil {
@@ -75,7 +68,7 @@ func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
 
-	request := &LatestAppRevisionRequest{}
+	request := &AppNotificationsRequest{}
 	if ok := c.DecodeAndValidate(w, r, request); !ok {
 		err := telemetry.Error(ctx, span, nil, "error decoding request")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
@@ -92,7 +85,7 @@ func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	porterApps, err := c.Repo().PorterApp().ReadPorterAppsByProjectIDAndName(project.ID, appName)
 	if err != nil {
-		err := telemetry.Error(ctx, span, err, "error getting porter app from repo")
+		err := telemetry.Error(ctx, span, err, "error getting porter apps")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
 		return
 	}
@@ -117,9 +110,11 @@ func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}
 
 	currentAppRevisionReq := connect.NewRequest(&porterv1.CurrentAppRevisionRequest{
-		ProjectId:          int64(project.ID),
-		AppId:              int64(appId),
-		DeploymentTargetId: request.DeploymentTargetID,
+		ProjectId: int64(project.ID),
+		AppId:     int64(appId),
+		DeploymentTargetIdentifier: &porterv1.DeploymentTargetIdentifier{
+			Id: request.DeploymentTargetID,
+		},
 	})
 
 	currentAppRevisionResp, err := c.Config().ClusterControlPlaneClient.CurrentAppRevision(ctx, currentAppRevisionReq)
@@ -149,9 +144,33 @@ func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		telemetry.AttributeKV{Key: "app-revision-id", Value: appRevisionId},
 		telemetry.AttributeKV{Key: "app-instance-id", Value: appInstanceId},
 	)
+	notificationEvents, err := c.Repo().PorterAppEvent().ReadNotificationsByAppRevisionID(ctx, appInstanceId, appRevisionId)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting notifications from repo")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+	latestNotifications := make([]notifications.Notification, 0)
+	for _, event := range notificationEvents {
+		notification, err := notifications.NotificationFromPorterAppEvent(event)
+		if err != nil {
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "notification-conversion-error", Value: err.Error()})
+			continue
+		}
+		if notification == nil {
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "notification-conversion-error", Value: "notification is nil"})
+			continue
+		}
+		// TODO: remove this check once this attribute is not found in the span for >30 days
+		if notification.Scope == "" {
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "notification-conversion-error", Value: "old-notification-format"})
+			continue
+		}
+		latestNotifications = append(latestNotifications, *notification)
+	}
 
-	response := LatestAppRevisionResponse{
-		AppRevision: encodedRevision,
+	response := AppNotificationsResponse{
+		Notifications: latestNotifications,
 	}
 
 	c.WriteResult(w, r, response)

--- a/api/server/handlers/porter_app/app_notifications.go
+++ b/api/server/handlers/porter_app/app_notifications.go
@@ -24,7 +24,7 @@ import (
 	"github.com/porter-dev/porter/internal/models"
 )
 
-// AppNotifications handles requests to the /apps/{porter_app_name}/notifications endpoint
+// AppNotificationsHandler handles requests to the /apps/{porter_app_name}/notifications endpoint
 type AppNotificationsHandler struct {
 	handlers.PorterHandlerReadWriter
 	authz.KubernetesAgentGetter

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -833,6 +833,35 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/notifications -> porter_app.NewAppNotificationsHandler
+	appNotificationsEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("%s/{%s}/notifications", relPathV2, types.URLParamPorterAppName),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	appNotificationsHandler := porter_app.NewAppNotificationsHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: appNotificationsEndpoint,
+		Handler:  appNotificationsHandler,
+		Router:   r,
+	})
+
 	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/revisions -> porter_app.NewCurrentAppRevisionHandler
 	listAppRevisionsEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/types.ts
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/activity-feed/events/types.ts
@@ -47,8 +47,6 @@ const porterAppPreDeployEventMetadataValidator = z.object({
 
 const serviceNoticationValidator = z.object({
   id: z.string(),
-  app_id: z.string(),
-  app_name: z.string(),
   app_revision_id: z.string(),
   error: z.object({
     code: z.number(),
@@ -85,8 +83,6 @@ const serviceNoticationValidator = z.object({
 });
 const revisionNotificationValidator = z.object({
   id: z.string(),
-  app_id: z.string(),
-  app_name: z.string(),
   app_revision_id: z.string(),
   error: z.object({
     code: z.number(),
@@ -100,8 +96,6 @@ const revisionNotificationValidator = z.object({
 });
 const applicationNotificationValidator = z.object({
   id: z.string(),
-  app_id: z.string(),
-  app_name: z.string(),
   app_revision_id: z.string(),
   error: z.object({
     code: z.number(),

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -1117,6 +1117,19 @@ const getLatestRevision = baseApi<
   return `/api/projects/${project_id}/clusters/${cluster_id}/apps/${porter_app_name}/latest`;
 });
 
+const appNotifications = baseApi<
+  {
+    deployment_target_id: string;
+  },
+  {
+    project_id: number;
+    cluster_id: number;
+    porter_app_name: string;
+  }
+>("GET", ({ project_id, cluster_id, porter_app_name }) => {
+  return `/api/projects/${project_id}/clusters/${cluster_id}/apps/${porter_app_name}/notifications`;
+});
+
 const getRevision = baseApi<
   {},
   {
@@ -3396,6 +3409,7 @@ export default {
   revertApp,
   getAttachedEnvGroups,
   getLatestRevision,
+  appNotifications,
   getRevision,
   listAppRevisions,
   getLatestAppRevisions,

--- a/internal/porter_app/notifications/notification.go
+++ b/internal/porter_app/notifications/notification.go
@@ -8,10 +8,6 @@ import (
 
 // Notification is a struct that contains all actionable information from an app event
 type Notification struct {
-	// AppID is the ID of the app
-	AppID string `json:"app_id"`
-	// AppName is the name of the app
-	AppName string `json:"app_name"`
 	// AppRevisionID is the ID of the app revision that the notification belongs to
 	AppRevisionID string `json:"app_revision_id"`
 	// Error is the Porter error parsed from the agent event


### PR DESCRIPTION
Currently, notifications are fetched with each call to latestAppRevision. In the future, we may want to retrieve notifications for different app revisions, so it doesn't make much sense to bundle the two objects in the same endpoint. These changes separate the get notifications call into its own endpoint.