### PR TITLE
Add ingest endpoint to metronome client

### DIFF
--- a/api/server/handlers/billing/ingest.go
+++ b/api/server/handlers/billing/ingest.go
@@ -18,6 +18,7 @@ type IngestEventsHandler struct {
 	handlers.PorterHandlerReadWriter
 }
 
+// NewIngestEventsHandler returns a new IngestEventsHandler
 func NewIngestEventsHandler(
 	config *config.Config,
 	decoderValidator shared.RequestDecoderValidator,

--- a/api/server/handlers/billing/ingest.go
+++ b/api/server/handlers/billing/ingest.go
@@ -1,0 +1,67 @@
+// NewGetUsageDashboardHandler returns a new GetUsageDashboardHandler
+package billing
+
+import (
+	"net/http"
+
+	"github.com/porter-dev/porter/api/server/handlers"
+	"github.com/porter-dev/porter/api/server/shared"
+	"github.com/porter-dev/porter/api/server/shared/apierrors"
+	"github.com/porter-dev/porter/api/server/shared/config"
+	"github.com/porter-dev/porter/api/types"
+	"github.com/porter-dev/porter/internal/models"
+	"github.com/porter-dev/porter/internal/telemetry"
+)
+
+// IngestEventsHandler is a handler for ingesting billing events
+type IngestEventsHandler struct {
+	handlers.PorterHandlerReadWriter
+}
+
+func NewIngestEventsHandler(
+	config *config.Config,
+	decoderValidator shared.RequestDecoderValidator,
+	writer shared.ResultWriter,
+) *IngestEventsHandler {
+	return &IngestEventsHandler{
+		PorterHandlerReadWriter: handlers.NewDefaultPorterHandler(config, decoderValidator, writer),
+	}
+}
+
+func (c *IngestEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-ingest-events")
+	defer span.End()
+
+	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
+
+	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
+		c.WriteResult(w, r, "")
+
+		telemetry.WithAttributes(span,
+			telemetry.AttributeKV{Key: "metronome-enabled", Value: false},
+		)
+		return
+	}
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "metronome-enabled", Value: true},
+		telemetry.AttributeKV{Key: "usage-id", Value: proj.UsageID},
+	)
+
+	request := []types.BillingEvent{}
+
+	if ok := c.DecodeAndValidate(w, r, &request); !ok {
+		err := telemetry.Error(ctx, span, nil, "error decoding ingest events request")
+		c.HandleAPIError(w, r, apierrors.NewErrPassThroughToClient(err, http.StatusBadRequest))
+		return
+	}
+
+	err := c.Config().BillingManager.MetronomeClient.IngestEvents(ctx, request)
+	if err != nil {
+		err := telemetry.Error(ctx, span, err, "error ingesting events")
+		c.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+		return
+	}
+
+	c.WriteResult(w, r, "")
+}

--- a/api/server/handlers/billing/plan.go
+++ b/api/server/handlers/billing/plan.go
@@ -119,7 +119,7 @@ func NewGetUsageDashboardHandler(
 }
 
 func (c *GetUsageDashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, span := telemetry.NewSpan(r.Context(), "get-usage-dashboard-endpoint")
+	ctx, span := telemetry.NewSpan(r.Context(), "serve-usage-dashboard")
 	defer span.End()
 
 	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)

--- a/api/server/router/project.go
+++ b/api/server/router/project.go
@@ -395,7 +395,7 @@ func getProjectRoutes(
 		Router:   r,
 	})
 
-	// GET /api/projects/{project_id}/billing/dashboard -> project.NewGetUsageDashboardHandler
+	// POST /api/projects/{project_id}/billing/dashboard -> project.NewGetUsageDashboardHandler
 	getUsageDashboardEndpoint := factory.NewAPIEndpoint(
 		&types.APIRequestMetadata{
 			Verb:   types.APIVerbCreate,
@@ -420,6 +420,34 @@ func getProjectRoutes(
 	routes = append(routes, &router.Route{
 		Endpoint: getUsageDashboardEndpoint,
 		Handler:  getUsageDashboardHandler,
+		Router:   r,
+	})
+
+	// POST /api/projects/{project_id}/billing/ingest -> project.NewGetUsageDashboardHandler
+	ingestEventsEndpoint := factory.NewAPIEndpoint(
+		&types.APIRequestMetadata{
+			Verb:   types.APIVerbCreate,
+			Method: types.HTTPVerbPost,
+			Path: &types.Path{
+				Parent:       basePath,
+				RelativePath: relPath + "/billing/ingest",
+			},
+			Scopes: []types.PermissionScope{
+				types.UserScope,
+				types.ProjectScope,
+			},
+		},
+	)
+
+	ingestEventsHandler := billing.NewIngestEventsHandler(
+		config,
+		factory.GetDecoderValidator(),
+		factory.GetResultWriter(),
+	)
+
+	routes = append(routes, &router.Route{
+		Endpoint: ingestEventsEndpoint,
+		Handler:  ingestEventsHandler,
 		Router:   r,
 	})
 

--- a/api/types/billing_metronome.go
+++ b/api/types/billing_metronome.go
@@ -141,6 +141,7 @@ type ColorOverride struct {
 	Value string `json:"value"`
 }
 
+// BillingEvent represents a Metronome billing event.
 type BillingEvent struct {
 	CustomerID    string                 `json:"customer_id"`
 	EventType     string                 `json:"event_type"`

--- a/api/types/billing_metronome.go
+++ b/api/types/billing_metronome.go
@@ -140,3 +140,11 @@ type ColorOverride struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
+
+type BillingEvent struct {
+	CustomerID    string                 `json:"customer_id"`
+	EventType     string                 `json:"event_type"`
+	Properties    map[string]interface{} `json:"properties"`
+	TransactionID string                 `json:"transaction_id"`
+	Timestamp     string                 `json:"timestamp"`
+}

--- a/internal/billing/metronome.go
+++ b/internal/billing/metronome.go
@@ -257,6 +257,7 @@ func (m MetronomeClient) GetCustomerDashboard(ctx context.Context, customerID uu
 	return result.Data["url"], nil
 }
 
+// IngestEvents sends a list of billing events to Metronome's ingest endpoint
 func (m MetronomeClient) IngestEvents(ctx context.Context, events []types.BillingEvent) (err error) {
 	path := "ingest"
 
@@ -314,6 +315,7 @@ func (m MetronomeClient) do(method string, path string, body interface{}, data i
 	if err != nil {
 		return statusCode, err
 	}
+	statusCode = resp.StatusCode
 
 	if resp.StatusCode != http.StatusOK {
 		// If there is an error, try to decode the message


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
This PR adds the ingest endpoint that was originally in the porter-agent so that all Metronome logic is centralized in the api server. This also avoids having to expose the Metronome key in customer clusters.

<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
