### PR TITLE
Add button to show intercom on billing modal

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -387,7 +387,8 @@ const Home: React.FC<Props> = (props) => {
   };
 
   const showCardBanner = !hasPaymentEnabled;
-  const trialExpired = plan && isTrialExpired(plan.trial_info.ending_before);
+  // const trialExpired = plan && isTrialExpired(plan.trial_info.ending_before);
+  const trialExpired = true;
 
   return (
     <ThemeProvider

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -387,8 +387,7 @@ const Home: React.FC<Props> = (props) => {
   };
 
   const showCardBanner = !hasPaymentEnabled;
-  // const trialExpired = plan && isTrialExpired(plan.trial_info.ending_before);
-  const trialExpired = true;
+  const trialExpired = plan && isTrialExpired(plan.trial_info.ending_before);
 
   return (
     <ThemeProvider

--- a/dashboard/src/main/home/modals/BillingModal.tsx
+++ b/dashboard/src/main/home/modals/BillingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 
@@ -25,21 +25,11 @@ const BillingModal = ({
   const { currentProject } = useContext(Context);
   const { publishableKey } = usePublishableKey();
 
-  const [showIntercom, setShowIntercom] = useState(false);
   const { showIntercomWithMessage } = useIntercom();
-
-  if (showIntercom) {
-    showIntercomWithMessage({
-      message: "I have already redeemed my startup deal.",
-      delaySeconds: 0,
-    });
-    setShowIntercom(false);
-  }
 
   let stripePromise;
   if (publishableKey) {
     stripePromise = loadStripe(publishableKey);
-
   }
 
   const appearance = {
@@ -91,14 +81,16 @@ const BillingModal = ({
                 <div>
                   Your applications will continue to run but you will not be able to access your project until you link a payment method.
                   {" "}
-                  <Text style={{ cursor: "pointer" }} onClick={() => setShowIntercom(true)}>
+                  <Text style={{ cursor: "pointer" }} onClick={() => showIntercomWithMessage({
+                    message: "I have already redeemed my startup deal.",
+                    delaySeconds: 0,
+                  })}>
                     Already redeemed your startup deal?
                   </Text>
                 </div>
               )
               : "Link a payment method to your Porter project."}
-            <br />
-            <br />
+            <Spacer y={0.5} />
             {`You can learn more about our pricing under "For Businesses" `}
             <Link target="_blank" to="https://porter.run/pricing">
               here
@@ -107,17 +99,18 @@ const BillingModal = ({
         )}
         <Spacer y={1} />
         {
-          publishableKey ? <Elements
-            stripe={stripePromise}
-            options={options}
-            appearance={appearance}
-          >
-            <PaymentSetupForm onCreate={onCreate}></PaymentSetupForm>
-          </Elements> : null
+          publishableKey ? (
+            <Elements
+              stripe={stripePromise || null}
+              options={options}
+              appearance={appearance}
+            >
+              <PaymentSetupForm onCreate={onCreate}></PaymentSetupForm>
+            </Elements>
+          ) : null
         }
-
       </div>
-    </Modal>
+    </Modal >
   );
 };
 

--- a/dashboard/src/main/home/modals/BillingModal.tsx
+++ b/dashboard/src/main/home/modals/BillingModal.tsx
@@ -30,7 +30,7 @@ const BillingModal = ({
 
   if (showIntercom) {
     showIntercomWithMessage({
-      message: "I have already redeemed my startup deal and need help linking my payment method.",
+      message: "I have already redeemed my startup deal.",
       delaySeconds: 0,
     });
     setShowIntercom(false);

--- a/dashboard/src/main/home/modals/BillingModal.tsx
+++ b/dashboard/src/main/home/modals/BillingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 
@@ -7,6 +7,7 @@ import Modal from "components/porter/Modal";
 import Spacer from "components/porter/Spacer";
 import Text from "components/porter/Text";
 import { usePublishableKey } from "lib/hooks/useStripe";
+import { useIntercom } from "lib/hooks/useIntercom";
 
 import { Context } from "shared/Context";
 
@@ -23,6 +24,17 @@ const BillingModal = ({
 }): JSX.Element => {
   const { currentProject } = useContext(Context);
   const { publishableKey } = usePublishableKey();
+
+  const [showIntercom, setShowIntercom] = useState(false);
+  const { showIntercomWithMessage } = useIntercom();
+
+  if (showIntercom) {
+    showIntercomWithMessage({
+      message: "I have already redeemed my startup deal and need help linking my payment method.",
+      delaySeconds: 0,
+    });
+    setShowIntercom(false);
+  }
 
   let stripePromise;
   if (publishableKey) {
@@ -75,7 +87,15 @@ const BillingModal = ({
         ) : (
           <Text color="helper">
             {trialExpired
-              ? `Your applications will continue to run but you will not be able to access your project until you link a payment method. `
+              ? (
+                <div>
+                  Your applications will continue to run but you will not be able to access your project until you link a payment method.
+                  {" "}
+                  <Text style={{ cursor: "pointer" }} onClick={() => setShowIntercom(true)}>
+                    Already redeemed your startup deal?
+                  </Text>
+                </div>
+              )
               : "Link a payment method to your Porter project."}
             <br />
             <br />


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
Add a small prompt on the blocking billing modal for users who have an expired trial but had already redeemed the startup deal on a call/email. Note that this blocking modal is only shown for users who don't have an active trial, and most of the startup deal users should already have it because of the reconciliation in Metronome. 


[screen.webm](https://github.com/porter-dev/porter/assets/19579265/56d38abb-a2ba-4f0f-a2d0-3458f7c7de6d)


<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
