### PR TITLE
patch/redirect-to-correct-preview-environment-page

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -38,6 +38,7 @@ import NewAddOnFlow from "./add-on-dashboard/NewAddOnFlow";
 import AppView from "./app-dashboard/app-view/AppView";
 import AppDashboard from "./app-dashboard/AppDashboard";
 import Apps from "./app-dashboard/apps/Apps";
+import CreateEnvGroup from "./env-dashboard/CreateEnvGroup";
 import CreateApp from "./app-dashboard/create-app/CreateApp";
 import ExpandedApp from "./app-dashboard/expanded-app/ExpandedApp";
 import NewAppFlow from "./app-dashboard/new-app-flow/NewAppFlow";
@@ -49,9 +50,6 @@ import Dashboard from "./dashboard/Dashboard";
 import CreateDatabase from "./database-dashboard/CreateDatabase";
 import DatabaseDashboard from "./database-dashboard/DatabaseDashboard";
 import DatabaseView from "./database-dashboard/DatabaseView";
-import CreateEnvGroup from "./env-dashboard/CreateEnvGroup";
-import EnvDashboard from "./env-dashboard/EnvDashboard";
-import ExpandedEnv from "./env-dashboard/ExpandedEnv";
 import InfrastructureRouter from "./infrastructure/InfrastructureRouter";
 import Integrations from "./integrations/Integrations";
 import LaunchWrapper from "./launch/LaunchWrapper";
@@ -61,6 +59,9 @@ import { NewProjectFC } from "./new-project/NewProject";
 import Onboarding from "./onboarding/Onboarding";
 import ProjectSettings from "./project-settings/ProjectSettings";
 import Sidebar from "./sidebar/Sidebar";
+import ExpandedEnv from "./env-dashboard/ExpandedEnv";
+import EnvDashboard from "./env-dashboard/EnvDashboard";
+
 
 // Guarded components
 const GuardedProjectSettings = fakeGuardedRoute("settings", "", [

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -62,7 +62,6 @@ import Sidebar from "./sidebar/Sidebar";
 import ExpandedEnv from "./env-dashboard/ExpandedEnv";
 import EnvDashboard from "./env-dashboard/EnvDashboard";
 
-
 // Guarded components
 const GuardedProjectSettings = fakeGuardedRoute("settings", "", [
   "get",

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -38,7 +38,6 @@ import NewAddOnFlow from "./add-on-dashboard/NewAddOnFlow";
 import AppView from "./app-dashboard/app-view/AppView";
 import AppDashboard from "./app-dashboard/AppDashboard";
 import Apps from "./app-dashboard/apps/Apps";
-import CreateEnvGroup from "./env-dashboard/CreateEnvGroup";
 import CreateApp from "./app-dashboard/create-app/CreateApp";
 import ExpandedApp from "./app-dashboard/expanded-app/ExpandedApp";
 import NewAppFlow from "./app-dashboard/new-app-flow/NewAppFlow";
@@ -50,6 +49,9 @@ import Dashboard from "./dashboard/Dashboard";
 import CreateDatabase from "./database-dashboard/CreateDatabase";
 import DatabaseDashboard from "./database-dashboard/DatabaseDashboard";
 import DatabaseView from "./database-dashboard/DatabaseView";
+import CreateEnvGroup from "./env-dashboard/CreateEnvGroup";
+import EnvDashboard from "./env-dashboard/EnvDashboard";
+import ExpandedEnv from "./env-dashboard/ExpandedEnv";
 import InfrastructureRouter from "./infrastructure/InfrastructureRouter";
 import Integrations from "./integrations/Integrations";
 import LaunchWrapper from "./launch/LaunchWrapper";
@@ -59,8 +61,6 @@ import { NewProjectFC } from "./new-project/NewProject";
 import Onboarding from "./onboarding/Onboarding";
 import ProjectSettings from "./project-settings/ProjectSettings";
 import Sidebar from "./sidebar/Sidebar";
-import ExpandedEnv from "./env-dashboard/ExpandedEnv";
-import EnvDashboard from "./env-dashboard/EnvDashboard";
 
 // Guarded components
 const GuardedProjectSettings = fakeGuardedRoute("settings", "", [
@@ -605,10 +605,10 @@ const Home: React.FC<Props> = (props) => {
                       exact
                       path={`/preview-environments/apps/:appName/:tab`}
                     >
-                      <AppView />
+                      <AppView preview />
                     </Route>
                     <Route exact path="/preview-environments/apps/:appName">
-                      <AppView />
+                      <AppView preview />
                     </Route>
                     <Route exact path={`/preview-environments/apps`}>
                       <Apps />

--- a/dashboard/src/main/home/app-dashboard/app-view/AppView.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/AppView.tsx
@@ -28,9 +28,9 @@ export const porterAppValidator = z.object({
 });
 export type PorterAppRecord = z.infer<typeof porterAppValidator>;
 
-type Props = RouteComponentProps;
+type Props = RouteComponentProps & { preview?: boolean };
 
-const AppView: React.FC<Props> = ({ match }) => {
+const AppView: React.FC<Props> = ({ match, preview }) => {
   const params = useMemo(() => {
     const { params } = match;
     const validParams = z
@@ -53,7 +53,7 @@ const AppView: React.FC<Props> = ({ match }) => {
   return (
     <LatestRevisionProvider appName={params.appName}>
       <StyledExpandedApp>
-        <Back to="/apps" />
+        <Back to={preview ? "/preview-environments" : "/apps"} />
         <AppHeader />
         <AppDataContainer tabParam={params.tab} />
       </StyledExpandedApp>


### PR DESCRIPTION
## NA

## What does this PR do?

Clicking the back button on the preview-environments redirects to `/apps` where it should redirect to `/preview-environments`.

![image](https://github.com/porter-dev/porter/assets/13038919/7106eb64-8621-4bad-8453-5bd8ac58790e)


Didn't run or test locally, treat as such 🙏🏻 .
