### PR TITLE
implement porter app manifests command

### DIFF
--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -177,6 +177,26 @@ func (c *Client) ParseYAML(
 	return resp, err
 }
 
+// GetAppManifests returns the manifests for a given app based on the latest successful app revision
+func (c *Client) GetAppManifests(
+	ctx context.Context,
+	projectID, clusterID uint,
+	appName string,
+) (*porter_app.GetAppManifestsResponse, error) {
+	resp := &porter_app.GetAppManifestsResponse{}
+
+	err := c.getRequest(
+		fmt.Sprintf(
+			"/projects/%d/clusters/%d/apps/%s/manifests",
+			projectID, clusterID, appName,
+		),
+		nil,
+		resp,
+	)
+
+	return resp, err
+}
+
 // ValidatePorterAppInput is the input struct to ValidatePorterApp
 type ValidatePorterAppInput struct {
 	ProjectID          uint

--- a/api/client/porter_app.go
+++ b/api/client/porter_app.go
@@ -182,8 +182,8 @@ func (c *Client) GetAppManifests(
 	ctx context.Context,
 	projectID, clusterID uint,
 	appName string,
-) (*porter_app.GetAppManifestsResponse, error) {
-	resp := &porter_app.GetAppManifestsResponse{}
+) (*porter_app.AppManifestsResponse, error) {
+	resp := &porter_app.AppManifestsResponse{}
 
 	err := c.getRequest(
 		fmt.Sprintf(

--- a/api/server/handlers/porter_app/manifests.go
+++ b/api/server/handlers/porter_app/manifests.go
@@ -20,47 +20,42 @@ import (
 	"github.com/porter-dev/porter/internal/models"
 )
 
-// GetAppManifestsHandler handles requests to the /apps/{porter_app_name}/manifests endpoint
-type GetAppManifestsHandler struct {
+// AppManifestsHandler handles requests to the /apps/{porter_app_name}/manifests endpoint
+type AppManifestsHandler struct {
 	handlers.PorterHandlerReadWriter
 	authz.KubernetesAgentGetter
 }
 
-// NewGetAppManifestsHandler returns a new GetAppManifestsHandler
-func NewGetAppManifestsHandler(
+// NewAppManifestsHandler returns a new AppManifestsHandler
+func NewAppManifestsHandler(
 	config *config.Config,
 	decoderValidator shared.RequestDecoderValidator,
 	writer shared.ResultWriter,
-) *GetAppManifestsHandler {
-	return &GetAppManifestsHandler{
+) *AppManifestsHandler {
+	return &AppManifestsHandler{
 		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
 		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
 	}
 }
 
-// GetAppManifestsRequest is the request object for the /apps/{porter_app_name}/manifests endpoint
-type GetAppManifestsRequest struct {
+// AppManifestsRequest is the request object for the /apps/{porter_app_name}/manifests endpoint
+type AppManifestsRequest struct {
 	DeploymentTargetID string `schema:"deployment_target_id"`
 }
 
-// GetAppManifestsResponse is the response object for the /apps/{porter_app_name}/manifests endpoint
-type GetAppManifestsResponse struct {
+// AppManifestsResponse is the response object for the /apps/{porter_app_name}/manifests endpoint
+type AppManifestsResponse struct {
 	// Base64Manifests is the base64 encoded manifests
 	Base64Manifests string `json:"base64_manifests"`
 }
 
 // ServeHTTP translates the request into a TemplateAppManifests grpc request, forwards to the cluster control plane, and returns the response.
-func (c *GetAppManifestsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (c *AppManifestsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, span := telemetry.NewSpan(r.Context(), "serve-app-manifests")
 	defer span.End()
 
 	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
 	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
-
-	telemetry.WithAttributes(span,
-		telemetry.AttributeKV{Key: "project-id", Value: project.ID},
-		telemetry.AttributeKV{Key: "cluster-id", Value: cluster.ID},
-	)
 
 	appName, reqErr := requestutils.GetURLParamString(r, types.URLParamPorterAppName)
 	if reqErr != nil {
@@ -71,7 +66,7 @@ func (c *GetAppManifestsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
 
-	request := &GetAppManifestsRequest{}
+	request := &AppManifestsRequest{}
 	if ok := c.DecodeAndValidate(w, r, request); !ok {
 		err := telemetry.Error(ctx, span, nil, "error decoding request")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
@@ -109,7 +104,7 @@ func (c *GetAppManifestsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	response := GetAppManifestsResponse{
+	response := AppManifestsResponse{
 		Base64Manifests: appManifestsRes.Msg.Base64Manifests,
 	}
 

--- a/api/server/handlers/porter_app/manifests.go
+++ b/api/server/handlers/porter_app/manifests.go
@@ -1,0 +1,117 @@
+package porter_app
+
+import (
+	"net/http"
+
+	"github.com/porter-dev/porter/api/server/authz"
+	"github.com/porter-dev/porter/api/server/shared/requestutils"
+
+	"connectrpc.com/connect"
+
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+
+	"github.com/porter-dev/porter/internal/telemetry"
+
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+)
+
+// GetAppManifestsHandler handles requests to the /apps/{porter_app_name}/manifests endpoint
+type GetAppManifestsHandler struct {
+	handlers.PorterHandlerReadWriter
+	authz.KubernetesAgentGetter
+}
+
+// NewGetAppManifestsHandler returns a new GetAppManifestsHandler
+func NewGetAppManifestsHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *GetAppManifestsHandler {
+	return &GetAppManifestsHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+		KubernetesAgentGetter:   authz.NewOutOfClusterAgentGetter(config),
+	}
+}
+
+// GetAppManifestsRequest is the request object for the /apps/{porter_app_name}/manifests endpoint
+type GetAppManifestsRequest struct {
+	DeploymentTargetID string `schema:"deployment_target_id"`
+}
+
+// GetAppManifestsResponse is the response object for the /apps/{porter_app_name}/manifests endpoint
+type GetAppManifestsResponse struct {
+	// Base64Manifests is the base64 encoded manifests
+	Base64Manifests string `json:"base64_manifests"`
+}
+
+// ServeHTTP translates the request into a TemplateAppManifests grpc request, forwards to the cluster control plane, and returns the response.
+func (c *GetAppManifestsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-app-manifests")
+	defer span.End()
+
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "project-id", Value: project.ID},
+		telemetry.AttributeKV{Key: "cluster-id", Value: cluster.ID},
+	)
+
+	appName, reqErr := requestutils.GetURLParamString(r, types.URLParamPorterAppName)
+	if reqErr != nil {
+		e := telemetry.Error(ctx, span, reqErr, "error parsing stack name from url")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(e, http.StatusBadRequest))
+		return
+	}
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
+
+	request := &GetAppManifestsRequest{}
+	if ok := c.DecodeAndValidate(w, r, request); !ok {
+		err := telemetry.Error(ctx, span, nil, "error decoding request")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	// optional deployment target id - if not provided, use the cluster's default
+	deploymentTargetID := request.DeploymentTargetID
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: deploymentTargetID})
+
+	var deploymentTargetIdentifer *porterv1.DeploymentTargetIdentifier
+	if deploymentTargetID != "" {
+		deploymentTargetIdentifer = &porterv1.DeploymentTargetIdentifier{
+			Id: deploymentTargetID,
+		}
+	}
+
+	appManifestsReq := connect.NewRequest(&porterv1.TemplateAppManifestsRequest{
+		ProjectId:                  int64(project.ID),
+		ClusterId:                  int64(cluster.ID),
+		AppName:                    appName,
+		DeploymentTargetIdentifier: deploymentTargetIdentifer,
+	})
+
+	appManifestsRes, err := c.Config().ClusterControlPlaneClient.TemplateAppManifests(ctx, appManifestsReq)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error getting current app manifests from cluster control plane client")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	if appManifestsRes == nil || appManifestsRes.Msg == nil {
+		err := telemetry.Error(ctx, span, err, "current app manifests resp is nil")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	response := GetAppManifestsResponse{
+		Base64Manifests: appManifestsRes.Msg.Base64Manifests,
+	}
+
+	c.WriteResult(w, r, response)
+}

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -647,7 +647,7 @@ func getPorterAppRoutes(
 		},
 	)
 
-	getAppManifestsHandler := porter_app.NewGetAppManifestsHandler(
+	getAppManifestsHandler := porter_app.NewAppManifestsHandler(
 		config,
 		factory.GetDecoderValidator(),
 		factory.GetResultWriter(),

--- a/api/server/router/porter_app.go
+++ b/api/server/router/porter_app.go
@@ -630,6 +630,35 @@ func getPorterAppRoutes(
 		Router:   r,
 	})
 
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/manifests -> porter_app.NewGetAppManifestsHandler
+	getAppManifestsEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("%s/{%s}/manifests", relPathV2, types.URLParamPorterAppName),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	getAppManifestsHandler := porter_app.NewGetAppManifestsHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: getAppManifestsEndpoint,
+		Handler:  getAppManifestsHandler,
+		Router:   r,
+	})
+
 	// GET /api/projects/{project_id}/clusters/{cluster_id}/apps/{porter_app_name}/env-variables -> porter_app.AppEnvVariablesHandler
 	appEnvVariablesEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{

--- a/cli/cmd/commands/app.go
+++ b/cli/cmd/commands/app.go
@@ -134,7 +134,7 @@ func registerCommand_App(cliConf config.CLIConfig) *cobra.Command {
 	appManifestsCmd := &cobra.Command{
 		Use:   "manifests [application]",
 		Args:  cobra.MinimumNArgs(1),
-		Short: "Prints the manifests for an application.",
+		Short: "Prints the kubernetes manifests for an application.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return checkLoginAndRunWithConfig(cmd, cliConf, args, appManifests)
 		},

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.80
+	github.com/porter-dev/api-contracts v0.2.83
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.80 h1:Ufa0d64kO+XhrZcANje2vltCbgn7WzsIafo3p3cu+jE=
-github.com/porter-dev/api-contracts v0.2.80/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.83 h1:UndRYlFMUbDa6oZaMpE8Q8sUpEfq+MOOf4pP/7MX1gw=
+github.com/porter-dev/api-contracts v0.2.83/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
## What does this PR do?

- Usage: `porter app manifests [app-name]`
- Returns raw k8s manifests for the app and any attached env groups and prints them to stdout

![Screenshot 2024-01-04 at 6 51 54 PM](https://github.com/porter-dev/porter/assets/104453631/2a9c7aa7-5c07-4340-a5f9-ce66c42e55c3)
