### PR TITLE
add app name to updated requests with deprected app id

### DIFF
--- a/api/server/handlers/porter_app/app_notifications.go
+++ b/api/server/handlers/porter_app/app_notifications.go
@@ -115,6 +115,7 @@ func (c *AppNotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		ProjectId:                  int64(project.ID),
 		AppId:                      int64(appId),
 		DeploymentTargetIdentifier: &porterv1.DeploymentTargetIdentifier{Id: request.DeploymentTargetID},
+		AppName:                    appName,
 	})
 
 	listAppRevisionsResp, err := c.Config().ClusterControlPlaneClient.ListAppRevisions(ctx, listAppRevisionsReq)

--- a/api/server/handlers/porter_app/create_and_update_events.go
+++ b/api/server/handlers/porter_app/create_and_update_events.go
@@ -222,6 +222,7 @@ func (p *CreateUpdatePorterAppEventHandler) createNewAppEvent(ctx context.Contex
 			ProjectId:          int64(cluster.ProjectID),
 			AppId:              int64(app.ID),
 			DeploymentTargetId: deploymentTargetID,
+			AppName:            porterAppName,
 		}))
 		if err != nil {
 			return types.PorterAppEvent{}, telemetry.Error(ctx, span, err, "error getting current app revision from cluster control plane client")

--- a/api/server/handlers/porter_app/current_app_revision.go
+++ b/api/server/handlers/porter_app/current_app_revision.go
@@ -133,6 +133,7 @@ func (c *LatestAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			Id:   request.DeploymentTargetID,
 			Name: deploymentTargetName,
 		},
+		AppName: appName,
 	})
 
 	currentAppRevisionResp, err := c.Config().ClusterControlPlaneClient.CurrentAppRevision(ctx, currentAppRevisionReq)

--- a/api/server/handlers/porter_app/delete.go
+++ b/api/server/handlers/porter_app/delete.go
@@ -37,6 +37,7 @@ func (c *DeletePorterAppByNameHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	defer span.End()
 
 	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+	cluster, _ := ctx.Value(types.ClusterScope).(*models.Cluster)
 
 	appName, reqErr := requestutils.GetURLParamString(r, types.URLParamPorterAppName)
 	if reqErr != nil {
@@ -55,6 +56,7 @@ func (c *DeletePorterAppByNameHandler) ServeHTTP(w http.ResponseWriter, r *http.
 
 	deleteReq := connect.NewRequest[porterv1.DeletePorterAppRequest](&porterv1.DeletePorterAppRequest{
 		ProjectId: int64(project.ID),
+		ClusterId: int64(cluster.ID),
 		AppName:   appName,
 	})
 	ccpResp, err := c.Config().ClusterControlPlaneClient.DeletePorterApp(r.Context(), deleteReq)

--- a/api/server/handlers/porter_app/helm_values_v2.go
+++ b/api/server/handlers/porter_app/helm_values_v2.go
@@ -103,6 +103,7 @@ func (c *AppHelmValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		AppId:              int64(request.AppID),
 		DeploymentTargetId: request.DeploymentTargetID,
 		WithDefaults:       request.WithDefaults,
+		AppName:            appName,
 	})
 
 	helmValuesResp, err := c.Config().ClusterControlPlaneClient.AppHelmValues(ctx, helmValuesReq)

--- a/api/server/handlers/porter_app/list_app_revisions.go
+++ b/api/server/handlers/porter_app/list_app_revisions.go
@@ -98,6 +98,7 @@ func (c *ListAppRevisionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		ProjectId:          int64(project.ID),
 		AppId:              int64(app.ID),
 		DeploymentTargetId: request.DeploymentTargetID,
+		AppName:            appName,
 	})
 
 	listAppRevisionsResp, err := c.Config().ClusterControlPlaneClient.ListAppRevisions(ctx, listAppRevisionsReq)

--- a/api/server/handlers/porter_app/rollback_revision.go
+++ b/api/server/handlers/porter_app/rollback_revision.go
@@ -115,6 +115,7 @@ func (c *RollbackAppRevisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 			Name: deploymentTargetName,
 		},
 		AppRevisionId: request.AppRevisionID,
+		AppName:       appName,
 	})
 	ccpResp, err := c.Config().ClusterControlPlaneClient.RollbackRevision(ctx, rollbackReq)
 	if err != nil {

--- a/api/server/handlers/porter_app/service_status.go
+++ b/api/server/handlers/porter_app/service_status.go
@@ -122,6 +122,7 @@ func (c *ServiceStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		ProjectId:          int64(project.ID),
 		AppId:              int64(app.ID),
 		DeploymentTargetId: request.DeploymentTargetID,
+		AppName:            appName,
 	})
 
 	listAppRevisionsResp, err := c.Config().ClusterControlPlaneClient.ListAppRevisions(ctx, listAppRevisionsReq)

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.104
+	github.com/porter-dev/api-contracts v0.2.106
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1523,8 +1523,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
-github.com/porter-dev/api-contracts v0.2.104 h1:4ddEMSPlqR12lZWhhY92yZxdHCqoypIuvFiAwfL1g2U=
-github.com/porter-dev/api-contracts v0.2.104/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.106 h1:VDDPGZod38rXGmmOC1rVN7Dw9Qzy38EvNrhv8DFtcKw=
+github.com/porter-dev/api-contracts v0.2.106/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
## What does this PR do?

- Maintain backwards compatibility and plan for forwards compatibility for upcoming changes around how we retrieve app instances
- app id is used to get the app instance in many of these cases, instead we just want to use the app name + deployment target id together
- app id will not be included in the request at all once CCP changes are out and it is no longer used