### PR TITLE
Add billing page link on billing modal

### DIFF
--- a/dashboard/src/main/home/Home.tsx
+++ b/dashboard/src/main/home/Home.tsx
@@ -221,7 +221,7 @@ const Home: React.FC<Props> = (props) => {
       } else {
         setHasFinishedOnboarding(true);
       }
-    } catch (error) {}
+    } catch (error) { }
   };
 
   useEffect(() => {
@@ -428,32 +428,6 @@ const Home: React.FC<Props> = (props) => {
                     {dayjs().to(dayjs(plan.trial_info.ending_before))}
                   </GlobalBanner>
                 )}
-                {!trialExpired && showBillingModal && (
-                  <BillingModal
-                    back={() => {
-                      setShowBillingModal(false);
-                    }}
-                    onCreate={async () => {
-                      await refetchPaymentEnabled({
-                        throwOnError: false,
-                        cancelRefetch: false,
-                      });
-                      setShowBillingModal(false);
-                    }}
-                  />
-                )}
-                {trialExpired && (
-                  <BillingModal
-                    trialExpired
-                    onCreate={async () => {
-                      await refetchPaymentEnabled({
-                        throwOnError: false,
-                        cancelRefetch: false,
-                      });
-                      setShowBillingModal(false);
-                    }}
-                  />
-                )}
               </>
             )}
           <ModalHandler setRefreshClusters={setForceRefreshClusters} />
@@ -550,8 +524,8 @@ const Home: React.FC<Props> = (props) => {
 
               <Route path="/addons/new">
                 {currentProject?.capi_provisioner_enabled &&
-                currentProject?.simplified_view_enabled &&
-                currentProject?.beta_features_enabled ? (
+                  currentProject?.simplified_view_enabled &&
+                  currentProject?.beta_features_enabled ? (
                   <AddonTemplates />
                 ) : (
                   <LegacyNewAddOnFlow />
@@ -565,8 +539,8 @@ const Home: React.FC<Props> = (props) => {
               </Route>
               <Route path="/addons">
                 {currentProject?.capi_provisioner_enabled &&
-                currentProject?.simplified_view_enabled &&
-                currentProject?.beta_features_enabled ? (
+                  currentProject?.simplified_view_enabled &&
+                  currentProject?.beta_features_enabled ? (
                   <AddonDashboard />
                 ) : (
                   <LegacyAddOnDashboard />

--- a/dashboard/src/main/home/app-dashboard/AppDashboard.tsx
+++ b/dashboard/src/main/home/app-dashboard/AppDashboard.tsx
@@ -32,9 +32,6 @@ import time from "assets/time.png";
 import letter from "assets/vector.svg";
 
 import DashboardHeader from "../cluster-dashboard/DashboardHeader";
-import BillingModal from "../modals/BillingModal";
-import { checkIfProjectHasPayment, useCustomerPlan } from "lib/hooks/useStripe";
-import dayjs from "dayjs";
 
 type Props = {};
 
@@ -56,7 +53,7 @@ const namespaceBlacklist = [
   "monitoring",
 ];
 
-const AppDashboard: React.FC<Props> = ({ }) => {
+const AppDashboard: React.FC<Props> = ({}) => {
   const { currentProject, currentCluster, setFeaturePreview } =
     useContext(Context);
   const [apps, setApps] = useState([]);
@@ -68,19 +65,6 @@ const AppDashboard: React.FC<Props> = ({ }) => {
 
   const [isLoading, setIsLoading] = useState(true);
   const [shouldLoadTime, setShouldLoadTime] = useState(true);
-
-  const { hasPaymentEnabled, refetchPaymentEnabled } =
-    checkIfProjectHasPayment();
-  const { plan } = useCustomerPlan();
-
-  const isTrialExpired = (timestamp: string): boolean => {
-    if (timestamp === "") {
-      return true;
-    }
-    const timestampDate = dayjs(timestamp);
-    return timestampDate.isBefore(dayjs(new Date()));
-  };
-  const trialExpired = plan !== null && plan && isTrialExpired(plan.trial_info.ending_before);
 
   const filteredApps = useMemo(() => {
     const filteredBySearch = search(apps ?? [], searchValue, {
@@ -383,17 +367,6 @@ const AppDashboard: React.FC<Props> = ({ }) => {
             </List>
           )}
         </>
-      )}
-      {trialExpired && !hasPaymentEnabled && (
-        <BillingModal
-          trialExpired
-          onCreate={async () => {
-            await refetchPaymentEnabled({
-              throwOnError: false,
-              cancelRefetch: false,
-            });
-          }}
-        />
       )}
       <Spacer y={5} />
     </StyledAppDashboard>

--- a/dashboard/src/main/home/app-dashboard/AppDashboard.tsx
+++ b/dashboard/src/main/home/app-dashboard/AppDashboard.tsx
@@ -32,6 +32,9 @@ import time from "assets/time.png";
 import letter from "assets/vector.svg";
 
 import DashboardHeader from "../cluster-dashboard/DashboardHeader";
+import BillingModal from "../modals/BillingModal";
+import { checkIfProjectHasPayment, useCustomerPlan } from "lib/hooks/useStripe";
+import dayjs from "dayjs";
 
 type Props = {};
 
@@ -53,7 +56,7 @@ const namespaceBlacklist = [
   "monitoring",
 ];
 
-const AppDashboard: React.FC<Props> = ({}) => {
+const AppDashboard: React.FC<Props> = ({ }) => {
   const { currentProject, currentCluster, setFeaturePreview } =
     useContext(Context);
   const [apps, setApps] = useState([]);
@@ -65,6 +68,19 @@ const AppDashboard: React.FC<Props> = ({}) => {
 
   const [isLoading, setIsLoading] = useState(true);
   const [shouldLoadTime, setShouldLoadTime] = useState(true);
+
+  const { hasPaymentEnabled, refetchPaymentEnabled } =
+    checkIfProjectHasPayment();
+  const { plan } = useCustomerPlan();
+
+  const isTrialExpired = (timestamp: string): boolean => {
+    if (timestamp === "") {
+      return true;
+    }
+    const timestampDate = dayjs(timestamp);
+    return timestampDate.isBefore(dayjs(new Date()));
+  };
+  const trialExpired = plan !== null && plan && isTrialExpired(plan.trial_info.ending_before);
 
   const filteredApps = useMemo(() => {
     const filteredBySearch = search(apps ?? [], searchValue, {
@@ -367,6 +383,17 @@ const AppDashboard: React.FC<Props> = ({}) => {
             </List>
           )}
         </>
+      )}
+      {trialExpired && !hasPaymentEnabled && (
+        <BillingModal
+          trialExpired
+          onCreate={async () => {
+            await refetchPaymentEnabled({
+              throwOnError: false,
+              cancelRefetch: false,
+            });
+          }}
+        />
       )}
       <Spacer y={5} />
     </StyledAppDashboard>

--- a/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
+++ b/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
@@ -484,21 +484,24 @@ const Apps: React.FC = () => {
           loading={envDeleting}
         />
       )}
-      {trialExpired && !hasPaymentEnabled && showBillingModal && (
-        <BillingModal
-          back={() => {
-            setShowBillingModal(false);
-            history.push("/project-settings?selected_tab=billing");
-          }}
-          trialExpired
-          onCreate={async () => {
-            await refetchPaymentEnabled({
-              throwOnError: false,
-              cancelRefetch: false,
-            });
-          }}
-        />
-      )}
+      {!currentProject?.sandbox_enabled &&
+        trialExpired &&
+        !hasPaymentEnabled &&
+        showBillingModal && (
+          <BillingModal
+            back={() => {
+              setShowBillingModal(false);
+              history.push("/project-settings?selected_tab=billing");
+            }}
+            trialExpired
+            onCreate={async () => {
+              await refetchPaymentEnabled({
+                throwOnError: false,
+                cancelRefetch: false,
+              });
+            }}
+          />
+        )}
     </StyledAppDashboard>
   );
 };

--- a/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
+++ b/dashboard/src/main/home/app-dashboard/apps/Apps.tsx
@@ -87,13 +87,13 @@ const Apps: React.FC = () => {
     return timestampDate.isBefore(dayjs(new Date()));
   };
   const trialExpired =
-    plan !== null && plan && isTrialExpired(plan.trial_info.ending_before);
+    plan != null && isTrialExpired(plan.trial_info.ending_before);
 
   useEffect(() => {
     if (trialExpired && !hasPaymentEnabled) {
       setShowBillingModal(true);
     }
-  });
+  }, []);
 
   const [{ data: apps = [], status }, { data: addons = [] }] = useQueries({
     queries: [

--- a/dashboard/src/main/home/modals/BillingModal.tsx
+++ b/dashboard/src/main/home/modals/BillingModal.tsx
@@ -87,6 +87,9 @@ const BillingModal = ({
                   })}>
                     Already redeemed your startup deal?
                   </Text>
+                  <Spacer y={0.5} />
+                  {"For more details on the current costs and usage of this project, visit the "}
+                  <Link to="/project-settings?selected_tab=billing">billing page.</Link>
                 </div>
               )
               : "Link a payment method to your Porter project."}

--- a/dashboard/src/main/home/project-settings/ProjectSettings.tsx
+++ b/dashboard/src/main/home/project-settings/ProjectSettings.tsx
@@ -104,11 +104,6 @@ function ProjectSettings(props: any) {
     if (!_.isEqual(tabOpts, tabOptions)) {
       setTabOptions(tabOpts);
     }
-
-    const selectedTab = getQueryParam(props, "selected_tab");
-    if (selectedTab && selectedTab !== currentTab) {
-      setCurrentTab(selectedTab);
-    }
   }, [context, projectName, currentTab, props, tabOptions]);
 
   const validateProjectName = (): ValidationError => {


### PR DESCRIPTION
## POR-
<!-- Enter your issue ID in the title above or type "N/A" if there isn't one -->
## What does this PR do?
Adds a link to the billing modal so users can visit the billing page, and not get blocked from using all of the dashboard. The modal now opens on the apps dashboard if the user doesn't have payment method or trial.

[apps-modal.webm](https://github.com/porter-dev/porter/assets/19579265/32397c14-6323-4a92-8d23-6f92d77a337f)


<!--
This is where you should write the PR description. What are we reviewing?
Be concise, summarize with bullet points if possible.

- Add screenshots for frontend changes.
- Outline complex testing steps for posterity.
- Note if this PR depends on other PRs or specific actions.
-->
