### PR TITLE
remove any app lookups by project id and name

### DIFF
--- a/api/server/handlers/porter_app/app_notifications.go
+++ b/api/server/handlers/porter_app/app_notifications.go
@@ -85,35 +85,8 @@ func (c *AppNotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: request.DeploymentTargetID})
 
-	porterApps, err := c.Repo().PorterApp().ReadPorterAppsByProjectIDAndName(project.ID, appName)
-	if err != nil {
-		err := telemetry.Error(ctx, span, err, "error getting porter apps")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
-	}
-	if len(porterApps) == 0 {
-		err := telemetry.Error(ctx, span, err, "no porter apps returned")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
-	}
-	if len(porterApps) > 1 {
-		err := telemetry.Error(ctx, span, err, "multiple porter apps returned; unable to determine which one to use")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
-	}
-
-	appId := porterApps[0].ID
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-id", Value: appId})
-
-	if appId == 0 {
-		err := telemetry.Error(ctx, span, err, "porter app id is missing")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
-		return
-	}
-
 	listAppRevisionsReq := connect.NewRequest(&porterv1.ListAppRevisionsRequest{
 		ProjectId:                  int64(project.ID),
-		AppId:                      int64(appId),
 		DeploymentTargetIdentifier: &porterv1.DeploymentTargetIdentifier{Id: request.DeploymentTargetID},
 		AppName:                    appName,
 	})


### PR DESCRIPTION
## What does this PR do?

- remove any DB calls that explicitly look up porter app by project id and name
    - this is ok now because CCP just takes in the app name + deployment target and looks up the correct app instance
- creating a porter app is now scoped to cluster
    - this is a temporary measure until we decide what the relationship is between porter apps and deployment targets
    - another option might be to drop the table all together - which we should be able to safely do once these changes are in
 - note: this is blocked by the corresponding CCP PR (https://github.com/porter-dev/cluster-control-plane/pull/832)
