### PR TITLE
gate addons till gitea is enabled

### DIFF
--- a/dashboard/src/main/home/cluster-dashboard/preview-environments/v2/setup-app/PreviewAppDataContainer.tsx
+++ b/dashboard/src/main/home/cluster-dashboard/preview-environments/v2/setup-app/PreviewAppDataContainer.tsx
@@ -328,7 +328,7 @@ export const PreviewAppDataContainer: React.FC<Props> = ({
           ...(currentProject?.beta_features_enabled
             ? [
                 { label: "Required Apps", value: "required-apps" },
-                { label: "Add-ons", value: "addons" },
+                // { label: "Add-ons", value: "addons" },
               ]
             : []),
         ]}


### PR DESCRIPTION
## What does this PR do?

- Now that everyone is on update, need to stress test Gitea in prod before allowing preview addons to be used in GA
