### PR TITLE
app update command and no build flag on apply

### DIFF
--- a/cli/cmd/commands/flags/app_build.go
+++ b/cli/cmd/commands/flags/app_build.go
@@ -17,6 +17,8 @@ const (
 	App_Buildpacks = "attach-buildpacks"
 	// App_BuildContext is the key for the build context flag
 	App_BuildContext = "build-context"
+	// App_NoBuild is the key for the no build flag
+	App_NoBuild = "no-build"
 )
 
 // UseAppBuildFlags adds build flags to the given command

--- a/cli/cmd/commands/flags/app_config.go
+++ b/cli/cmd/commands/flags/app_config.go
@@ -1,0 +1,41 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// App_ConfigAttachEnvGroups is the key for the attach env groups flag
+	App_ConfigAttachEnvGroups = "attach-env-groups"
+)
+
+type appConfigValues struct {
+	AttachEnvGroups []string
+}
+
+// UseAppConfigFlags adds config flags to the given command
+func UseAppConfigFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringSlice(
+		App_ConfigAttachEnvGroups,
+		nil,
+		"attach environment groups to the app",
+	)
+}
+
+// AppConfigValuesFromCmd retrieves config values from command flags
+func AppConfigValuesFromCmd(cmd *cobra.Command) (appConfigValues, error) {
+	var values appConfigValues
+
+	envGroups, err := cmd.Flags().GetStringSlice(App_ConfigAttachEnvGroups)
+	if err != nil {
+		return values, fmt.Errorf("error getting attach env groups: %w", err)
+	}
+
+	values = appConfigValues{
+		AttachEnvGroups: envGroups,
+	}
+
+	return values, nil
+}


### PR DESCRIPTION
## What does this PR do?

Allows for users to apply config changes to an app from the CLI without having to build with `porter apply`

Option 1:
`porter apply -f porter.yaml --no-build`

Same as option 2:
`porter app update my-app -f porter.yaml`