### PR TITLE
update log structure used by api clients

### DIFF
--- a/api/server/handlers/porter_app/logs_apply_v2.go
+++ b/api/server/handlers/porter_app/logs_apply_v2.go
@@ -206,7 +206,6 @@ func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	logs, err := porter_agent.Logs(ctx, k8sAgent.Clientset, agentSvc, logRequest)
 	if err != nil {
-		fmt.Printf("error getting logs: %v\n", err)
 		_ = telemetry.Error(ctx, span, err, "unable to get logs")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(fmt.Errorf("unable to get logs"), http.StatusInternalServerError))
 		return

--- a/api/server/handlers/porter_app/logs_apply_v2.go
+++ b/api/server/handlers/porter_app/logs_apply_v2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/porter-dev/porter/internal/deployment_target"
 	porter_agent "github.com/porter-dev/porter/internal/kubernetes/porter_agent/v2"
 	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/porter_app"
 	"github.com/porter-dev/porter/internal/telemetry"
 )
 
@@ -38,15 +39,17 @@ func NewAppLogsHandler(
 
 // AppLogsRequest represents the accepted fields on a request to the /apps/logs endpoint
 type AppLogsRequest struct {
-	DeploymentTargetID string    `schema:"deployment_target_id"`
-	ServiceName        string    `schema:"service_name"`
-	AppID              uint      `schema:"app_id"`
-	Limit              uint      `schema:"limit"`
-	StartRange         time.Time `schema:"start_range,omitempty"`
-	EndRange           time.Time `schema:"end_range,omitempty"`
-	SearchParam        string    `schema:"search_param"`
-	Direction          string    `schema:"direction"`
-	AppRevisionID      string    `schema:"app_revision_id"`
+	DeploymentTargetID   string    `schema:"deployment_target_id"`
+	DeploymentTargetName string    `schema:"deployment_target_name"`
+	ServiceName          string    `schema:"service_name"`
+	AppID                uint      `schema:"app_id"`
+	Limit                uint      `schema:"limit"`
+	StartRange           time.Time `schema:"start_range,omitempty"`
+	EndRange             time.Time `schema:"end_range,omitempty"`
+	SearchParam          string    `schema:"search_param"`
+	Direction            string    `schema:"direction"`
+	AppRevisionID        string    `schema:"app_revision_id"`
+	JobRunName           string    `schema:"job_run_name"`
 }
 
 const (
@@ -55,8 +58,16 @@ const (
 	lokiLabel_PorterServiceName   = "porter_run_service_name"
 	lokiLabel_PorterAppRevisionID = "porter_run_app_revision_id"
 	lokiLabel_DeploymentTargetId  = "porter_run_deployment_target_id"
+	lokiLabel_JobRunName          = "job_name"
 	lokiLabel_Namespace           = "namespace"
 )
+
+// AppLogsResponse represents the response to the /apps/logs endpoint
+type AppLogsResponse struct {
+	BackwardContinueTime *time.Time                 `json:"backward_continue_time,omitempty"`
+	ForwardContinueTime  *time.Time                 `json:"forward_continue_time,omitempty"`
+	Logs                 []porter_app.StructuredLog `json:"logs"`
+}
 
 // ServeHTTP gets logs for a given app, service, and deployment target
 func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -81,12 +92,6 @@ func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "app-name", Value: appName})
 
-	if request.AppID == 0 {
-		err := telemetry.Error(ctx, span, nil, "must provide app id")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
-	}
-
 	if request.ServiceName == "" {
 		err := telemetry.Error(ctx, span, nil, "must provide service name")
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
@@ -94,18 +99,32 @@ func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "service-name", Value: request.ServiceName})
 
-	if request.DeploymentTargetID == "" {
-		err := telemetry.Error(ctx, span, nil, "must provide deployment target id")
-		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
-		return
+	deploymentTargetName := request.DeploymentTargetName
+	if request.DeploymentTargetName == "" && request.DeploymentTargetID == "" {
+		defaultDeploymentTarget, err := defaultDeploymentTarget(ctx, defaultDeploymentTargetInput{
+			ProjectID:                 project.ID,
+			ClusterID:                 cluster.ID,
+			ClusterControlPlaneClient: c.Config().ClusterControlPlaneClient,
+		})
+		if err != nil {
+			err := telemetry.Error(ctx, span, err, "error getting default deployment target")
+			c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+			return
+		}
+		deploymentTargetName = defaultDeploymentTarget.Name
 	}
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "deployment-target-id", Value: request.DeploymentTargetID})
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "deployment-target-name", Value: deploymentTargetName},
+		telemetry.AttributeKV{Key: "deployment-target-id", Value: request.DeploymentTargetID},
+	)
 
 	deploymentTarget, err := deployment_target.DeploymentTargetDetails(ctx, deployment_target.DeploymentTargetDetailsInput{
-		ProjectID:          int64(project.ID),
-		ClusterID:          int64(cluster.ID),
-		DeploymentTargetID: request.DeploymentTargetID,
-		CCPClient:          c.Config().ClusterControlPlaneClient,
+		ProjectID:            int64(project.ID),
+		ClusterID:            int64(cluster.ID),
+		DeploymentTargetID:   request.DeploymentTargetID,
+		DeploymentTargetName: deploymentTargetName,
+		CCPClient:            c.Config().ClusterControlPlaneClient,
 	})
 	if err != nil {
 		err := telemetry.Error(ctx, span, err, "error getting deployment target details")
@@ -141,20 +160,20 @@ func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	matchLabels := map[string]string{
-		lokiLabel_Namespace:     namespace,
-		lokiLabel_PorterAppName: appName,
-		lokiLabel_PorterAppID:   fmt.Sprintf("%d", request.AppID),
+		lokiLabel_Namespace:          namespace,
+		lokiLabel_PorterAppName:      appName,
+		lokiLabel_DeploymentTargetId: request.DeploymentTargetID,
 	}
 
 	if request.ServiceName != "all" {
 		matchLabels[lokiLabel_PorterServiceName] = request.ServiceName
 	}
-
 	if request.AppRevisionID != "" {
 		matchLabels[lokiLabel_PorterAppRevisionID] = request.AppRevisionID
 	}
-
-	matchLabels[lokiLabel_DeploymentTargetId] = request.DeploymentTargetID
+	if request.JobRunName != "" {
+		matchLabels[lokiLabel_JobRunName] = request.JobRunName
+	}
 
 	logRequest := &types.LogRequest{
 		Limit:       request.Limit,
@@ -171,6 +190,17 @@ func (c *AppLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(fmt.Errorf("unable to get logs"), http.StatusInternalServerError))
 		return
 	}
+	if logs == nil {
+		err := telemetry.Error(ctx, span, nil, "logs response is nil")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
 
-	c.WriteResult(w, r, logs)
+	res := AppLogsResponse{
+		Logs:                 porter_app.AgentLogToStructuredLog(logs.Logs),
+		ForwardContinueTime:  logs.ForwardContinueTime,
+		BackwardContinueTime: logs.BackwardContinueTime,
+	}
+
+	c.WriteResult(w, r, res)
 }

--- a/dashboard/src/main/home/app-dashboard/app-view/tabs/LogsTab.tsx
+++ b/dashboard/src/main/home/app-dashboard/app-view/tabs/LogsTab.tsx
@@ -1,24 +1,26 @@
 import React from "react";
-import Logs from "../../validate-apply/logs/Logs"
+
+import Logs from "../../validate-apply/logs/Logs";
 import { useLatestRevision } from "../LatestRevisionContext";
 
 const LogsTab: React.FC = () => {
-    const { projectId, clusterId, latestProto, deploymentTarget, porterApp } = useLatestRevision();
+  const { projectId, clusterId, latestProto, deploymentTarget, porterApp } =
+    useLatestRevision();
 
-    const appName = latestProto.name
-    const serviceNames = Object.keys(latestProto.services)
+  const appName = latestProto.name;
+  const serviceNames = Object.keys(latestProto.services);
 
-    return (
-        <Logs
-            projectId={projectId}
-            clusterId={clusterId}
-            appName={appName}
-            serviceNames={serviceNames}
-            deploymentTargetId={deploymentTarget.id}
-            filterPredeploy={true}
-            appId={porterApp.id}
-        />
-    );
+  return (
+    <Logs
+      projectId={projectId}
+      clusterId={clusterId}
+      appName={appName}
+      serviceNames={serviceNames}
+      deploymentTargetId={deploymentTarget.id}
+      filterPredeploy={true}
+      appId={porterApp.id}
+    />
+  );
 };
 
 export default LogsTab;

--- a/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
+++ b/dashboard/src/main/home/app-dashboard/expanded-app/logs/types.ts
@@ -25,6 +25,8 @@ const rawLabelsValidator = z.object({
     porter_run_app_revision_id: z.string().optional(),
     porter_run_service_name: z.string().optional(),
     porter_run_service_type: z.string().optional(),
+    porter_run_deployment_target_id: z.string().optional(),
+    job_name: z.string().optional(),
     controller_uid: z.string().optional(),
 });
 export type RawLabels = z.infer<typeof rawLabelsValidator>;

--- a/dashboard/src/main/home/app-dashboard/validate-apply/jobs/JobRunDetails.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/jobs/JobRunDetails.tsx
@@ -107,7 +107,7 @@ const JobRunDetails: React.FC<Props> = ({ jobRun }) => {
         }}
         appId={porterApp.id}
         defaultLatestRevision={false}
-        jobRunID={jobRun.id}
+        jobRunName={jobRun.name}
       />
     </>
   );

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -23,7 +23,6 @@ import api from "shared/api";
 import spinner from "assets/loading.gif";
 
 import { useLatestRevision } from "../../app-view/LatestRevisionContext";
-import StyledLogs from "../../expanded-app/logs/StyledLogs";
 import {
   Direction,
   GenericFilter,
@@ -31,6 +30,7 @@ import {
   type FilterName,
 } from "../../expanded-app/logs/types";
 import { useLogs } from "./utils";
+import StyledLogs from "./StyledLogs";
 
 type Props = {
   projectId: number;
@@ -50,7 +50,7 @@ type Props = {
   selectedRevisionId?: string;
   defaultScrollToBottomEnabled?: boolean;
   defaultLatestRevision?: boolean;
-  jobRunID?: string;
+  jobRunName?: string;
 };
 
 const DEFAULT_LOG_TIMEOUT_SECONDS = 60;
@@ -70,7 +70,7 @@ const Logs: React.FC<Props> = ({
   selectedRevisionId,
   defaultScrollToBottomEnabled = true,
   defaultLatestRevision = true,
-  jobRunID = "",
+  jobRunName = "",
 }) => {
   const { search } = useLocation();
   const queryParams = new URLSearchParams(search);
@@ -256,7 +256,7 @@ const Logs: React.FC<Props> = ({
     filterPredeploy,
     timeRange,
     appID: appId,
-    jobRunID,
+    jobRunName,
   });
 
   const {

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/Logs.tsx
@@ -29,8 +29,8 @@ import {
   GenericFilterOption,
   type FilterName,
 } from "../../expanded-app/logs/types";
-import { useLogs } from "./utils";
 import StyledLogs from "./StyledLogs";
+import { useLogs } from "./utils";
 
 type Props = {
   projectId: number;
@@ -128,7 +128,7 @@ const Logs: React.FC<Props> = ({
     });
   }, [selectedService, selectedRevisionId]);
 
-  const { revisionIdToNumber } = useRevisionList({
+  const { revisionIdToNumber, numberToRevisionId } = useRevisionList({
     appName,
     deploymentTargetId,
     projectId,
@@ -251,6 +251,7 @@ const Logs: React.FC<Props> = ({
     notify,
     setLoading: setIsLoading,
     revisionIdToNumber,
+    revisionNumberToId: numberToRevisionId,
     setDate: selectedDate,
     appRevisionId,
     filterPredeploy,

--- a/dashboard/src/main/home/app-dashboard/validate-apply/logs/StyledLogs.tsx
+++ b/dashboard/src/main/home/app-dashboard/validate-apply/logs/StyledLogs.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import type Anser from "anser";
+import dayjs from "dayjs";
+import styled from "styled-components";
+import { match } from "ts-pattern";
+
+import { GenericFilter } from "../../expanded-app/logs/types";
+import { type PorterLog } from "./utils";
+
+export const getVersionTagColor = (version: string): string => {
+  const colors = ["#7B61FF", "#FF7B61", "#61FF7B"];
+
+  const versionInt = parseInt(version);
+  if (isNaN(versionInt)) {
+    return colors[0];
+  }
+  return colors[versionInt % colors.length];
+};
+
+type Props = {
+  logs: PorterLog[];
+  appName: string;
+  filters: GenericFilter[];
+};
+
+const StyledLogs: React.FC<Props> = ({ logs, filters }) => {
+  const renderFilterTagForLog = (
+    filter: GenericFilter,
+    log: PorterLog,
+    index: number
+  ): React.ReactNode => {
+    return match(filter.name)
+      .with("revision", () => {
+        return (
+          <StyledLogsTableData width={"100px"} key={index}>
+            <LogInnerPill
+              color={getVersionTagColor(log.revision)}
+              key={index}
+              onClick={() => {
+                filter.setValue(log.revision);
+              }}
+            >
+              {`Version: ${log.revision}`}
+            </LogInnerPill>
+          </StyledLogsTableData>
+        );
+      })
+      .with("pod_name", () => {
+        return (
+          <StyledLogsTableData width={"100px"} key={index}>
+            <LogInnerPill
+              color={"white"}
+              key={index}
+              onClick={() => {
+                filter.setValue(log.service_name);
+              }}
+            >
+              {log.service_name}
+            </LogInnerPill>
+          </StyledLogsTableData>
+        );
+      })
+      .with("service_name", () => {
+        return (
+          <StyledLogsTableData width={"100px"} key={index}>
+            <LogInnerPill
+              color={"white"}
+              key={index}
+              onClick={() => {
+                filter.setValue(
+                  log.service_name ??
+                    GenericFilter.getDefaultOption("service_name").value
+                );
+              }}
+            >
+              {log.service_name}
+            </LogInnerPill>
+          </StyledLogsTableData>
+        );
+      })
+      .otherwise(() => null);
+  };
+
+  return (
+    <StyledLogsTable>
+      <StyledLogsTableBody>
+        {logs.map((log, i) => {
+          return (
+            <StyledLogsTableRow key={[log.lineNumber, i].join(".")}>
+              <StyledLogsTableData width={"100px"}>
+                <LineTimestamp className="line-timestamp">
+                  {log.timestamp
+                    ? dayjs(log.timestamp).format("MM/DD HH:mm:ss")
+                    : "-"}
+                </LineTimestamp>
+              </StyledLogsTableData>
+              {filters.map((filter, j) => {
+                return renderFilterTagForLog(filter, log, j);
+              })}
+              <StyledLogsTableData>
+                <LogOuter key={[log.lineNumber, i].join(".")}>
+                  {log.line?.map((ansi, j) => {
+                    if (ansi.clearLine) {
+                      return null;
+                    }
+
+                    return (
+                      <LogInnerSpan
+                        key={[log.lineNumber, i, j].join(".")}
+                        ansi={ansi}
+                      >
+                        {ansi.content.replace(/ /g, "\u00a0")}
+                      </LogInnerSpan>
+                    );
+                  })}
+                </LogOuter>
+              </StyledLogsTableData>
+            </StyledLogsTableRow>
+          );
+        })}
+      </StyledLogsTableBody>
+    </StyledLogsTable>
+  );
+};
+
+export default StyledLogs;
+
+const StyledLogsTable = styled.table`
+  border-collapse: collapse;
+`;
+
+const StyledLogsTableBody = styled.tbody``;
+
+const StyledLogsTableRow = styled.tr``;
+
+const StyledLogsTableData = styled.td<{ width?: string }>`
+  padding: 2px;
+  vertical-align: top;
+  ${(props) => props.width && `width: ${props.width};`}
+`;
+
+const LineTimestamp = styled.div`
+  height: 100%;
+  color: #949effff;
+  opacity: 0.5;
+  font-family: monospace;
+  white-space: nowrap;
+`;
+
+const LogInnerPill = styled.div<{ color: string }>`
+  display: inline-block;
+  vertical-align: middle;
+  width: 120px;
+  padding: 0px 5px;
+  height: 20px;
+  color: black;
+  background-color: ${(props) => props.color};
+  border-radius: 5px;
+  opacity: 1;
+  font-family: monospace;
+  cursor: pointer;
+  hover: {
+    border: 1px solid #949effff;
+  }
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const LogOuter = styled.div`
+  user-select: text;
+  display: inline-block;
+  word-wrap: anywhere;
+  flex-grow: 1;
+  font-family: monospace, sans-serif;
+  font-size: 12px;
+`;
+
+const LogInnerSpan = styled.span`
+  user-select: text;
+  font-family: monospace, sans-serif;
+  font-size: 12px;
+  font-weight: ${(props: { ansi: Anser.AnserJsonEntry }) =>
+    props.ansi?.decoration && props.ansi?.decoration === "bold"
+      ? "700"
+      : "400"};
+  color: ${(props: { ansi: Anser.AnserJsonEntry }) =>
+    props.ansi?.fg ? `rgb(${props.ansi?.fg})` : "white"};
+  background-color: ${(props: { ansi: Anser.AnserJsonEntry }) =>
+    props.ansi?.bg ? `rgb(${props.ansi?.bg})` : "transparent"};
+`;

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -282,7 +282,6 @@ const getLogsWithinTimeRange = baseApi<
 
 const appLogs = baseApi<
   {
-    app_id: number;
     service_name: string;
     deployment_target_id: string;
     limit: number;
@@ -291,6 +290,7 @@ const appLogs = baseApi<
     search_param?: string;
     direction?: string;
     app_revision_id?: string;
+    job_run_name?: string;
   },
   {
     project_id: number;

--- a/internal/kubernetes/agent.go
+++ b/internal/kubernetes/agent.go
@@ -1781,6 +1781,7 @@ func (a *Agent) StreamHelmReleases(namespace string, chartList []string, selecto
 }
 
 func (a *Agent) StreamPorterAgentLokiLog(
+	ctx context.Context,
 	labels []string,
 	startTime string,
 	searchParam string,
@@ -1830,7 +1831,7 @@ func (a *Agent) StreamPorterAgentLokiLog(
 
 			defer wg.Done()
 
-			podList, err := a.Clientset.CoreV1().Pods("porter-agent-system").List(context.Background(), metav1.ListOptions{
+			podList, err := a.Clientset.CoreV1().Pods("porter-agent-system").List(ctx, metav1.ListOptions{
 				LabelSelector: "control-plane=controller-manager",
 			})
 			if err != nil {
@@ -1893,7 +1894,7 @@ func (a *Agent) StreamPorterAgentLokiLog(
 				return
 			}
 
-			err = exec.Stream(remotecommand.StreamOptions{
+			err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 				Stdin:  nil,
 				Stdout: rw,
 				Stderr: rw,

--- a/internal/kubernetes/porter_agent/v2/agent_server.go
+++ b/internal/kubernetes/porter_agent/v2/agent_server.go
@@ -316,10 +316,14 @@ func GetHistoricalLogs(
 
 // Logs returns logs from the porter agent matching the provided labels and other query parameters
 func Logs(
+	ctx context.Context,
 	clientset kubernetes.Interface,
 	service *v1.Service,
 	req *types.LogRequest,
 ) (*types.GetLogResponse, error) {
+	ctx, span := telemetry.NewSpan(ctx, "agent-get-logs")
+	defer span.End()
+
 	vals := make(map[string]string)
 
 	if req.Limit != 0 {
@@ -329,7 +333,7 @@ func Logs(
 	if req.StartRange != nil {
 		startVal, err := req.StartRange.MarshalText()
 		if err != nil {
-			return nil, err
+			return nil, telemetry.Error(ctx, span, err, "unable to marshal start range")
 		}
 
 		vals["start_range"] = string(startVal)
@@ -338,7 +342,7 @@ func Logs(
 	if req.EndRange != nil {
 		endVal, err := req.EndRange.MarshalText()
 		if err != nil {
-			return nil, err
+			return nil, telemetry.Error(ctx, span, err, "unable to marshal end range")
 		}
 
 		vals["end_range"] = string(endVal)
@@ -368,16 +372,16 @@ func Logs(
 		vals,
 	)
 
-	rawQuery, err := resp.DoRaw(context.Background())
+	rawQuery, err := resp.DoRaw(ctx)
 	if err != nil {
-		return nil, err
+		return nil, telemetry.Error(ctx, span, err, "unable to get raw response")
 	}
 
 	logsResp := &types.GetLogResponse{}
 
 	err = json.Unmarshal(rawQuery, logsResp)
 	if err != nil {
-		return nil, err
+		return nil, telemetry.Error(ctx, span, err, "unable to unmarshal logs response")
 	}
 
 	return logsResp, nil

--- a/internal/porter_app/logs.go
+++ b/internal/porter_app/logs.go
@@ -1,0 +1,69 @@
+package porter_app
+
+import (
+	"time"
+
+	"github.com/porter-dev/porter/api/types"
+)
+
+// StructuredLog represents a single log line with all necessary fields required by Porter API clients
+type StructuredLog struct {
+	Timestamp          time.Time `json:"timestamp"`
+	Line               string    `json:"line"`
+	OutputStream       string    `json:"output_stream"`
+	ServiceName        string    `json:"service_name"`
+	AppRevisionID      string    `json:"app_revision_id"`
+	DeploymentTargetID string    `json:"deployment_target_id"`
+	AppInstanceID      string    `json:"app_instance_id"`
+	JobName            string    `json:"job_name,omitempty"`
+	JobRunID           string    `json:"job_run_id,omitempty"`
+}
+
+const (
+	lokiLabel_PorterAppName       = "porter_run_app_name"
+	lokiLabel_PorterAppID         = "porter_run_app_id"
+	lokiLabel_PorterServiceName   = "porter_run_service_name"
+	lokiLabel_PorterAppRevisionID = "porter_run_app_revision_id"
+	lokiLabel_DeploymentTargetId  = "porter_run_deployment_target_id"
+	lokiLabel_AppInstanceID			 = "porter_run_app_instance_id"
+	lokiLabel_JobRunName          = "job_name"
+	lokiLabel_ControllerUID       = "controller_uid"
+)
+
+// AgentLogToStructuredLog converts a set of raw logs from the agent to structured logs
+func AgentLogToStructuredLog(rawLogs []types.LogLine) []StructuredLog {
+	var logs []StructuredLog
+
+	for _, log := range rawLogs {
+		structuredLog := StructuredLog{
+			Line:         log.Line,
+			OutputStream: log.Metadata.OutputStream,
+		}
+
+		if log.Timestamp != nil {
+			structuredLog.Timestamp = *log.Timestamp
+		}
+		if serviceName, ok := log.Metadata.RawLabels[lokiLabel_PorterServiceName]; ok {
+			structuredLog.ServiceName = serviceName
+		}
+		if appRevisionID, ok := log.Metadata.RawLabels[lokiLabel_PorterAppRevisionID]; ok {
+			structuredLog.AppRevisionID = appRevisionID
+		}
+		if deploymentTargetID, ok := log.Metadata.RawLabels[lokiLabel_DeploymentTargetId]; ok {
+			structuredLog.DeploymentTargetID = deploymentTargetID
+		}
+		if jobName, ok := log.Metadata.RawLabels[lokiLabel_JobRunName]; ok {
+			structuredLog.JobName = jobName
+		}
+		if jobRunID, ok := log.Metadata.RawLabels[lokiLabel_ControllerUID]; ok {
+			structuredLog.JobRunID = jobRunID
+		}
+		if appInstanceID, ok := log.Metadata.RawLabels[lokiLabel_AppInstanceID]; ok {
+			structuredLog.AppInstanceID = appInstanceID
+		}
+
+		logs = append(logs, structuredLog)
+	}
+
+	return logs
+}

--- a/internal/porter_app/logs.go
+++ b/internal/porter_app/logs.go
@@ -25,7 +25,7 @@ const (
 	lokiLabel_PorterServiceName   = "porter_run_service_name"
 	lokiLabel_PorterAppRevisionID = "porter_run_app_revision_id"
 	lokiLabel_DeploymentTargetId  = "porter_run_deployment_target_id"
-	lokiLabel_AppInstanceID			 = "porter_run_app_instance_id"
+	lokiLabel_AppInstanceID       = "porter_run_app_instance_id"
 	lokiLabel_JobRunName          = "job_name"
 	lokiLabel_ControllerUID       = "controller_uid"
 )
@@ -36,30 +36,18 @@ func AgentLogToStructuredLog(rawLogs []types.LogLine) []StructuredLog {
 
 	for _, log := range rawLogs {
 		structuredLog := StructuredLog{
-			Line:         log.Line,
-			OutputStream: log.Metadata.OutputStream,
+			Line:               log.Line,
+			OutputStream:       log.Metadata.OutputStream,
+			ServiceName:        log.Metadata.RawLabels[lokiLabel_PorterServiceName],
+			AppRevisionID:      log.Metadata.RawLabels[lokiLabel_PorterAppRevisionID],
+			DeploymentTargetID: log.Metadata.RawLabels[lokiLabel_DeploymentTargetId],
+			JobName:            log.Metadata.RawLabels[lokiLabel_JobRunName],
+			JobRunID:           log.Metadata.RawLabels[lokiLabel_ControllerUID],
+			AppInstanceID:      log.Metadata.RawLabels[lokiLabel_AppInstanceID],
 		}
 
 		if log.Timestamp != nil {
 			structuredLog.Timestamp = *log.Timestamp
-		}
-		if serviceName, ok := log.Metadata.RawLabels[lokiLabel_PorterServiceName]; ok {
-			structuredLog.ServiceName = serviceName
-		}
-		if appRevisionID, ok := log.Metadata.RawLabels[lokiLabel_PorterAppRevisionID]; ok {
-			structuredLog.AppRevisionID = appRevisionID
-		}
-		if deploymentTargetID, ok := log.Metadata.RawLabels[lokiLabel_DeploymentTargetId]; ok {
-			structuredLog.DeploymentTargetID = deploymentTargetID
-		}
-		if jobName, ok := log.Metadata.RawLabels[lokiLabel_JobRunName]; ok {
-			structuredLog.JobName = jobName
-		}
-		if jobRunID, ok := log.Metadata.RawLabels[lokiLabel_ControllerUID]; ok {
-			structuredLog.JobRunID = jobRunID
-		}
-		if appInstanceID, ok := log.Metadata.RawLabels[lokiLabel_AppInstanceID]; ok {
-			structuredLog.AppInstanceID = appInstanceID
 		}
 
 		logs = append(logs, structuredLog)


### PR DESCRIPTION
## What does this PR do?

- Giving a more defined structure to logs when they're initially loaded in, so that we can expose this API more generally and not ask consumers to parse raw JSON from Loki
- FE changes are for accommodating the object format change
- also adding in a filter for job run name
- This PR does not update the websocket output, as Loki writes directly to the output stream at the moment
