### PR TITLE
Fix porter cloud ingest aliases

### DIFF
--- a/api/server/handlers/billing/ingest.go
+++ b/api/server/handlers/billing/ingest.go
@@ -66,7 +66,7 @@ func (c *IngestEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		telemetry.AttributeKV{Key: "usage-events-count", Value: len(ingestEventsRequest.Events)},
 	)
 
-	// For Porter Cloud events, we apend a prefix to avoid collisions
+	// For Porter Cloud events, we apend a prefix to avoid collisions before sending to Metronome
 	if proj.EnableSandbox {
 		for i := range ingestEventsRequest.Events {
 			ingestEventsRequest.Events[i].CustomerID = fmt.Sprintf("porter-cloud-%s", ingestEventsRequest.Events[i].CustomerID)

--- a/api/server/handlers/billing/ingest.go
+++ b/api/server/handlers/billing/ingest.go
@@ -36,11 +36,11 @@ func (c *IngestEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
 
-	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
+	if !c.Config().BillingManager.MetronomeConfigLoaded || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
 		c.WriteResult(w, r, "")
 
 		telemetry.WithAttributes(span,
-			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeEnabled},
+			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeConfigLoaded},
 			telemetry.AttributeKV{Key: "metronome-enabled", Value: proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient)},
 			telemetry.AttributeKV{Key: "porter-cloud-enabled", Value: proj.EnableSandbox},
 		)

--- a/api/server/handlers/billing/list.go
+++ b/api/server/handlers/billing/list.go
@@ -166,7 +166,7 @@ func (c *CheckPaymentEnabledHandler) ensureStripeCustomerExists(ctx context.Cont
 	ctx, span := telemetry.NewSpan(ctx, "ensure-stripe-customer-exists")
 	defer span.End()
 
-	if !c.Config().BillingManager.StripeEnabled || !proj.GetFeatureFlag(models.BillingEnabled, c.Config().LaunchDarklyClient) || proj.BillingID != "" {
+	if !c.Config().BillingManager.StripeConfigLoaded || !proj.GetFeatureFlag(models.BillingEnabled, c.Config().LaunchDarklyClient) || proj.BillingID != "" {
 		return nil
 	}
 
@@ -193,7 +193,7 @@ func (c *CheckPaymentEnabledHandler) ensureMetronomeCustomerExists(ctx context.C
 	ctx, span := telemetry.NewSpan(ctx, "ensure-metronome-customer-exists")
 	defer span.End()
 
-	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) || proj.UsageID != uuid.Nil {
+	if !c.Config().BillingManager.MetronomeConfigLoaded || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) || proj.UsageID != uuid.Nil {
 		return nil
 	}
 

--- a/api/server/handlers/billing/plan.go
+++ b/api/server/handlers/billing/plan.go
@@ -33,11 +33,11 @@ func (c *ListPlansHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
 
-	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
+	if !c.Config().BillingManager.MetronomeConfigLoaded || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
 		c.WriteResult(w, r, "")
 
 		telemetry.WithAttributes(span,
-			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeEnabled},
+			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeConfigLoaded},
 			telemetry.AttributeKV{Key: "metronome-enabled", Value: proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient)},
 		)
 		return
@@ -79,11 +79,11 @@ func (c *ListCreditsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
 
-	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
+	if !c.Config().BillingManager.MetronomeConfigLoaded || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
 		c.WriteResult(w, r, "")
 
 		telemetry.WithAttributes(span,
-			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeEnabled},
+			telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeConfigLoaded},
 			telemetry.AttributeKV{Key: "metronome-enabled", Value: proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient)},
 		)
 		return
@@ -127,12 +127,12 @@ func (c *ListCustomerUsageHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	proj, _ := ctx.Value(types.ProjectScope).(*models.Project)
 
 	telemetry.WithAttributes(span,
-		telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeEnabled},
+		telemetry.AttributeKV{Key: "metronome-config-exists", Value: c.Config().BillingManager.MetronomeConfigLoaded},
 		telemetry.AttributeKV{Key: "metronome-enabled", Value: proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient)},
 		telemetry.AttributeKV{Key: "usage-id", Value: proj.UsageID},
 	)
 
-	if !c.Config().BillingManager.MetronomeEnabled || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
+	if !c.Config().BillingManager.MetronomeConfigLoaded || !proj.GetFeatureFlag(models.MetronomeEnabled, c.Config().LaunchDarklyClient) {
 		c.WriteResult(w, r, "")
 		return
 	}

--- a/api/server/handlers/project/create.go
+++ b/api/server/handlers/project/create.go
@@ -81,7 +81,7 @@ func (p *ProjectCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Create Stripe Customer
-	if p.Config().ServerConf.StripeSecretKey != "" && p.Config().ServerConf.StripePublishableKey != "" {
+	if p.Config().BillingManager.StripeEnabled && proj.GetFeatureFlag(models.BillingEnabled, p.Config().LaunchDarklyClient) {
 		// Create billing customer for project and set the billing ID
 		billingID, err := p.Config().BillingManager.StripeClient.CreateCustomer(ctx, user.Email, proj.ID, proj.Name)
 		if err != nil {

--- a/api/server/handlers/project/create.go
+++ b/api/server/handlers/project/create.go
@@ -81,7 +81,7 @@ func (p *ProjectCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Create Stripe Customer
-	if p.Config().BillingManager.StripeEnabled && proj.GetFeatureFlag(models.BillingEnabled, p.Config().LaunchDarklyClient) {
+	if p.Config().BillingManager.StripeConfigLoaded && proj.GetFeatureFlag(models.BillingEnabled, p.Config().LaunchDarklyClient) {
 		// Create billing customer for project and set the billing ID
 		billingID, err := p.Config().BillingManager.StripeClient.CreateCustomer(ctx, user.Email, proj.ID, proj.Name)
 		if err != nil {
@@ -98,7 +98,7 @@ func (p *ProjectCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Create Metronome customer and add to starter plan
-	if p.Config().BillingManager.MetronomeEnabled && proj.GetFeatureFlag(models.MetronomeEnabled, p.Config().LaunchDarklyClient) {
+	if p.Config().BillingManager.MetronomeConfigLoaded && proj.GetFeatureFlag(models.MetronomeEnabled, p.Config().LaunchDarklyClient) {
 		customerID, customerPlanID, err := p.Config().BillingManager.MetronomeClient.CreateCustomerWithPlan(ctx, user.Email, proj.Name, proj.ID, proj.BillingID, proj.EnableSandbox)
 		if err != nil {
 			err = telemetry.Error(ctx, span, err, "error creating Metronome customer")

--- a/api/server/handlers/project/delete.go
+++ b/api/server/handlers/project/delete.go
@@ -92,7 +92,7 @@ func (p *ProjectDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if p.Config().BillingManager.MetronomeEnabled && proj.GetFeatureFlag(models.MetronomeEnabled, p.Config().LaunchDarklyClient) {
+	if p.Config().BillingManager.MetronomeConfigLoaded && proj.GetFeatureFlag(models.MetronomeEnabled, p.Config().LaunchDarklyClient) {
 		err = p.Config().BillingManager.MetronomeClient.EndCustomerPlan(ctx, proj.UsageID, proj.UsagePlanID)
 		if err != nil {
 			e := "error ending billing plan"

--- a/api/server/shared/config/loader/loader.go
+++ b/api/server/shared/config/loader/loader.go
@@ -360,10 +360,10 @@ func (e *EnvConfigLoader) LoadConfig() (res *config.Config, err error) {
 
 	res.Logger.Info().Msg("Creating billing manager")
 	res.BillingManager = billing.Manager{
-		StripeClient:     stripeClient,
-		StripeEnabled:    stripeEnabled,
-		MetronomeClient:  metronomeClient,
-		MetronomeEnabled: metronomeEnabled,
+		StripeClient:          stripeClient,
+		StripeConfigLoaded:    stripeEnabled,
+		MetronomeClient:       metronomeClient,
+		MetronomeConfigLoaded: metronomeEnabled,
 	}
 	res.Logger.Info().Msg("Created billing manager")
 

--- a/api/server/shared/config/loader/loader.go
+++ b/api/server/shared/config/loader/loader.go
@@ -335,11 +335,13 @@ func (e *EnvConfigLoader) LoadConfig() (res *config.Config, err error) {
 
 	var (
 		stripeClient     billing.StripeClient
+		stripeEnabled    bool
 		metronomeClient  billing.MetronomeClient
 		metronomeEnabled bool
 	)
 	if sc.StripeSecretKey != "" {
 		stripeClient = billing.NewStripeClient(InstanceEnvConf.ServerConf.StripeSecretKey, InstanceEnvConf.ServerConf.StripePublishableKey)
+		stripeEnabled = true
 		res.Logger.Info().Msg("Stripe configuration loaded")
 	} else {
 		res.Logger.Info().Msg("STRIPE_SECRET_KEY not set, all Stripe functionality will be disabled")
@@ -359,6 +361,7 @@ func (e *EnvConfigLoader) LoadConfig() (res *config.Config, err error) {
 	res.Logger.Info().Msg("Creating billing manager")
 	res.BillingManager = billing.Manager{
 		StripeClient:     stripeClient,
+		StripeEnabled:    stripeEnabled,
 		MetronomeClient:  metronomeClient,
 		MetronomeEnabled: metronomeEnabled,
 	}

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -215,7 +215,7 @@ const Home: React.FC<Props> = (props) => {
       } else {
         setHasFinishedOnboarding(true);
       }
-    } catch (error) {}
+    } catch (error) { }
   };
 
   useEffect(() => {
@@ -423,7 +423,7 @@ const Home: React.FC<Props> = (props) => {
                     >
                       connect a valid payment method
                     </Link>
-                    . Your free trial is ending in{" "}
+                    . Your free trial is ending {" "}
                     {relativeDate(plan.trial_info.ending_before, true)}.
                   </GlobalBanner>
                 )}

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -3,6 +3,7 @@ package billing
 // Manager contains methods for managing billing for a project
 type Manager struct {
 	StripeClient     StripeClient
+	StripeEnabled    bool
 	MetronomeClient  MetronomeClient
 	MetronomeEnabled bool
 }

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -2,8 +2,8 @@ package billing
 
 // Manager contains methods for managing billing for a project
 type Manager struct {
-	StripeClient     StripeClient
-	StripeEnabled    bool
-	MetronomeClient  MetronomeClient
-	MetronomeEnabled bool
+	StripeClient          StripeClient
+	StripeConfigLoaded    bool
+	MetronomeClient       MetronomeClient
+	MetronomeConfigLoaded bool
 }


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
This PR fixes some edge cases I found while validating the billing code:
- Fixe an edge case with porter cloud ingest aliases collisioning with porter standard ingest aliases. This is rare but as Porter Cloud users start to grow the probability of collision will become higher, so I introduced a prefix for porter cloud aliases.
- Fix an edge case where if the Metronme creation fails, the project billing id is not updated
- Fix a small typo on the global banner showing remaining trial time
- Improve some of the conditions and feature flag checks for billing 

<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
