### PR TITLE
propagate app name to preview app definition

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1523,10 +1523,6 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.99 h1:eHzYSwacLEV5Di2boCnuv8ddoxzvaNCORAD0VOibOBU=
-github.com/porter-dev/api-contracts v0.2.99/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
-github.com/porter-dev/api-contracts v0.2.101 h1:pNPtkTqcr+khUwBfT1z8y86DaVhFIkcHjtD+GL2xCF0=
-github.com/porter-dev/api-contracts v0.2.101/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/api-contracts v0.2.102 h1:iZnwSmBM4gfRqdNXV5t9fFqd/pz5bj49MV+yqXgb46Q=
 github.com/porter-dev/api-contracts v0.2.102/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=

--- a/internal/porter_app/parse.go
+++ b/internal/porter_app/parse.go
@@ -71,14 +71,9 @@ func ParseYAML(ctx context.Context, porterYaml []byte, appName string) (v2.AppWi
 		}
 
 		appDefinition.AppProto.Name = appName
-
-		if appDefinition.PreviewApp != nil && appDefinition.PreviewApp.AppProto != nil {
-			if appDefinition.PreviewApp.AppProto.Name != "" && appDefinition.PreviewApp.AppProto.Name != appName {
-				telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "parsed-preview-name", Value: appDefinition.PreviewApp.AppProto.Name})
-				return appDefinition, telemetry.Error(ctx, span, nil, "name specified in porter.yaml does not match preview app name")
-			}
-			appDefinition.PreviewApp.AppProto.Name = appName
-		}
+	}
+	if appDefinition.PreviewApp != nil && appDefinition.PreviewApp.AppProto != nil {
+		appDefinition.PreviewApp.AppProto.Name = appDefinition.AppProto.Name
 	}
 
 	return appDefinition, nil


### PR DESCRIPTION
## What does this PR do?

- Not specifying PORTER_APP_NAME and also adding a `previews` section caused for the app name on the preview overrides proto to be empty, erroring on hydrate
- This sets the name for the preview app definition to whatever was set for the base app
