### PR TITLE
set preview env explicitly on update request

### DIFF
--- a/api/server/handlers/porter_app/update_app.go
+++ b/api/server/handlers/porter_app/update_app.go
@@ -120,6 +120,7 @@ func (c *UpdateAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var overrides *porterv1.PorterApp
 	appProto := &porterv1.PorterApp{}
 
+	var previewEnvVariables map[string]string
 	envVariables := request.Variables
 
 	// get app definition from either base64 yaml or base64 porter app proto
@@ -180,7 +181,7 @@ func (c *UpdateAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if appFromYaml.PreviewApp != nil {
 			overrides = appFromYaml.PreviewApp.AppProto
 			addonOverrides = appFromYaml.PreviewApp.Addons
-			envVariables = mergeEnvVariables(envVariables, appFromYaml.PreviewApp.EnvVariables)
+			previewEnvVariables = appFromYaml.PreviewApp.EnvVariables
 		}
 
 		addons = appFromYaml.Addons
@@ -249,6 +250,9 @@ func (c *UpdateAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AppEnv: &porterv1.EnvGroupVariables{
 			Normal: envVariables,
 			Secret: request.Secrets,
+		},
+		AppEnvOverrides: &porterv1.EnvGroupVariables{
+			Normal: previewEnvVariables,
 		},
 		Deletions: &porterv1.Deletions{
 			ServiceNames:     request.Deletions.ServiceNames,

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.102
+	github.com/porter-dev/api-contracts v0.2.103
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1523,12 +1523,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.99 h1:eHzYSwacLEV5Di2boCnuv8ddoxzvaNCORAD0VOibOBU=
-github.com/porter-dev/api-contracts v0.2.99/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
-github.com/porter-dev/api-contracts v0.2.101 h1:pNPtkTqcr+khUwBfT1z8y86DaVhFIkcHjtD+GL2xCF0=
-github.com/porter-dev/api-contracts v0.2.101/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
-github.com/porter-dev/api-contracts v0.2.102 h1:iZnwSmBM4gfRqdNXV5t9fFqd/pz5bj49MV+yqXgb46Q=
-github.com/porter-dev/api-contracts v0.2.102/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.103 h1:z6tMxs5aF7owi4SRiFUKN/IzXYkOHKIb5Ekqlw8N5U8=
+github.com/porter-dev/api-contracts v0.2.103/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
## What does this PR do?

- Accounts for case where same key is set in porter.yaml for both base app and preview app, causing for preview app value to always be used regardless of deployment target
- splits preview env out into its own field to be handled separately.
