### PR TITLE
poll for cloud provider permission status

### DIFF
--- a/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
+++ b/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
@@ -1,0 +1,138 @@
+package project_integration
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+	porterv1 "github.com/porter-dev/api-contracts/generated/go/porter/v1"
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+type CloudProviderPermissionsStatusHandler struct {
+	handlers.PorterHandlerReadWriter
+}
+
+func NewCloudProviderPermissionsStatusHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *CloudProviderPermissionsStatusHandler {
+	return &CloudProviderPermissionsStatusHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+	}
+}
+
+type CloudProviderType string
+
+const (
+	CloudProviderAWS   CloudProviderType = "AWS"
+	CloudProviderGCP   CloudProviderType = "GCP"
+	CloudProviderAzure CloudProviderType = "Azure"
+)
+
+type Aws struct {
+	TargetArn  string `schema:"target_arn"`
+	ExternalID string `schema:"external_id"`
+}
+
+type Gcp struct {
+	ServiceAccountKey string `schema:"service_account_key"`
+	GcpProjectId      string `schema:"gcp_project_id"`
+}
+
+type Azure struct {
+	SubscriptionId      string `schema:"subscription_id"`
+	ClientId            string `schema:"client_id"`
+	TenantId            string `schema:"tenant_id"`
+	ServicePrincipalKey string `schema:"service_principal_key"`
+}
+
+type CloudProviderPermissionsStatusRequest struct {
+	CloudProvider CloudProviderType `schema:"cloud_provider"`
+	Aws
+	Gcp
+	Azure
+}
+
+type CloudProviderPermissionsStatusResponse struct {
+	PercentCompleted float32 `json:"percent_completed"`
+}
+
+func (p *CloudProviderPermissionsStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-cloud-provider-permissions-status")
+	defer span.End()
+
+	project, _ := ctx.Value(types.ProjectScope).(*models.Project)
+
+	request := &CloudProviderPermissionsStatusRequest{}
+	if ok := p.DecodeAndValidate(w, r, request); !ok {
+		err := telemetry.Error(ctx, span, nil, "error decoding request")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	credReq := porterv1.CloudProviderPermissionsStatusRequest{
+		ProjectId: int64(project.ID),
+	}
+
+	switch request.CloudProvider {
+	case CloudProviderAWS:
+		credReq.CloudProvider = porterv1.EnumCloudProvider_ENUM_CLOUD_PROVIDER_AWS
+		credReq.CloudProviderCredentials = &porterv1.CloudProviderPermissionsStatusRequest_AwsCredentials{
+			AwsCredentials: &porterv1.AWSCredentials{
+				TargetArn:  request.Aws.TargetArn,
+				ExternalId: request.Aws.ExternalID,
+			},
+		}
+	case CloudProviderGCP:
+		credReq.CloudProvider = porterv1.EnumCloudProvider_ENUM_CLOUD_PROVIDER_GCP
+		credReq.CloudProviderCredentials = &porterv1.CloudProviderPermissionsStatusRequest_GcpCredentials{
+			GcpCredentials: &porterv1.GCPCredentials{
+				ServiceAccountJsonBase64: request.Gcp.ServiceAccountKey,
+			},
+		}
+	case CloudProviderAzure:
+		credReq.CloudProvider = porterv1.EnumCloudProvider_ENUM_CLOUD_PROVIDER_AZURE
+		credReq.CloudProviderCredentials = &porterv1.CloudProviderPermissionsStatusRequest_AzureCredentials{
+			AzureCredentials: &porterv1.AzureCredentials{
+				SubscriptionId:         request.Azure.SubscriptionId,
+				TenantId:               request.Azure.TenantId,
+				ClientId:               request.Azure.ClientId,
+				ServicePrincipalSecret: []byte(request.Azure.ServicePrincipalKey),
+			},
+		}
+	default:
+		err := telemetry.Error(ctx, span, nil, "unsupported cloud provider")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	credResp, err := p.Config().ClusterControlPlaneClient.CloudProviderPermissionsStatus(ctx, connect.NewRequest(&credReq))
+	if err != nil {
+		err = telemetry.Error(ctx, span, err, "error checking cloud provider permissions status")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+	if credResp == nil {
+		err = telemetry.Error(ctx, span, err, "error reading cloud provider permissions response")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+	if credResp.Msg == nil {
+		err = telemetry.Error(ctx, span, err, "error reading cloud provider permissions message")
+		p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusInternalServerError))
+		return
+	}
+
+	res := CloudProviderPermissionsStatusResponse{
+		PercentCompleted: credResp.Msg.PercentCompleted,
+	}
+
+	p.WriteResult(w, r, res)
+}

--- a/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
+++ b/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
@@ -16,10 +16,12 @@ import (
 	"github.com/porter-dev/porter/internal/telemetry"
 )
 
+// CloudProviderPermissionsStatusHandler is the handler for checking the status of cloud provider permissions
 type CloudProviderPermissionsStatusHandler struct {
 	handlers.PorterHandlerReadWriter
 }
 
+// NewCloudProviderPermissionsStatusHandler returns a handler for checking the status of cloud provider permissions
 func NewCloudProviderPermissionsStatusHandler(
 	config *config.Config,
 	decoderValidator shared.RequestDecoderValidator,

--- a/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
+++ b/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
@@ -30,23 +30,30 @@ func NewCloudProviderPermissionsStatusHandler(
 	}
 }
 
+// CloudProviderType is a type for the cloud provider
 type CloudProviderType string
 
 const (
-	CloudProviderAWS   CloudProviderType = "AWS"
-	CloudProviderGCP   CloudProviderType = "GCP"
+	// CloudProviderAWS is the AWS cloud provider
+	CloudProviderAWS CloudProviderType = "AWS"
+	// CloudProviderGCP is the GCP cloud provider
+	CloudProviderGCP CloudProviderType = "GCP"
+	// CloudProviderAzure is the Azure cloud provider
 	CloudProviderAzure CloudProviderType = "Azure"
 )
 
+// CloudProviderPermissionsStatusRequest is the request to check the status of cloud provider permissions
 type CloudProviderPermissionsStatusRequest struct {
 	CloudProvider                     CloudProviderType `schema:"cloud_provider"`
 	CloudProviderCredentialIdentifier string            `schema:"cloud_provider_credential_identifier"`
 }
 
+// CloudProviderPermissionsStatusResponse is the response to check the status of cloud provider permissions
 type CloudProviderPermissionsStatusResponse struct {
 	PercentCompleted float32 `json:"percent_completed"`
 }
 
+// ServeHTTP checks the status of cloud provider permissions
 func (p *CloudProviderPermissionsStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, span := telemetry.NewSpan(r.Context(), "serve-cloud-provider-permissions-status")
 	defer span.End()

--- a/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
+++ b/api/server/handlers/project_integration/get_cloud_provider_permissions_status.go
@@ -100,7 +100,7 @@ func (p *CloudProviderPermissionsStatusHandler) ServeHTTP(w http.ResponseWriter,
 		}
 
 		if accessErrorExists {
-			err = telemetry.Error(ctx, span, err, "same account is used in a project this user has no access to")
+			err = telemetry.Error(ctx, span, err, "user does not have access to all projects")
 			p.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusForbidden))
 			return
 		}

--- a/api/server/router/project_integration.go
+++ b/api/server/router/project_integration.go
@@ -679,5 +679,33 @@ func getProjectIntegrationRoutes(
 		Router:   r,
 	})
 
+	// GET /api/projects/{project_id}/integrations/cloud-permissions -> project_integration.NewCloudProviderPermissionsStatusHandler
+	cloudPermissionsStatusEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbGet,
+			Method: types.HTTPVerbGet,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: relPath + "/cloud-permissions",
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+			},
+		},
+	)
+
+	cloudPermissionsStatusHandler := project_integration.NewCloudProviderPermissionsStatusHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: cloudPermissionsStatusEndpoint,
+		Handler:  cloudPermissionsStatusHandler,
+		Router:   r,
+	})
+
 	return routes, newPath
 }

--- a/dashboard/src/lib/hooks/useCloudProvider.ts
+++ b/dashboard/src/lib/hooks/useCloudProvider.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 
 import api from "shared/api";
 
-// TODO: refactor this to match "connectTo.." syntax
-export const isAWSArnAccessible = async ({
+export const connectToAwsAccount = async ({
   targetArn,
   externalId,
   projectId,
@@ -11,8 +10,8 @@ export const isAWSArnAccessible = async ({
   targetArn: string;
   externalId: string;
   projectId: number;
-}): Promise<number> => {
-  const res = await api.createAWSIntegration(
+}): Promise<void> => {
+  await api.createAWSIntegration(
     "<token>",
     {
       aws_target_arn: targetArn,
@@ -20,13 +19,6 @@ export const isAWSArnAccessible = async ({
     },
     { id: projectId }
   );
-  const parsed = await z
-    .object({
-      percent_completed: z.number(),
-    })
-    .parseAsync(res.data);
-
-  return parsed.percent_completed;
 };
 
 export const connectToAzureAccount = async ({

--- a/dashboard/src/main/home/infrastructure-dashboard/forms/CloudProviderSelect.tsx
+++ b/dashboard/src/main/home/infrastructure-dashboard/forms/CloudProviderSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
 import Button from "components/porter/Button";
@@ -14,6 +14,7 @@ import {
 } from "lib/clusters/constants";
 import { type ClientCloudProvider } from "lib/clusters/types";
 
+import { Context } from "shared/Context";
 import bolt from "assets/bolt.svg";
 
 import CostConsentModal from "../modals/cost-consent/CostConsentModal";
@@ -25,6 +26,7 @@ const CloudProviderSelect: React.FC<Props> = ({ onComplete }) => {
   const [cloudProvider, setCloudProvider] = useState<
     ClientCloudProvider | undefined
   >(undefined);
+  const { user } = useContext(Context);
 
   return (
     <div>
@@ -43,7 +45,11 @@ const CloudProviderSelect: React.FC<Props> = ({ onComplete }) => {
                 <Block
                   key={i}
                   onClick={() => {
-                    setCloudProvider(provider);
+                    if (user?.isPorterUser) {
+                      onComplete(provider);
+                    } else {
+                      setCloudProvider(provider);
+                    }
                   }}
                 >
                   <Icon src={provider.icon} />

--- a/dashboard/src/main/home/infrastructure-dashboard/forms/aws/GrantAWSPermissions.tsx
+++ b/dashboard/src/main/home/infrastructure-dashboard/forms/aws/GrantAWSPermissions.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
+import AnimateHeight from "react-animate-height";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
@@ -25,6 +26,7 @@ import { useIntercom } from "lib/hooks/useIntercom";
 import api from "shared/api";
 
 import GrantAWSPermissionsHelpModal from "../../modals/help/permissions/GrantAWSPermissionsHelpModal";
+import { CheckItem } from "../../modals/PreflightChecksModal";
 
 type Props = {
   goBack: () => void;
@@ -397,32 +399,47 @@ const GrantAWSPermissions: React.FC<Props> = ({
           <>
             <Text size={16}>Check permissions</Text>
             <Spacer y={1} />
-            <StatusBar
-              icon={CloudProviderAWS.icon}
-              title={"AWS permissions setup"}
-              titleDescriptor={awsPermissionsLoadingMessage}
-              subtitle={
-                permissionsGrantCompletionPercentage === 100
-                  ? "Porter can access your account! You may now continue."
-                  : "Porter is creating roles and policies to access your account. This can take up to 15 minutes. Please stay on this page."
-              }
-              percentCompleted={Math.max(
-                permissionsGrantCompletionPercentage,
-                5
-              )}
-            />
-            <Spacer y={0.5} />
-            <Link
-              hasunderline
-              onClick={() => {
-                showIntercomWithMessage({
-                  message: "I need help with AWS permissions setup.",
-                  delaySeconds: 0,
-                });
-              }}
+            <AnimateHeight
+              height={permissionsGrantCompletionPercentage === 100 ? 0 : "auto"}
             >
-              Need help?
-            </Link>
+              <StatusBar
+                icon={CloudProviderAWS.icon}
+                title={"AWS permissions setup"}
+                titleDescriptor={awsPermissionsLoadingMessage}
+                subtitle={
+                  permissionsGrantCompletionPercentage === 100
+                    ? "Porter can access your account! You may now continue."
+                    : "Porter is creating roles and policies to access your account. This can take up to 15 minutes. Please stay on this page."
+                }
+                percentCompleted={Math.max(
+                  permissionsGrantCompletionPercentage,
+                  5
+                )}
+              />
+              <Spacer y={0.5} />
+              <Link
+                hasunderline
+                onClick={() => {
+                  showIntercomWithMessage({
+                    message: "I need help with AWS permissions setup.",
+                    delaySeconds: 0,
+                  });
+                }}
+              >
+                Need help?
+              </Link>
+            </AnimateHeight>
+            <AnimateHeight
+              height={permissionsGrantCompletionPercentage === 100 ? "auto" : 0}
+            >
+              <CheckItem
+                preflightCheck={{
+                  title:
+                    "AWS account is accessible by Porter! You may continue.",
+                  status: "success",
+                }}
+              />
+            </AnimateHeight>
             <Spacer y={1} />
             <Container row>
               <Button

--- a/dashboard/src/main/home/infrastructure-dashboard/forms/aws/GrantAWSPermissions.tsx
+++ b/dashboard/src/main/home/infrastructure-dashboard/forms/aws/GrantAWSPermissions.tsx
@@ -103,8 +103,7 @@ const GrantAWSPermissions: React.FC<Props> = ({
           "<token>",
           {
             cloud_provider: "AWS",
-            target_arn: `arn:aws:iam::${AWSAccountID}:role/porter-manager`,
-            external_id: externalId,
+            cloud_provider_credential_identifier: `arn:aws:iam::${AWSAccountID}:role/porter-manager`,
           },
           {
             project_id: projectId,
@@ -145,8 +144,7 @@ const GrantAWSPermissions: React.FC<Props> = ({
         "<token>",
         {
           cloud_provider: "AWS",
-          target_arn: `arn:aws:iam::${AWSAccountID}:role/porter-manager`,
-          external_id: externalId,
+          cloud_provider_credential_identifier: `arn:aws:iam::${AWSAccountID}:role/porter-manager`,
         },
         {
           project_id: projectId,
@@ -215,28 +213,29 @@ const GrantAWSPermissions: React.FC<Props> = ({
 
   const directToCloudFormation = useCallback(async () => {
     try {
+      // this sends an async connection request on the backend
       await connectToAwsAccount({
         targetArn: `arn:aws:iam::${AWSAccountID}:role/porter-manager`,
         externalId,
         projectId,
       });
-
-      const trustArn = process.env.TRUST_ARN
-        ? process.env.TRUST_ARN
-        : "arn:aws:iam::108458755588:role/CAPIManagement";
-      const cloudFormationUrl = `https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://porter-role.s3.us-east-2.amazonaws.com/cloudformation-access-policy.json&stackName=PorterRole&param_TrustArnParameter=${trustArn}`;
-      void reportToAnalytics({
-        projectId,
-        step: "aws-cloudformation-redirect-success",
-        awsAccountId: AWSAccountID,
-        cloudFormationUrl,
-        externalId,
-      });
-      setCurrentStep(3);
-      window.open(cloudFormationUrl, "_blank");
     } catch (err) {
       // todo: handle error here
     }
+
+    const trustArn = process.env.TRUST_ARN
+      ? process.env.TRUST_ARN
+      : "arn:aws:iam::108458755588:role/CAPIManagement";
+    const cloudFormationUrl = `https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://porter-role.s3.us-east-2.amazonaws.com/cloudformation-access-policy.json&stackName=PorterRole&param_TrustArnParameter=${trustArn}`;
+    void reportToAnalytics({
+      projectId,
+      step: "aws-cloudformation-redirect-success",
+      awsAccountId: AWSAccountID,
+      cloudFormationUrl,
+      externalId,
+    });
+    setCurrentStep(3);
+    window.open(cloudFormationUrl, "_blank");
   }, [AWSAccountID, externalId]);
 
   const handleGrantPermissionsComplete = (): void => {

--- a/dashboard/src/main/home/infrastructure-dashboard/forms/gcp/GrantGCPPermissions.tsx
+++ b/dashboard/src/main/home/infrastructure-dashboard/forms/gcp/GrantGCPPermissions.tsx
@@ -227,7 +227,7 @@ const GrantGCPPermissions: React.FC<Props> = ({
             <Container row>
               <Button
                 onClick={() => {
-                  setCurrentStep(2);
+                  setCurrentStep(1);
                 }}
                 color="#222222"
               >

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -3464,23 +3464,10 @@ const createSecretAndOpenGitHubPullRequest = baseApi<
 );
 
 const getCloudProviderPermissionsStatus = baseApi<
-  | {
-      cloud_provider: "AWS";
-      target_arn: string;
-      external_id: string;
-    }
-  | {
-      cloud_provider: "GCP";
-      service_account_key: string;
-      gcp_project_id: string;
-    }
-  | {
-      cloud_provider: "Azure";
-      subscription_id: string;
-      client_id: string;
-      tenant_id: string;
-      service_principal_key: string;
-    },
+  {
+    cloud_provider: string;
+    cloud_provider_credential_identifier: string;
+  },
   { project_id: number }
 >(
   "GET",

--- a/dashboard/src/shared/api.tsx
+++ b/dashboard/src/shared/api.tsx
@@ -3451,6 +3451,31 @@ const createSecretAndOpenGitHubPullRequest = baseApi<
     `/api/projects/${project_id}/clusters/${cluster_id}/applications/${stack_name}/pr`
 );
 
+const getCloudProviderPermissionsStatus = baseApi<
+  | {
+      cloud_provider: "AWS";
+      target_arn: string;
+      external_id: string;
+    }
+  | {
+      cloud_provider: "GCP";
+      service_account_key: string;
+      gcp_project_id: string;
+    }
+  | {
+      cloud_provider: "Azure";
+      subscription_id: string;
+      client_id: string;
+      tenant_id: string;
+      service_principal_key: string;
+    },
+  { project_id: number }
+>(
+  "GET",
+  ({ project_id }) =>
+    `/api/projects/${project_id}/integrations/cloud-permissions`
+);
+
 // Bundle export to allow default api import (api.<method> is more readable)
 export default {
   checkAuth,
@@ -3741,4 +3766,5 @@ export default {
   // STATUS
   getGithubStatus,
   getDatabaseStatus,
+  getCloudProviderPermissionsStatus,
 };

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/porter-dev/porter
 
 go 1.20
 
+// replace api-contracts with local
+replace github.com/porter-dev/api-contracts => ../api-contracts
+
 require (
 	cloud.google.com/go v0.110.0 // indirect
 	github.com/AlecAivazis/survey/v2 v2.2.9

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/porter-dev/porter
 
 go 1.20
 
-// replace api-contracts with local
-replace github.com/porter-dev/api-contracts => ../api-contracts
-
 require (
 	cloud.google.com/go v0.110.0 // indirect
 	github.com/AlecAivazis/survey/v2 v2.2.9
@@ -86,7 +83,7 @@ require (
 	github.com/matryer/is v1.4.0
 	github.com/nats-io/nats.go v1.24.0
 	github.com/open-policy-agent/opa v0.44.0
-	github.com/porter-dev/api-contracts v0.2.114
+	github.com/porter-dev/api-contracts v0.2.116
 	github.com/riandyrn/otelchi v0.5.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1
 	github.com/stefanmcshane/helm v0.0.0-20221213002717-88a4a2c6e77d

--- a/go.sum
+++ b/go.sum
@@ -1527,6 +1527,8 @@ github.com/porter-dev/api-contracts v0.2.113 h1:sv1huO9MpykJaWhV2D5zTD2LouMbRSBV
 github.com/porter-dev/api-contracts v0.2.113/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/api-contracts v0.2.114 h1:qfEq70BJ8xXTkiZU7ygzOSGnMCqJHOa5Lbkfu4OzQBI=
 github.com/porter-dev/api-contracts v0.2.114/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
+github.com/porter-dev/api-contracts v0.2.116 h1:Oe7pO69yyv1lEnafGWnKoHqNYJAe8KpQCE9cnTC1m1w=
+github.com/porter-dev/api-contracts v0.2.116/go.mod h1:fX6JmP5QuzxDLvqP3evFOTXjI4dHxsG0+VKNTjImZU8=
 github.com/porter-dev/switchboard v0.0.3 h1:dBuYkiVLa5Ce7059d6qTe9a1C2XEORFEanhbtV92R+M=
 github.com/porter-dev/switchboard v0.0.3/go.mod h1:xSPzqSFMQ6OSbp42fhCi4AbGbQbsm6nRvOkrblFeXU4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=


### PR DESCRIPTION
only supporting aws for now, azure and gcp can continue using the old endpoint because their perm update is sync