### PR TITLE
add general instance metric to validate apply dashboards

### DIFF
--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/types.ts
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/types.ts
@@ -9,7 +9,8 @@ export type MetricType =
   | "network"
   | "nginx:status"
   | "nginx:errors"
-  | "hpa_replicas";
+  | "hpa_replicas"
+  | "replicas";
 export type Metric = {
   type: MetricType;
   label: string;

--- a/dashboard/src/main/home/app-dashboard/expanded-app/metrics/utils.ts
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/metrics/utils.ts
@@ -5,12 +5,12 @@ import {
   type AvailableMetrics,
   type GenericMetricResponse,
   type MetricsCPUDataResponse,
-  type MetricsHpaReplicasDataResponse,
   type MetricsMemoryDataResponse,
   type MetricsNetworkDataResponse,
   type MetricsNGINXErrorsDataResponse,
   type MetricsNGINXLatencyDataResponse,
   type MetricsNGINXStatusDataResponse,
+  type MetricsReplicasDataResponse,
   type NormalizedMetricsData,
   type NormalizedNginxStatusMetricsData,
 } from "main/home/cluster-dashboard/expanded-chart/metrics/types";
@@ -148,8 +148,9 @@ export class MetricNormalizer {
     ) {
       return this.parseNGINXLatencyMetrics(this.metric_results);
     }
-    if (this.kind.includes("hpa_replicas")) {
-      return this.parseHpaReplicaMetrics(this.metric_results);
+    // covers replicas and hpa_replicas
+    if (this.kind.includes("replicas")) {
+      return this.parseReplicaMetrics(this.metric_results);
     }
     return [];
   }
@@ -265,9 +266,7 @@ export class MetricNormalizer {
     });
   }
 
-  private parseHpaReplicaMetrics(
-    arr: MetricsHpaReplicasDataResponse["results"]
-  ) {
+  private parseReplicaMetrics(arr: MetricsReplicasDataResponse["results"]) {
     return arr.map((d) => {
       return {
         date: d.date,

--- a/dashboard/src/main/home/app-dashboard/validate-apply/metrics/MetricsSection.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/metrics/MetricsSection.tsx
@@ -126,9 +126,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
       }
     }
 
-    if (isHpaEnabled) {
-      metricTypes.push("hpa_replicas");
-    }
+    metricTypes.push("replicas");
 
     return [serviceName, serviceKind, metricTypes, isHpaEnabled];
   }, [selectedFilterValues.service_name]);
@@ -269,7 +267,7 @@ const MetricsSection: React.FunctionComponent<PropsType> = ({
               aggregatedData: allPodsAggregatedData,
               hpaData,
             }))
-            .with("hpa_replicas", () => ({
+            .with("replicas", () => ({
               type: metricType,
               label: "Number of replicas",
               data,

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricNormalizer.ts
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/MetricNormalizer.ts
@@ -5,12 +5,12 @@ import {
   type AvailableMetrics,
   type GenericMetricResponse,
   type MetricsCPUDataResponse,
-  type MetricsHpaReplicasDataResponse,
   type MetricsMemoryDataResponse,
   type MetricsNetworkDataResponse,
   type MetricsNGINXErrorsDataResponse,
   type MetricsNGINXLatencyDataResponse,
   type MetricsNGINXStatusDataResponse,
+  type MetricsReplicasDataResponse,
   type NormalizedMetricsData,
   type NormalizedNginxStatusMetricsData,
 } from "./types";
@@ -163,9 +163,7 @@ export class MetricNormalizer {
     });
   }
 
-  private parseHpaReplicaMetrics(
-    arr: MetricsHpaReplicasDataResponse["results"]
-  ) {
+  private parseHpaReplicaMetrics(arr: MetricsReplicasDataResponse["results"]) {
     return arr.map((d) => {
       return {
         date: d.date,

--- a/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/types.ts
+++ b/dashboard/src/main/home/cluster-dashboard/expanded-chart/metrics/types.ts
@@ -50,7 +50,7 @@ export type MetricsNGINXStatusDataResponse = {
   }>;
 };
 
-export type MetricsHpaReplicasDataResponse = {
+export type MetricsReplicasDataResponse = {
   pod?: string;
   results: Array<{
     date: number;

--- a/internal/kubernetes/prometheus/metrics.go
+++ b/internal/kubernetes/prometheus/metrics.go
@@ -234,6 +234,8 @@ func QueryPrometheus(
 		}
 
 		query = createHPACurrentReplicasQuery(metricName, opts.Name, opts.Namespace, appLabel, hpaMetricName)
+	} else if opts.Metric == "replicas" {
+		query = fmt.Sprintf(`kube_deployment_status_replicas{deployment="%s"}`, opts.Name)
 	}
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "query", Value: query})
@@ -362,6 +364,8 @@ func parseQuery(rawQuery []byte, metric string) ([]*promParsedSingletonQuery, er
 				singletonResult.Replicas = values[1]
 			} else if metric == "nginx:latency" || metric == "nginx:latency-histogram" {
 				singletonResult.Latency = values[1]
+			} else if metric == "replicas" {
+				singletonResult.Replicas = values[1]
 			}
 
 			singletonResults = append(singletonResults, *singletonResult)


### PR DESCRIPTION
Add a replica count graph to every dashboard: this will allow KEDA users to monitor scaling while we are building out the support.