### PR TITLE
remove condition disabling save if revision is in created state

### DIFF
--- a/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppDataContainer.tsx
@@ -595,9 +595,7 @@ const AppDataContainer: React.FC<AppDataContainerProps> = ({ tabParam }) => {
                 <AppSaveButton
                   height={"10px"}
                   status={isSubmitting ? "loading" : ""}
-                  isDisabled={
-                    isSubmitting || latestRevision.status === "CREATED"
-                  }
+                  isDisabled={isSubmitting}
                   disabledTooltipMessage="Please wait for the deploy to complete before updating the app"
                   disabledTooltipPosition="bottom"
                 />

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/BuildSettingsTab.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/BuildSettingsTab.tsx
@@ -19,7 +19,7 @@ const BuildSettingsTab: React.FC<Props> = ({ buttonStatus }) => {
     watch,
     formState: { isSubmitting },
   } = useFormContext<PorterAppFormData>();
-  const { projectId, latestRevision } = useLatestRevision();
+  const { projectId } = useLatestRevision();
 
   const build = watch("app.build");
   const source = watch("source");
@@ -38,7 +38,7 @@ const BuildSettingsTab: React.FC<Props> = ({ buttonStatus }) => {
             <Spacer y={1} />
             <AppSaveButton
               status={buttonStatus}
-              isDisabled={isSubmitting || latestRevision.status === "CREATED"}
+              isDisabled={isSubmitting}
               disabledTooltipMessage="Please wait for the build to complete before updating build settings"
             />
           </>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Environment.tsx
@@ -73,7 +73,7 @@ const Environment: React.FC<Props> = ({ latestSource, buttonStatus }) => {
       <Spacer y={0.5} />
       <AppSaveButton
         status={buttonStatus}
-        isDisabled={isSubmitting || latestRevision.status === "CREATED"}
+        isDisabled={isSubmitting}
         disabledTooltipMessage="Please wait for the deploy to complete before updating environment variables"
       />
     </>

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/HelmEditorTab.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/HelmEditorTab.tsx
@@ -26,14 +26,8 @@ const HelmEditorTab: React.FC<Props> = ({
   } = useFormContext<PorterAppFormData>();
 
   const overrides = watch("app.helmOverrides");
-  const {
-    projectId,
-    clusterId,
-    latestProto,
-    deploymentTarget,
-    porterApp,
-    latestRevision,
-  } = useLatestRevision();
+  const { projectId, clusterId, latestProto, deploymentTarget, porterApp } =
+    useLatestRevision();
 
   const appName = latestProto.name;
 
@@ -60,9 +54,7 @@ const HelmEditorTab: React.FC<Props> = ({
       <Spacer y={1} />
       <AppSaveButton
         status={buttonStatus}
-        isDisabled={
-          isSubmitting || latestRevision.status === "CREATED" || error !== ""
-        }
+        isDisabled={isSubmitting || error !== ""}
         disabledTooltipMessage={
           error !== ""
             ? "Error parsing yaml"

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/ImageSettingsTab.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/ImageSettingsTab.tsx
@@ -26,7 +26,7 @@ const ImageSettingsTab: React.FC<Props> = ({ buttonStatus }) => {
     formState: { isSubmitting },
     setValue,
   } = useFormContext<PorterAppFormData>();
-  const { projectId, latestRevision, latestProto } = useLatestRevision();
+  const { projectId, latestProto } = useLatestRevision();
 
   const source = watch("source");
 
@@ -54,10 +54,7 @@ const ImageSettingsTab: React.FC<Props> = ({ buttonStatus }) => {
         <AppSaveButton
           status={buttonStatus}
           isDisabled={
-            isSubmitting ||
-            latestRevision.status === "CREATED" ||
-            !source.image?.repository ||
-            !source.image?.tag
+            isSubmitting || !source.image?.repository || !source.image?.tag
           }
           disabledTooltipMessage="Please wait for the deploy to complete before updating image settings"
         />

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/Overview.tsx
@@ -31,7 +31,6 @@ const Overview: React.FC<Props> = ({ buttonStatus }) => {
   const {
     porterApp,
     latestProto,
-    latestRevision,
     projectId,
     clusterId,
     deploymentTarget,
@@ -86,9 +85,7 @@ const Overview: React.FC<Props> = ({ buttonStatus }) => {
       <Spacer y={0.75} />
       <AppSaveButton
         status={buttonStatus}
-        isDisabled={
-          formState.isSubmitting || latestRevision.status === "CREATED"
-        }
+        isDisabled={formState.isSubmitting}
         disabledTooltipMessage="Please wait for the deploy to complete before updating services"
       />
     </>


### PR DESCRIPTION
## What does this PR do?

This is unnecessary now that update is generally available, and if anything could cause issues for users