### PR TITLE
add deployment target scope to Porter API

### DIFF
--- a/api/server/authz/deployment_target.go
+++ b/api/server/authz/deployment_target.go
@@ -1,0 +1,79 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"gorm.io/gorm"
+)
+
+// DeploymentTargetScopedFactory is a factory for generating deployment target middleware
+type DeploymentTargetScopedFactory struct {
+	config *config.Config
+}
+
+// NewDeploymentTargetScopedFactory returns a new DeploymentTargetScopedFactory
+func NewDeploymentTargetScopedFactory(
+	config *config.Config,
+) *DeploymentTargetScopedFactory {
+	return &DeploymentTargetScopedFactory{config}
+}
+
+// Middleware checks that the request is scoped to a deployment target
+func (p *DeploymentTargetScopedFactory) Middleware(next http.Handler) http.Handler {
+	return &DeploymentTargetScopedMiddleware{next, p.config}
+}
+
+// DeploymentTargetScopedMiddleware checks that the request is scoped to a deployment target
+type DeploymentTargetScopedMiddleware struct {
+	next   http.Handler
+	config *config.Config
+}
+
+// ServeHTTP checks that the request is scoped to a deployment target
+func (p *DeploymentTargetScopedMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// read the project to check scopes
+	proj, _ := r.Context().Value(types.ProjectScope).(*models.Project)
+
+	// get the deployment target identifier from the URL param context
+	reqScopes, _ := r.Context().Value(types.RequestScopeCtxKey).(map[types.PermissionScope]*types.RequestAction)
+	deploymentTargetIdentifier := reqScopes[types.DeploymentTargetScope].Resource.Name
+
+	deploymentTargetDB, err := p.config.Repo.DeploymentTarget().DeploymentTarget(proj.ID, deploymentTargetIdentifier)
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			apierrors.HandleAPIError(p.config.Logger, p.config.Alerter, w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError), true)
+			return
+		}
+		err := fmt.Errorf("deployment target with identifier %s not found in project %d", deploymentTargetIdentifier, proj.ID)
+		apierrors.HandleAPIError(p.config.Logger, p.config.Alerter, w, r, apierrors.NewErrPassThroughToClient(err, http.StatusForbidden), true)
+		return
+	}
+
+	deploymentTarget := types.DeploymentTarget{
+		ID:           deploymentTargetDB.ID,
+		ProjectID:    uint(deploymentTargetDB.ProjectID),
+		ClusterID:    uint(deploymentTargetDB.ClusterID),
+		Name:         deploymentTargetDB.VanityName,
+		Namespace:    deploymentTargetDB.Selector,
+		IsPreview:    deploymentTargetDB.Preview,
+		IsDefault:    deploymentTargetDB.IsDefault,
+		CreatedAtUTC: deploymentTargetDB.CreatedAt.UTC(),
+		UpdatedAtUTC: deploymentTargetDB.UpdatedAt.UTC(),
+	}
+
+	ctx := NewDeploymentTargetContext(r.Context(), deploymentTarget)
+	r = r.Clone(ctx)
+	p.next.ServeHTTP(w, r)
+}
+
+// NewDeploymentTargetContext returns a new context with the deployment target
+func NewDeploymentTargetContext(ctx context.Context, deploymentTarget types.DeploymentTarget) context.Context {
+	return context.WithValue(ctx, types.DeploymentTargetScope, deploymentTarget)
+}

--- a/api/server/authz/policy.go
+++ b/api/server/authz/policy.go
@@ -122,6 +122,8 @@ func getRequestActionForEndpoint(
 			resource.UInt, reqErr = requestutils.GetURLParamUint(r, types.URLParamProjectID)
 		case types.ClusterScope:
 			resource.UInt, reqErr = requestutils.GetURLParamUint(r, types.URLParamClusterID)
+		case types.DeploymentTargetScope:
+			resource.Name, reqErr = requestutils.GetURLParamString(r, types.URLParamDeploymentTargetIdentifier)
 		case types.RegistryScope:
 			resource.UInt, reqErr = requestutils.GetURLParamUint(r, types.URLParamRegistryID)
 		case types.HelmRepoScope:

--- a/api/server/handlers/porter_app/default_deployment_target.go
+++ b/api/server/handlers/porter_app/default_deployment_target.go
@@ -130,15 +130,15 @@ func defaultDeploymentTarget(ctx context.Context, input defaultDeploymentTargetI
 	}
 
 	defaultDeploymentTarget = types.DeploymentTarget{
-		ID:        id,
-		ProjectID: uint(deploymentTargetProto.ProjectId),
-		ClusterID: uint(deploymentTargetProto.ClusterId),
-		Name:      deploymentTargetProto.Name,
-		Namespace: deploymentTargetProto.Namespace,
-		IsPreview: deploymentTargetProto.IsPreview,
-		IsDefault: deploymentTargetProto.IsDefault,
-		CreatedAt: time.Time{}, // not provided by default deployment target response
-		UpdatedAt: time.Time{}, // not provided by default deployment target response
+		ID:           id,
+		ProjectID:    uint(deploymentTargetProto.ProjectId),
+		ClusterID:    uint(deploymentTargetProto.ClusterId),
+		Name:         deploymentTargetProto.Name,
+		Namespace:    deploymentTargetProto.Namespace,
+		IsPreview:    deploymentTargetProto.IsPreview,
+		IsDefault:    deploymentTargetProto.IsDefault,
+		CreatedAtUTC: time.Time{}, // not provided by default deployment target response
+		UpdatedAtUTC: time.Time{}, // not provided by default deployment target response
 	}
 
 	return defaultDeploymentTarget, nil

--- a/api/server/router/deployment_target_legacy.go
+++ b/api/server/router/deployment_target_legacy.go
@@ -1,0 +1,181 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/porter-dev/porter/api/server/handlers/deployment_target"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/server/shared/router"
+	"github.com/porter-dev/porter/api/types"
+)
+
+// NewLegacyDeploymentTargetScopedRegisterer applies /api/projects/{project_id}/clusters/{cluster_id}/deployment-targets routes to the gin Router
+// Deprecated: use NewDeploymentTargetScopedRegisterer instead
+func NewLegacyDeploymentTargetScopedRegisterer(children ...*router.Registerer) *router.Registerer {
+	return &router.Registerer{
+		GetRoutes: GetLegacyDeploymentTargetScopedRoutes,
+		Children:  children,
+	}
+}
+
+// GetLegacyDeploymentTargetScopedRoutes returns the router handlers specific to deployment targets
+// Deprecated: use GetDeploymentTargetScopedRoutes instead, which are not scoped by cluster
+func GetLegacyDeploymentTargetScopedRoutes(
+	r chi.Router,
+	config *config.Config,
+	basePath *types.Path,
+	factory shared.APIEndpointFactory,
+	children ...*router.Registerer,
+) []*router.Route {
+	routes, projPath := getLegacyDeploymentTargetRoutes(r, config, basePath, factory)
+
+	if len(children) > 0 {
+		r.Route(projPath.RelativePath, func(r chi.Router) {
+			for _, child := range children {
+				childRoutes := child.GetRoutes(r, config, basePath, factory, child.Children...)
+
+				routes = append(routes, childRoutes...)
+			}
+		})
+	}
+
+	return routes
+}
+
+// getLegacyDeploymentTargetRoutes gets the routes specific to deployment targets
+// Deprecated: use getDeploymentTargetRoutes instead, which are not scoped by cluster
+func getLegacyDeploymentTargetRoutes(
+	r chi.Router,
+	config *config.Config,
+	basePath *types.Path,
+	factory shared.APIEndpointFactory,
+) ([]*router.Route, *types.Path) {
+	relPath := "/deployment-targets"
+
+	newPath := &types.Path{
+		Parent:       basePath,
+		RelativePath: relPath,
+	}
+
+	var routes []*router.Route
+
+	// POST /api/projects/{project_id}/clusters/{cluster_id}/deployment-targets -> deployment_target.CreateDeploymentTargetHandler
+	createDeploymentTargetEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbCreate,
+			Method: types.HTTPVerbPost,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: relPath,
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	createDeploymentTargetHandler := deployment_target.NewCreateDeploymentTargetHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: createDeploymentTargetEndpoint,
+		Handler:  createDeploymentTargetHandler,
+		Router:   r,
+	})
+
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/deployment-targets -> deployment_target.ListDeploymentTargetsHandler
+	listDeploymentTargetsEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbList,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: relPath,
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	listDeploymentTargetsHandler := deployment_target.NewListDeploymentTargetsHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: listDeploymentTargetsEndpoint,
+		Handler:  listDeploymentTargetsHandler,
+		Router:   r,
+	})
+
+	// DELETE /api/projects/{project_id}/clusters/{cluster_id}/deployment-targets/{deployment_target_id} -> deployment_target.DeleteDeploymentTargetHandler
+	deleteDeploymentTargetEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbDelete,
+			Method: types.HTTPVerbDelete,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("%s/{%s}", relPath, types.URLParamDeploymentTargetID),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	deleteDeploymentTargetHandler := deployment_target.NewDeleteDeploymentTargetHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: deleteDeploymentTargetEndpoint,
+		Handler:  deleteDeploymentTargetHandler,
+		Router:   r,
+	})
+
+	// GET /api/projects/{project_id}/clusters/{cluster_id}/deployment-targets/{deployment_target_id} -> deployment_target.GetDeploymentTargetHandler
+	getDeploymentTargetEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: fmt.Sprintf("%s/{%s}", relPath, types.URLParamDeploymentTargetID),
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+				types.ClusterScope,
+			},
+		},
+	)
+
+	getDeploymentTargetHandler := deployment_target.NewGetDeploymentTargetHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: getDeploymentTargetEndpoint,
+		Handler:  getDeploymentTargetHandler,
+		Router:   r,
+	})
+
+	return routes, newPath
+}

--- a/api/types/deployment_target.go
+++ b/api/types/deployment_target.go
@@ -12,10 +12,10 @@ type DeploymentTarget struct {
 	ProjectID uint      `json:"project_id"`
 	ClusterID uint      `json:"cluster_id"`
 
-	Name      string    `json:"name"`
-	Namespace string    `json:"namespace"`
-	IsPreview bool      `json:"is_preview"`
-	IsDefault bool      `json:"is_default"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Name         string    `json:"name"`
+	Namespace    string    `json:"namespace"`
+	IsPreview    bool      `json:"is_preview"`
+	IsDefault    bool      `json:"is_default"`
+	CreatedAtUTC time.Time `json:"created_at"`
+	UpdatedAtUTC time.Time `json:"updated_at"`
 }

--- a/api/types/policy.go
+++ b/api/types/policy.go
@@ -8,6 +8,7 @@ const (
 	UserScope                PermissionScope = "user"
 	ProjectScope             PermissionScope = "project"
 	ClusterScope             PermissionScope = "cluster"
+	DeploymentTargetScope    PermissionScope = "target"
 	RegistryScope            PermissionScope = "registry"
 	InviteScope              PermissionScope = "invite"
 	HelmRepoScope            PermissionScope = "helm_repo"

--- a/api/types/request.go
+++ b/api/types/request.go
@@ -58,7 +58,9 @@ const (
 	URLParamCloudProviderType     URLParam = "cloud_provider_type"
 	URLParamCloudProviderID       URLParam = "cloud_provider_id"
 	URLParamDeploymentTargetID    URLParam = "deployment_target_id"
-	URLParamWebhookID             URLParam = "webhook_id"
+	// URLParamDeploymentTargetIdentifier can be either the deployment target id or deployment target name
+	URLParamDeploymentTargetIdentifier URLParam = "deployment_target_identifier"
+	URLParamWebhookID                  URLParam = "webhook_id"
 )
 
 type Path struct {

--- a/internal/models/deployment_target.go
+++ b/internal/models/deployment_target.go
@@ -49,14 +49,14 @@ type DeploymentTarget struct {
 // ToDeploymentTargetType generates an external types.PorterApp to be shared over REST
 func (d *DeploymentTarget) ToDeploymentTargetType() *types.DeploymentTarget {
 	return &types.DeploymentTarget{
-		ID:        d.ID,
-		ProjectID: uint(d.ProjectID),
-		ClusterID: uint(d.ClusterID),
-		Namespace: d.Selector,
-		IsPreview: d.Preview,
-		IsDefault: d.IsDefault,
-		Name:      d.VanityName,
-		CreatedAt: d.CreatedAt,
-		UpdatedAt: d.UpdatedAt,
+		ID:           d.ID,
+		ProjectID:    uint(d.ProjectID),
+		ClusterID:    uint(d.ClusterID),
+		Namespace:    d.Selector,
+		IsPreview:    d.Preview,
+		IsDefault:    d.IsDefault,
+		Name:         d.VanityName,
+		CreatedAtUTC: d.CreatedAt,
+		UpdatedAtUTC: d.UpdatedAt,
 	}
 }

--- a/internal/repository/deployment_target.go
+++ b/internal/repository/deployment_target.go
@@ -12,4 +12,6 @@ type DeploymentTargetRepository interface {
 	List(projectID uint, clusterID uint, preview bool) ([]*models.DeploymentTarget, error)
 	// CreateDeploymentTarget creates a new deployment target
 	CreateDeploymentTarget(deploymentTarget *models.DeploymentTarget) (*models.DeploymentTarget, error)
+	// DeploymentTarget retrieves a deployment target by its id if a uuid is provided or by name
+	DeploymentTarget(projectID uint, deploymentTargetIdentifier string) (*models.DeploymentTarget, error)
 }

--- a/internal/repository/gorm/deployment_target.go
+++ b/internal/repository/gorm/deployment_target.go
@@ -42,6 +42,27 @@ func (repo *DeploymentTargetRepository) List(projectID uint, clusterID uint, pre
 	return deploymentTargets, nil
 }
 
+// DeploymentTarget finds all deployment targets for a given project
+func (repo *DeploymentTargetRepository) DeploymentTarget(projectID uint, deploymentTargetIdentifier string) (*models.DeploymentTarget, error) {
+	if deploymentTargetIdentifier == "" {
+		return nil, errors.New("deployment target identifier is empty")
+	}
+
+	whereArg := "project_id = ? AND id = ?"
+
+	_, err := uuid.Parse(deploymentTargetIdentifier)
+	if err != nil {
+		whereArg = "project_id = ? AND vanity_name = ?"
+	}
+
+	deploymentTarget := &models.DeploymentTarget{}
+	if err := repo.db.Where(whereArg, projectID, deploymentTargetIdentifier).Find(deploymentTarget).Error; err != nil {
+		return nil, err
+	}
+
+	return deploymentTarget, nil
+}
+
 // CreateDeploymentTarget creates a new deployment target
 func (repo *DeploymentTargetRepository) CreateDeploymentTarget(deploymentTarget *models.DeploymentTarget) (*models.DeploymentTarget, error) {
 	if deploymentTarget == nil {

--- a/internal/repository/test/deployment_target.go
+++ b/internal/repository/test/deployment_target.go
@@ -31,3 +31,8 @@ func (repo *DeploymentTargetRepository) List(projectID uint, clusterID uint, pre
 func (repo *DeploymentTargetRepository) CreateDeploymentTarget(deploymentTarget *models.DeploymentTarget) (*models.DeploymentTarget, error) {
 	return nil, errors.New("cannot write database")
 }
+
+// DeploymentTarget finds a deployment target by its id if a uuid is provided or by name
+func (repo *DeploymentTargetRepository) DeploymentTarget(projectID uint, deploymentTargetIdentifier string) (*models.DeploymentTarget, error) {
+	return nil, errors.New("cannot read database")
+}


### PR DESCRIPTION
You can use either `id` or `vanity_name` as the identifier

![Screenshot 2024-01-25 at 11 45 14 AM](https://github.com/porter-dev/porter/assets/66391417/8bcd93a7-d030-4777-a323-7412017a441d)
![Screenshot 2024-01-25 at 11 45 00 AM](https://github.com/porter-dev/porter/assets/66391417/cec074a5-f83b-4a5f-8b6c-8aeab4794d3f)
