### PR TITLE
refresh env vars on save for switching tabs

### DIFF
--- a/dashboard/src/main/home/env-dashboard/ExpandedEnv.tsx
+++ b/dashboard/src/main/home/env-dashboard/ExpandedEnv.tsx
@@ -130,7 +130,14 @@ const ExpandedEnv: React.FC = () => {
           />
           <Spacer y={1} />
           {match(tab)
-            .with("env-vars", () => <EnvVarsTab envGroup={envGroup} />)
+            .with("env-vars", () => {
+              return (
+                <EnvVarsTab 
+                  envGroup={envGroup}
+                  fetchEnvGroup={fetchEnvGroup}
+                />
+              );
+            })
             .with("synced-apps", () => <SyncedAppsTab envGroup={envGroup} />)
             .with("settings", () => <SettingsTab envGroup={envGroup} />)
             .otherwise(() => null)}

--- a/dashboard/src/main/home/env-dashboard/tabs/EnvVarsTab.tsx
+++ b/dashboard/src/main/home/env-dashboard/tabs/EnvVarsTab.tsx
@@ -20,9 +20,10 @@ type Props = {
     secret_variables?: Record<string, string>;
     type?: string;
   };
+  fetchEnvGroup: () => void;
 }
 
-const EnvVarsTab: React.FC<Props> = ({ envGroup }) => {
+const EnvVarsTab: React.FC<Props> = ({ envGroup, fetchEnvGroup }) => {
   const { currentProject, currentCluster } = useContext(Context);
   const [buttonStatus, setButtonStatus] = useState<string | React.ReactNode>("");
 
@@ -149,7 +150,7 @@ const EnvVarsTab: React.FC<Props> = ({ envGroup }) => {
           cluster_id: currentCluster?.id || -1,
         }
       );
-
+      fetchEnvGroup();
       setButtonStatus("success");
     } catch (err) {
       const errorMessage =


### PR DESCRIPTION
## POR-

## What does this PR do?
switching to a different tab and switching back on the expanded env group view removes updated contents. now an update refreshes the top-level env group