### PR TITLE
Correctly check for sandbox on apps page, fix relative date functions

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -24,7 +24,9 @@ import { fakeGuardedRoute } from "shared/auth/RouteGuard";
 import { Context } from "shared/Context";
 import DeploymentTargetProvider from "shared/DeploymentTargetContext";
 import { pushFiltered, pushQueryParams, type PorterUrl } from "shared/routing";
-import { relativeDate, timeFrom } from "shared/string_utils";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
 import midnight from "shared/themes/midnight";
 import standard from "shared/themes/standard";
 import {
@@ -65,6 +67,8 @@ import { NewProjectFC } from "./new-project/NewProject";
 import Onboarding from "./onboarding/Onboarding";
 import ProjectSettings from "./project-settings/ProjectSettings";
 import Sidebar from "./sidebar/Sidebar";
+
+dayjs.extend(relativeTime);
 
 // Guarded components
 const GuardedProjectSettings = fakeGuardedRoute("settings", "", [
@@ -377,13 +381,8 @@ const Home: React.FC<Props> = (props) => {
     if (timestamp === "") {
       return true;
     }
-
-    const diff = timeFrom(timestamp);
-    if (diff.when === "future") {
-      return false;
-    }
-
-    return true;
+    const timestampDate = dayjs(timestamp);
+    return timestampDate.isBefore(dayjs(new Date()));
   };
 
   const showCardBanner = !hasPaymentEnabled;
@@ -424,7 +423,8 @@ const Home: React.FC<Props> = (props) => {
                       connect a valid payment method
                     </Link>
                     . Your free trial is ending {" "}
-                    {relativeDate(plan.trial_info.ending_before, true)}.
+                    {dayjs().to(dayjs(plan.trial_info.ending_before))}
+                    {/* {intlFormatDistance(Date.parse(plan.trial_info.ending_before), new Date())}. */}
                   </GlobalBanner>
                 )}
                 {!trialExpired && showBillingModal && (

--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -424,7 +424,6 @@ const Home: React.FC<Props> = (props) => {
                     </Link>
                     . Your free trial is ending {" "}
                     {dayjs().to(dayjs(plan.trial_info.ending_before))}
-                    {/* {intlFormatDistance(Date.parse(plan.trial_info.ending_before), new Date())}. */}
                   </GlobalBanner>
                 )}
                 {!trialExpired && showBillingModal && (

--- a/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
+++ b/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
@@ -256,7 +256,7 @@ const Apps: React.FC = () => {
               Get started by creating an application.
             </Text>
             <Spacer y={1} />
-            {currentProject?.billing_enabled && !hasPaymentEnabled ? (
+            {currentProject?.sandbox_enabled && currentProject?.billing_enabled && !hasPaymentEnabled ? (
               <Button
                 alt
                 onClick={() => {
@@ -287,7 +287,7 @@ const Apps: React.FC = () => {
                 </Button>
               </PorterLink>
             )}
-            {showBillingModal && (
+            {currentProject?.sandbox_enabled && showBillingModal && (
               <BillingModal
                 back={() => {
                   setShowBillingModal(false);

--- a/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
+++ b/dashboard/src/main/home/app-dashboard/create-app/CreateApp.tsx
@@ -436,7 +436,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
       let stringifiedJson = "unable to stringify errors";
       try {
         stringifiedJson = JSON.stringify(errors);
-      } catch (e) {}
+      } catch (e) { }
       void updateAppStep({
         step: "stack-launch-failure",
         errorMessage: `Form validation error (visible to user): ${errorMessage}. Stringified JSON errors (invisible to user): ${stringifiedJson}`,
@@ -545,8 +545,8 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
                     <Text
                       color={
                         isNameHighlight &&
-                        porterAppFormMethods.getValues("app.name.value")
-                          .length > 0
+                          porterAppFormMethods.getValues("app.name.value")
+                            .length > 0
                           ? "#FFCC00"
                           : "helper"
                       }
@@ -681,9 +681,8 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
                             }
                           >
                             {detectedServices.count > 0
-                              ? `Detected ${detectedServices.count} service${
-                                  detectedServices.count > 1 ? "s" : ""
-                                } from porter.yaml.`
+                              ? `Detected ${detectedServices.count} service${detectedServices.count > 1 ? "s" : ""
+                              } from porter.yaml.`
                               : `Could not detect any services from porter.yaml. Make sure it exists in the root of your repo.`}
                           </Text>
                         </AppearingDiv>
@@ -778,7 +777,7 @@ const CreateApp: React.FC<CreateAppProps> = ({ history }) => {
           }}
         />
       )}
-      {currentProject?.billing_enabled && !hasPaymentEnabled && (
+      {currentProject?.sandbox_enabled && currentProject?.billing_enabled && !hasPaymentEnabled && (
         <BillingModal
           back={() => {
             history.push("/apps");

--- a/dashboard/src/main/home/project-settings/BillingPage.tsx
+++ b/dashboard/src/main/home/project-settings/BillingPage.tsx
@@ -17,7 +17,8 @@ import {
   usePorterCredits,
   useSetDefaultPaymentMethod,
 } from "lib/hooks/useStripe";
-import { relativeDate } from "shared/string_utils";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 
 import { Context } from "shared/Context";
 import cardIcon from "assets/credit-card.svg";
@@ -26,6 +27,8 @@ import trashIcon from "assets/trash.png";
 
 import BillingModal from "../modals/BillingModal";
 import Bars from "./Bars";
+
+dayjs.extend(relativeTime);
 
 function BillingPage(): JSX.Element {
   const { setCurrentOverlay } = useContext(Context);
@@ -233,7 +236,8 @@ function BillingPage(): JSX.Element {
                         plan.trial_info.ending_before !== "" ? (
                         <Text>
                           Free trial ends{" "}
-                          {relativeDate(plan.trial_info.ending_before, true)}
+                          {dayjs().to(dayjs(plan.trial_info.ending_before))}
+                          {/* {intlFormatDistance(Date.parse(plan.trial_info.ending_before), new Date())} */}
                         </Text>
                       ) : (
                         <Text>Started on {readableDate(plan.starting_on)}</Text>

--- a/dashboard/src/main/home/project-settings/BillingPage.tsx
+++ b/dashboard/src/main/home/project-settings/BillingPage.tsx
@@ -237,7 +237,6 @@ function BillingPage(): JSX.Element {
                         <Text>
                           Free trial ends{" "}
                           {dayjs().to(dayjs(plan.trial_info.ending_before))}
-                          {/* {intlFormatDistance(Date.parse(plan.trial_info.ending_before), new Date())} */}
                         </Text>
                       ) : (
                         <Text>Started on {readableDate(plan.starting_on)}</Text>


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
This PR fixes two issues:
- If a user doesn't have a payment method but a trial is active, they are able to use the dashboard, but when they try to deploy an app they will get a blocking modal asking for payment. This is because we didn't check for the `sandbox_enabled` property in the project.
- There was a weird bug with the relative time functions where if a data was between 8 months and a year, it displayed "8 months" every time. This PR changes those functions to use the `dayjs` library instead.

<!-- 
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
