### PR TITLE
Add default prefix for Metronome customer

### DIFF
--- a/internal/billing/metronome.go
+++ b/internal/billing/metronome.go
@@ -43,8 +43,13 @@ func (m MetronomeClient) createCustomer(ctx context.Context, orgName string, pro
 	path := "customers"
 	projIDStr := strconv.FormatUint(uint64(projectID), 10)
 
+	prefix := "Project"
+	if orgName != "" {
+		prefix = orgName
+	}
+
 	customer := types.Customer{
-		Name: fmt.Sprintf("%s - %s", orgName, projectName),
+		Name: fmt.Sprintf("%s - %s", prefix, projectName),
 		Aliases: []string{
 			projIDStr,
 		},


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
I incorrectly assumed that the company name would be available for all users, but that wasn't the case. This PR adds a default prefix so customer names have a default prefix if the company name is not present. Note that this name appears in the invoice, that is why the name has to be understandable, human-readable and indicate what the invoice is about.

<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
