### PR TITLE
Use pointer for trialspec

### DIFF
--- a/api/server/handlers/project/create.go
+++ b/api/server/handlers/project/create.go
@@ -103,6 +103,7 @@ func (p *ProjectCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			err = telemetry.Error(ctx, span, err, "error creating Metronome customer")
 			p.HandleAPIError(w, r, apierrors.NewErrInternal(err))
+			return
 		}
 		proj.UsageID = customerID
 		proj.UsagePlanID = customerPlanID

--- a/api/types/billing_metronome.go
+++ b/api/types/billing_metronome.go
@@ -36,7 +36,7 @@ type AddCustomerPlanRequest struct {
 	// NetPaymentTermDays is the number of days after issuance of invoice after which the invoice is due
 	NetPaymentTermDays int `json:"net_payment_terms_days,omitempty"`
 	// Trial is the trial period for the plan
-	Trial TrialSpec `json:"trial_spec,omitempty"`
+	Trial *TrialSpec `json:"trial_spec,omitempty"`
 }
 
 // TrialSpec is the trial period for the plan

--- a/internal/billing/metronome.go
+++ b/internal/billing/metronome.go
@@ -133,7 +133,7 @@ func (m MetronomeClient) addCustomerPlan(ctx context.Context, customerID uuid.UU
 	}
 
 	if trialDays != 0 {
-		req.Trial = types.TrialSpec{
+		req.Trial = &types.TrialSpec{
 			LengthInDays: int64(trialDays),
 		}
 	}


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
This PR fixes an issue that happens when the trial is empty (porter cloud). Currently the `TrialSpec` struct is not a pointer so the `omitempty` tag is not respected, causing an issue when creating the customer in Metronome. This PR fixes that by changing the type to be a pointer, so the tag works correctly and no value is passed to Metronome.

<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
