### PR TITLE
toggle skipping redeploys on linked apps

### DIFF
--- a/api/client/env_groups.go
+++ b/api/client/env_groups.go
@@ -26,12 +26,13 @@ func (c *Client) GetLatestEnvGroupVariables(
 
 // UpdateEnvGroupInput is the input for the UpdateEnvGroup method
 type UpdateEnvGroupInput struct {
-	ProjectID    uint
-	ClusterID    uint
-	EnvGroupName string
-	Variables    map[string]string
-	Secrets      map[string]string
-	Deletions    environment_groups.EnvVariableDeletions
+	ProjectID     uint
+	ClusterID     uint
+	EnvGroupName  string
+	Variables     map[string]string
+	Secrets       map[string]string
+	Deletions     environment_groups.EnvVariableDeletions
+	SkipRedeploys bool
 }
 
 // UpdateEnvGroup creates or updates an environment group with the provided variables
@@ -40,10 +41,11 @@ func (c *Client) UpdateEnvGroup(
 	inp UpdateEnvGroupInput,
 ) error {
 	req := &environment_groups.UpdateEnvironmentGroupRequest{
-		Name:            inp.EnvGroupName,
-		Variables:       inp.Variables,
-		SecretVariables: inp.Secrets,
-		Deletions:       inp.Deletions,
+		Name:              inp.EnvGroupName,
+		Variables:         inp.Variables,
+		SecretVariables:   inp.Secrets,
+		Deletions:         inp.Deletions,
+		SkipAppAutoDeploy: inp.SkipRedeploys,
 	}
 
 	return c.postRequest(

--- a/api/server/handlers/environment_groups/create.go
+++ b/api/server/handlers/environment_groups/create.go
@@ -62,6 +62,9 @@ type UpdateEnvironmentGroupRequest struct {
 
 	// Deletions is a set of keys to delete from the environment group
 	Deletions EnvVariableDeletions `json:"deletions"`
+
+	// SkipAppAutoDeploy is a flag to determine if the app should be auto deployed
+	SkipAppAutoDeploy bool `json:"skip_app_auto_deploy"`
 }
 type UpdateEnvironmentGroupResponse struct {
 	// Name of the env group to create or update
@@ -121,7 +124,7 @@ func (c *UpdateEnvironmentGroupHandler) ServeHTTP(w http.ResponseWriter, r *http
 				Secrets:   request.Deletions.Secrets,
 			},
 			IsEnvOverride:     request.IsEnvOverride,
-			SkipAppAutoDeploy: true, // switch to false once CCP changes are in, so as to not miss any redeploys
+			SkipAppAutoDeploy: request.SkipAppAutoDeploy,
 		}))
 		if err != nil {
 			err := telemetry.Error(ctx, span, err, "unable to create environment group")

--- a/dashboard/src/main/home/env-dashboard/tabs/EnvVarsTab.tsx
+++ b/dashboard/src/main/home/env-dashboard/tabs/EnvVarsTab.tsx
@@ -148,16 +148,6 @@ const EnvVarsTab: React.FC<Props> = ({ envGroup, fetchEnvGroup }) => {
         );
       };
      
-      await api.updateAppsLinkedToEnvironmentGroup(
-        "<token>",
-        {
-          name: envGroup?.name,
-        },
-        {
-          id: currentProject?.id || -1,
-          cluster_id: currentCluster?.id || -1,
-        }
-      );
       fetchEnvGroup();
       setButtonStatus("success");
     } catch (err) {


### PR DESCRIPTION
## What does this PR do?

** To merge after CCP PR is in that handle redeploys on linked apps in env group update flow

By default `env set` and `env unset` will trigger redeploys on all linked apps

Changes also add in a flag for skipping this, if needed for some reason:
`porter env set --group foo --variables FOO=bar --skip-redeploys`